### PR TITLE
Griptape > Nuke - Adds Griptape Node that runs headless Nuke sessions

### DIFF
--- a/griptape-nodes-library.json
+++ b/griptape-nodes-library.json
@@ -1,6 +1,6 @@
 {
     "name": "Nuke Nodes Library",
-    "library_schema_version": "0.5.0",
+    "library_schema_version": "0.7.0",
     "advanced_library_path": "nuke_nodes/nuke_library_advanced.py",
     "metadata": {
         "author": "Griptape",
@@ -13,7 +13,9 @@
             "Nuke"
         ],
         "dependencies": {
-            "pip_dependencies": []
+            "pip_dependencies": [
+                "trimesh>=4.12.2"
+            ]
         }
     },
     "categories": [
@@ -46,9 +48,32 @@
                 "display_name": "Nuke End Flow",
                 "icon": "logos/nuke.png"
             }
+        },
+        {
+            "class_name": "NukeScriptNode",
+            "file_path": "nuke_nodes/nuke_script_node.py",
+            "metadata": {
+                "category": "FoundryNuke",
+                "description": "Run a Nuke .nk script headlessly with annotated I/O ports",
+                "display_name": "Nuke Script",
+                "icon": "logos/nuke.png"
+            }
         }
     ],
     "workflows": [
         "workflows/templates/image_edit_nano_banana.py"
+    ],
+    "settings": [
+        {
+            "category": "nuke",
+            "description": "Nuke installation settings \u2014 configure the default executable, plugin paths, and environment variables for all NukeScriptNode instances",
+            "contents": {
+                "executable": "",
+                "nuke_path": [],
+                "env": {},
+                "annotator_nuke_version": 16,
+                "installations": {}
+            }
+        }
     ]
 }

--- a/nuke_nodes/nuke_end_flow.py
+++ b/nuke_nodes/nuke_end_flow.py
@@ -11,8 +11,8 @@ class NukeEndFlow(EndNode):
     ) -> None:
         if metadata is None:
             metadata = {}
-        super().__init__(name, metadata)
         metadata["showaddparameter"] = True
+        super().__init__(name, metadata)
 
     def process(self) -> None:
         super().process()

--- a/nuke_nodes/nuke_library_advanced.py
+++ b/nuke_nodes/nuke_library_advanced.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
@@ -12,7 +14,6 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from publish_gizmo.nuke_gizmo_publisher import NukeGizmoPublisher
 from publish_gizmo.nuke_publish_options import get_nuke_publish_options
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("griptape_nodes")
 
 

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -1,0 +1,790 @@
+from __future__ import annotations
+
+import atexit
+import contextlib
+import json
+import logging
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import urllib.request
+import uuid
+from typing import Any
+
+from griptape_nodes.common.macro_parser import ParsedMacro
+from griptape_nodes.common.macro_parser.exceptions import MacroSyntaxError
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterGroup
+from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.project_events import GetPathForMacroRequest, GetPathForMacroResultSuccess
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.traits.file_system_picker import FileSystemPicker
+from griptape_nodes.traits.options import Options
+from griptape_nodes.traits.slider import Slider
+
+from execution.direct import DirectSubprocessProvider
+from execution.installations import NukeInstallation, find_installation, merged_installations
+from nuke_plugin.installer import get_plugin_path
+from nuke_runner.manifest import JobManifest, KnobOverride, ManifestInput, ManifestOutput
+from script_parser.annotation import ExposedKnob, GriptapeAnnotation
+from script_parser.knob_type_map import griptape_type_for_knob, resolve_exposed_knob_type
+from script_parser.parser import ParsedNode, parse_script
+from script_parser.sidecar import read_knob_schema, read_sidecar
+
+_RUNNER_SCRIPT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "nuke_runner", "runner.py"))
+_BAKE_RUNNER_SCRIPT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "nuke_runner", "baker.py"))
+
+# Temp file suffix per gt_type — used when creating output placeholders before Nuke runs.
+_TEMP_SUFFIX: dict[str, str] = {
+    "ThreeDUrlArtifact": ".obj",
+    "GLTFUrlArtifact": ".glb",
+}
+
+
+def _path_to_artifact(gt_type: str, path: str) -> Any:
+    """Convert a runner output file path to the appropriate Griptape artifact."""
+    if gt_type in {"ThreeDUrlArtifact", "GLTFUrlArtifact"}:
+        suffix = pathlib.Path(path).suffix.lower() or ".obj"
+        if suffix in {".glb", ".gltf"}:
+            file_bytes = pathlib.Path(path).read_bytes()
+            serve_suffix = suffix
+        else:
+            try:
+                import trimesh  # pyright: ignore[reportMissingImports]  # noqa: PLC0415
+
+                scene = trimesh.load(path)
+                file_bytes = scene.export(file_type="glb")  # pyright: ignore[reportAttributeAccessIssue,reportCallIssue]
+                serve_suffix = ".glb"
+            except Exception:
+                file_bytes = pathlib.Path(path).read_bytes()
+                serve_suffix = suffix
+        url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{serve_suffix}")
+        try:
+            from griptape_nodes_library.three_d.three_d_artifact import (  # pyright: ignore[reportMissingImports]
+                ThreeDUrlArtifact,  # noqa: PLC0415
+            )
+        except ImportError:
+            return url
+        return ThreeDUrlArtifact(value=url)
+    file_bytes = pathlib.Path(path).read_bytes()
+    suffix = pathlib.Path(path).suffix or ".png"
+    url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{suffix}")
+    try:
+        from griptape.artifacts import ImageUrlArtifact  # noqa: PLC0415
+
+        return ImageUrlArtifact(value=url)
+    except ImportError:
+        return url
+
+
+def _coerce_knob_value(v: Any) -> float | int | str:
+    """Coerce a parameter value to a type Nuke's knob.setValue() accepts."""
+    if isinstance(v, bool):
+        return int(v)  # Bool_Knob.setValue(0/1) is reliable; str("True") is not
+    s = str(v)
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    return s
+
+
+# Startup script run inside Nuke GUI via `nuke -p`. Opens the .nk file and applies
+# knob overrides before the artist sees the session.
+_OPEN_IN_NUKE_STARTUP_TEMPLATE = """\
+import json
+import sys
+import nuke
+
+nuke.scriptOpen({script_path})
+try:
+    with open({manifest_path}, encoding="utf-8") as f:
+        data = json.load(f)
+except Exception as exc:
+    print("Griptape open-in-nuke: could not load overrides: " + str(exc), file=sys.stderr)
+    data = {{}}
+for o in data.get("knob_overrides", []):
+    node = nuke.toNode(o["node"])
+    if node is None:
+        print("Griptape open-in-nuke: node " + repr(o["node"]) + " not found", file=sys.stderr)
+        continue
+    try:
+        node[o["knob"]].setValue(o["value"])
+    except Exception as exc:
+        print("Griptape open-in-nuke: " + o["node"] + "." + o["knob"] + ": " + str(exc), file=sys.stderr)
+"""
+
+
+def _build_open_in_nuke_launch(
+    nuke_exe: str,
+    script_path: str,
+    overrides: list[KnobOverride],
+    env: dict[str, str],
+) -> tuple[list[str], dict[str, str]]:
+    """Return (command, env) for launching Nuke in GUI mode with overrides pre-applied."""
+    overrides_data = {"knob_overrides": [{"node": o.node, "knob": o.knob, "value": o.value} for o in overrides]}
+    tmpdir = tempfile.mkdtemp(prefix="griptape_nuke_")
+    atexit.register(shutil.rmtree, tmpdir, True)
+
+    manifest_path = os.path.join(tmpdir, "overrides.json")
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(overrides_data, f)
+
+    startup_src = _OPEN_IN_NUKE_STARTUP_TEMPLATE.format(
+        script_path=repr(script_path.replace("\\", "/")),
+        manifest_path=repr(manifest_path.replace("\\", "/")),
+    )
+    startup_path = os.path.join(tmpdir, "startup.py")
+    with open(startup_path, "w", encoding="utf-8") as f:
+        f.write(startup_src)
+
+    cmd = [nuke_exe, "-p", startup_path]
+    return cmd, env
+
+
+class NukeScriptNode(SuccessFailureNode):
+    """Runs a .nk script headlessly and surfaces annotated nodes as typed ports."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self._dynamic_param_names: list[str] = []
+        self._dynamic_group_names: list[str] = []
+        self._annotations: list[GriptapeAnnotation] = []
+        self._expose_knobs: list[ExposedKnob] = []
+        self._parsed_nodes: list[ParsedNode] = []
+
+        script_path_param = ParameterString(
+            name="script_path",
+            default_value="",
+            display_name="Script Path (.nk)",
+            allow_output=False,
+        )
+        script_path_param.add_trait(
+            FileSystemPicker(allow_files=True, allow_directories=False, file_extensions=[".nk"])
+        )
+        self.add_parameter(script_path_param)
+
+        try:
+            installation_choices = [i.display_name for i in merged_installations(GriptapeNodes.ConfigManager())]
+        except Exception:
+            installation_choices = []
+        if not installation_choices:
+            installation_choices = ["(none configured)"]
+        nuke_installation_param = Parameter(
+            name="nuke_installation",
+            type="str",
+            default_value=installation_choices[0],
+            display_name="Nuke Version",
+            tooltip="Select a Nuke installation. Click 'Refresh UI' to repopulate from Engine Settings.",
+            allow_output=False,
+        )
+        nuke_installation_param.add_trait(Options(choices=installation_choices))
+        self.add_parameter(nuke_installation_param)
+
+        self.add_parameter(
+            Parameter(
+                name="frame_start",
+                type="int",
+                default_value=1001,
+                display_name="Frame Start",
+                allow_output=False,
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="frame_end",
+                type="int",
+                default_value=1001,
+                display_name="Frame End",
+                allow_output=False,
+            )
+        )
+        self.add_parameter(
+            ParameterButton(
+                name="open_in_nuke",
+                label="Open in Nuke",
+                tooltip=(
+                    "Open Nuke with the Griptape Annotator panel loaded and current overrides pre-applied. "
+                    "Use the panel to mark I/O nodes and expose knobs, then save the .gt.json sidecar."
+                ),
+                variant="secondary",
+                full_width=True,
+                allow_output=False,
+                on_click=self._open_in_nuke,
+            )
+        )
+        self.add_parameter(
+            ParameterButton(
+                name="refresh_ui",
+                label="Refresh UI",
+                tooltip="Re-read the .gt.json sidecar and rebuild exposed knob parameters.",
+                variant="secondary",
+                full_width=True,
+                allow_output=False,
+                on_click=self._on_refresh_ui,
+            )
+        )
+        advanced_group = ParameterGroup(name="Advanced", collapsed=True)
+        self.add_node_element(advanced_group)
+        self.add_parameter(
+            Parameter(
+                name="nuke_executable",
+                type="str",
+                default_value="",
+                display_name="Nuke Executable (override)",
+                tooltip="Leave blank to use the nuke.executable engine setting",
+                allow_output=False,
+                parent_element_name="Advanced",
+            )
+        )
+        baked_path_param = ParameterString(
+            name="baked_script_path",
+            default_value="",
+            display_name="Baked Script Output Path",
+            tooltip="Path where the baked .nk copy will be saved (all current values written into the knobs).",
+            allow_input=False,
+            allow_output=False,
+        )
+        baked_path_param.add_trait(FileSystemPicker(allow_files=True, allow_directories=False, file_extensions=[".nk"]))
+        baked_path_param.parent_element_name = "Advanced"
+        self.add_parameter(baked_path_param)
+        save_baked_btn = ParameterButton(
+            name="save_baked_copy",
+            label="Save Baked Copy",
+            tooltip="Write a copy of the .nk script with all current parameter values baked into the knobs.",
+            variant="secondary",
+            full_width=True,
+            allow_output=False,
+            on_click=self._save_baked_copy,
+        )
+        save_baked_btn.parent_element_name = "Advanced"
+        self.add_parameter(save_baked_btn)
+        self._create_status_parameters()
+
+        # Pre-create ParameterGroups from the previous session so that
+        # AddParameterToNodeRequest(parent_element_name=...) succeeds during workflow restore.
+        # Placed after all static params so the node UI shows static params first.
+        # self.metadata is populated by BaseNode.__init__ before we get here.
+        for _group_name in (self.metadata or {}).get("_nuke_dynamic_groups", []):
+            _group = ParameterGroup(name=_group_name)
+            self.add_node_element(_group)
+            self._dynamic_group_names.append(_group_name)
+
+        if self._dynamic_group_names:
+            self._move_status_to_bottom()
+
+    # ------------------------------------------------------------------
+    # Open in Nuke (with Griptape Annotator loaded)
+    # ------------------------------------------------------------------
+
+    def _open_in_nuke(
+        self,
+        button: Button,  # noqa: ARG002
+        details: ButtonDetailsMessagePayload,  # noqa: ARG002
+    ) -> NodeMessageResult:
+        script_path = str(self.get_parameter_value("script_path") or "")
+        if not script_path or not os.path.exists(script_path):
+            return NodeMessageResult(success=False, details="script_path is not set or the file does not exist.")
+        nuke_exe = self._resolve_nuke_exe()
+        if not nuke_exe or not os.path.exists(nuke_exe):
+            return NodeMessageResult(success=False, details=f"Nuke executable not found: {nuke_exe!r}")
+
+        nuke_path_dirs: list[str] = list(GriptapeNodes.ConfigManager().get_config_value("nuke.nuke_path") or [])
+        installation = self._resolve_installation()
+        nuke_major = (
+            installation.annotator_nuke_version
+            if installation is not None
+            else int(GriptapeNodes.ConfigManager().get_config_value("nuke.annotator_nuke_version") or 16)
+        )
+        env: dict[str, str] = {**os.environ, **self._build_env(installation)}
+        # Strip third-party Qt plugin paths (e.g. cv2) that shadow Nuke's bundled Qt.
+        for _qt_var in ("QT_PLUGIN_PATH", "QT_QPA_PLATFORM_PLUGIN_PATH"):
+            env.pop(_qt_var, None)
+
+        try:
+            plugin_path = get_plugin_path(nuke_major)
+            plugin_path_str = str(plugin_path).replace("\\", "/")
+            existing_nuke_path = env.get("NUKE_PATH", "")
+            nuke_path_parts = (
+                [plugin_path_str]
+                + [d for d in nuke_path_dirs if d]
+                + ([existing_nuke_path] if existing_nuke_path else [])
+            )
+            env["NUKE_PATH"] = os.pathsep.join(nuke_path_parts)
+        except RuntimeError:
+            if nuke_path_dirs:
+                env["NUKE_PATH"] = os.pathsep.join(nuke_path_dirs)
+
+        self._ensure_annotations()
+        overrides: list[KnobOverride] = []
+        for ek in self._expose_knobs:
+            raw = self.get_parameter_value(ek.param_name)
+            if raw not in (None, ""):
+                overrides.append(KnobOverride(node=ek.target_node, knob=ek.target_knob, value=_coerce_knob_value(raw)))
+
+        try:
+            cmd, launch_env = _build_open_in_nuke_launch(nuke_exe, script_path, overrides, env)
+            subprocess.Popen(cmd, env=launch_env)  # noqa: S603
+        except OSError as exc:
+            return NodeMessageResult(success=False, details=str(exc))
+
+        return NodeMessageResult(
+            success=True,
+            details=(
+                "Nuke is open with the Griptape Annotator panel. "
+                "Open it from Panels > Griptape Annotator, annotate your script, "
+                "then save the .gt.json sidecar. "
+                "Back in Griptape, re-select the script path to pick up the changes."
+            ),
+            altered_workflow_state=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Dynamic port management
+    # ------------------------------------------------------------------
+
+    def _on_refresh_ui(
+        self,
+        button: Button,  # noqa: ARG002
+        details: ButtonDetailsMessagePayload,  # noqa: ARG002
+    ) -> NodeMessageResult:
+        self._refresh_installation_choices()
+        script_path = str(self.get_parameter_value("script_path") or "")
+        if not script_path or not os.path.exists(script_path):
+            return NodeMessageResult(
+                success=True, details="Installation choices refreshed.", altered_workflow_state=True
+            )
+        self._refresh_dynamic_ports(script_path)
+        return NodeMessageResult(success=True, details="UI refreshed.", altered_workflow_state=True)
+
+    def _refresh_installation_choices(self) -> None:
+        choices = [i.display_name for i in merged_installations(GriptapeNodes.ConfigManager())]
+        if not choices:
+            choices = ["(none configured)"]
+        from griptape_nodes.exe_types.core_types import Trait
+
+        param = self.get_parameter_by_name("nuke_installation")
+        if param is None:
+            return
+        for trait in param.find_elements_by_type(Trait):
+            if isinstance(trait, Options):
+                trait.choices = choices
+                break
+        current = self.get_parameter_value("nuke_installation") or ""
+        if current not in choices:
+            self.set_parameter_value("nuke_installation", choices[0])
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter.name == "script_path" and value:
+            self._refresh_dynamic_ports(str(value))
+
+    def _refresh_dynamic_ports(self, script_path: str) -> None:  # noqa: C901
+        # Absorb any user-defined params not yet tracked — e.g. params left behind by a
+        # broken restore where element_modification_commands partially succeeded.
+        for p in self.parameters:
+            if p.user_defined and p.name not in self._dynamic_param_names:
+                self._dynamic_param_names.append(p.name)
+
+        for gname in self._dynamic_group_names:
+            self.remove_parameter_element_by_name(gname)
+        self._dynamic_group_names.clear()
+        for name in self._dynamic_param_names:
+            self.remove_parameter_element_by_name(name)
+        self._dynamic_param_names.clear()
+        self._annotations.clear()
+        self._expose_knobs.clear()
+        self._parsed_nodes.clear()
+
+        if not os.path.exists(script_path):
+            return
+
+        with open(script_path, encoding="utf-8") as f:
+            text = f.read()
+        self._parsed_nodes = parse_script(text)
+
+        sidecar_path = os.path.splitext(script_path)[0] + ".gt.json"
+        if os.path.exists(sidecar_path):
+            try:
+                annotations, expose_knobs, is_stale = read_sidecar(sidecar_path, script_path)
+                if is_stale:
+                    print(
+                        f"WARNING: {sidecar_path} is stale (script may have been saved after annotation).",
+                        flush=True,
+                    )
+                self._annotations = annotations
+                self._expose_knobs = expose_knobs
+            except Exception as exc:
+                print(
+                    f"WARNING: Could not read sidecar {sidecar_path}: {exc}.",
+                    flush=True,
+                )
+
+        for ann in self._annotations:
+            if ann.role != "input":
+                continue
+            param = Parameter(
+                name=ann.gt_name,
+                type=ann.gt_type or "str",
+                input_types=["str", "ImageArtifact", "ImageUrlArtifact", "BlobArtifact"],
+                default_value="",
+                display_name=ann.gt_label or ann.gt_name,
+                tooltip=f"Input path for Nuke node {ann.node_name!r}",
+                allow_output=False,
+                user_defined=True,
+            )
+            self.add_parameter(param)
+            self._dynamic_param_names.append(ann.gt_name)
+
+        has_outputs = any(ann.role == "output" for ann in self._annotations)
+        if has_outputs:
+            outputs_group = ParameterGroup(name="Outputs")
+            self.add_node_element(outputs_group)
+            self._dynamic_group_names.append("Outputs")
+
+        for ann in self._annotations:
+            if ann.role == "input":
+                continue
+            if ann.gt_type in {"ThreeDUrlArtifact", "GLTFUrlArtifact"}:
+                try:
+                    from griptape_nodes.exe_types.param_types.parameter_three_d import (
+                        Parameter3D,  # type: ignore[import-not-found]  # noqa: PLC0415
+                    )
+
+                    param = Parameter3D(
+                        name=ann.gt_name,
+                        display_name=ann.gt_label or ann.gt_name,
+                        tooltip=f"3D geometry output from Nuke node {ann.node_name!r}",
+                        allow_input=False,
+                        allow_property=False,
+                        user_defined=True,
+                    )
+                    param.parent_element_name = "Outputs"
+                except ImportError:
+                    param = Parameter(
+                        name=ann.gt_name,
+                        type="ThreeDUrlArtifact",
+                        default_value="",
+                        display_name=ann.gt_label or ann.gt_name,
+                        tooltip=f"3D geometry output from Nuke node {ann.node_name!r}",
+                        allow_input=False,
+                        allow_property=False,
+                        user_defined=True,
+                        parent_element_name="Outputs",
+                    )
+            else:
+                param = Parameter(
+                    name=ann.gt_name,
+                    type=ann.gt_type or "str",
+                    default_value="",
+                    display_name=ann.gt_label or ann.gt_name,
+                    tooltip=f"Output from Nuke node {ann.node_name!r}",
+                    allow_input=False,
+                    allow_property=False,
+                    user_defined=True,
+                    parent_element_name="Outputs",
+                )
+            self.add_parameter(param)
+            self._dynamic_param_names.append(ann.gt_name)
+
+        knob_schema: dict[str, dict] | None = None
+        if os.path.exists(sidecar_path):
+            knob_schema = read_knob_schema(sidecar_path)
+
+        seen_groups: set[str] = set()
+        for ek in self._expose_knobs:
+            if ek.param_name in self._dynamic_param_names:
+                continue
+            group_name = ek.target_node
+            if group_name not in seen_groups:
+                group = ParameterGroup(name=group_name)
+                self.add_node_element(group)
+                self._dynamic_group_names.append(group_name)
+                seen_groups.add(group_name)
+            if ek.knob_type:
+                gt_type = griptape_type_for_knob(ek.knob_type)
+            else:
+                gt_type = resolve_exposed_knob_type(ek.target_node, ek.target_knob, knob_schema)
+            # Numeric types use None default (renders as empty number input = no override).
+            # String types use "" default for the same semantic.
+            default: float | str | None = None if gt_type in {"float", "int"} else ""
+            param = Parameter(
+                name=ek.param_name,
+                type=gt_type,
+                default_value=default,
+                display_name=ek.target_knob,
+                tooltip=f"Override for {ek.knob_ref}",
+                allow_output=False,
+                user_defined=True,
+                parent_element_name=group_name,
+            )
+            if gt_type == "float":
+                param.add_trait(Slider(min_val=-10.0, max_val=10.0))
+            self.add_parameter(param)
+            self._dynamic_param_names.append(ek.param_name)
+
+        self.metadata["_nuke_dynamic_groups"] = list(self._dynamic_group_names)
+        self._move_status_to_bottom()
+
+    def _move_status_to_bottom(self) -> None:
+        if not hasattr(self, "status_component"):
+            return
+        status_group = self.status_component._status_group
+        self.remove_node_element(status_group)
+        self.add_node_element(status_group)
+
+    def _ensure_annotations(self) -> None:
+        """Rebuild _annotations and _expose_knobs from the script if lost across workflow reload."""
+        if self._annotations or self._expose_knobs:
+            return
+        script_path = self.get_parameter_value("script_path") or ""
+        if not script_path or not os.path.exists(str(script_path)):
+            return
+        script_path = str(script_path)
+        sidecar_path = os.path.splitext(script_path)[0] + ".gt.json"
+        if os.path.exists(sidecar_path):
+            annotations, expose_knobs, is_stale = read_sidecar(sidecar_path, script_path)
+            if not is_stale:
+                self._annotations = annotations
+                self._expose_knobs = expose_knobs
+
+    # ------------------------------------------------------------------
+    # Artifact / path resolution
+    # ------------------------------------------------------------------
+
+    def _artifact_to_path(self, value: Any) -> str:
+        """Resolve a parameter value to a local file path Nuke can read."""
+        if isinstance(value, str):
+            return value
+        val = getattr(value, "value", None)
+        if isinstance(val, str):
+            if val.startswith(("http://", "https://")):
+                suffix = os.path.splitext(val.split("?")[0])[-1] or ".png"
+                tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+                try:
+                    with urllib.request.urlopen(val, timeout=30) as response:  # noqa: S310
+                        tmp.write(response.read())
+                    tmp.close()
+                except Exception:
+                    tmp.close()
+                    os.unlink(tmp.name)
+                    raise
+                return tmp.name
+            if "{" in val:
+                try:
+                    macro = ParsedMacro(val)
+                except MacroSyntaxError:
+                    macro = None
+                if macro is not None:
+                    result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=macro, variables={}))
+                    if isinstance(result, GetPathForMacroResultSuccess):
+                        return str(result.absolute_path)
+            return val
+        if isinstance(val, bytes):
+            tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+            tmp.write(val)
+            tmp.close()
+            return tmp.name
+        return str(value)
+
+    def _build_env(self, installation: NukeInstallation | None) -> dict[str, str]:
+        """Merge global env settings, installation overrides, and foundry_LICENSE from os.environ."""
+        global_env: dict[str, str] = GriptapeNodes.ConfigManager().get_config_value("nuke.env") or {}
+        install_env: dict[str, str] = installation.env_overrides if installation else {}
+        env = {**global_env, **install_env}
+        if fl := os.environ.get("foundry_LICENSE"):
+            env.setdefault("foundry_LICENSE", fl)
+        return env
+
+    def _resolve_installation(self) -> NukeInstallation | None:
+        selected = str(self.get_parameter_value("nuke_installation") or "")
+        if selected and selected != "(none configured)":
+            return find_installation(selected, GriptapeNodes.ConfigManager())
+        return None
+
+    def _resolve_nuke_exe(self) -> str:
+        override = self.get_parameter_value("nuke_executable") or ""
+        if override:
+            return str(override)
+        inst = self._resolve_installation()
+        if inst:
+            return inst.executable_path
+        return GriptapeNodes.ConfigManager().get_config_value("nuke.executable") or ""
+
+    # ------------------------------------------------------------------
+    # Validation and execution
+    # ------------------------------------------------------------------
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        self._ensure_annotations()
+        errors: list[Exception] = []
+
+        script_path = self.get_parameter_value("script_path") or ""
+        if not script_path:
+            errors.append(ValueError("script_path is required"))
+        elif not os.path.exists(str(script_path)):
+            errors.append(FileNotFoundError(f"Script not found: {script_path}"))
+
+        nuke_exe = self._resolve_nuke_exe()
+        if not nuke_exe:
+            errors.append(ValueError("nuke_executable is not set and nuke.executable engine setting is empty"))
+        elif not os.path.exists(nuke_exe):
+            errors.append(FileNotFoundError(f"Nuke executable not found: {nuke_exe}"))
+
+        return errors or None
+
+    def _save_baked_copy(
+        self,
+        button: Button,  # noqa: ARG002
+        details: ButtonDetailsMessagePayload,  # noqa: ARG002
+    ) -> NodeMessageResult:
+        self._ensure_annotations()
+        script_path = self.get_parameter_value("script_path")
+        baked_path = self.get_parameter_value("baked_script_path")
+
+        if not script_path or not os.path.exists(str(script_path)):
+            return NodeMessageResult(success=False, details="No valid script_path set.", altered_workflow_state=False)
+        if not baked_path:
+            return NodeMessageResult(
+                success=False, details="Set 'Baked Script Output Path' first.", altered_workflow_state=False
+            )
+
+        installation = self._resolve_installation()
+        nuke_exe = self._resolve_nuke_exe()
+        if not nuke_exe:
+            return NodeMessageResult(
+                success=False, details="Nuke executable not configured.", altered_workflow_state=False
+            )
+
+        nuke_path_dirs: list[str] = GriptapeNodes.ConfigManager().get_config_value("nuke.nuke_path") or []
+        env = self._build_env(installation)
+        if nuke_path_dirs:
+            env["NUKE_PATH"] = os.pathsep.join(nuke_path_dirs)
+
+        inputs: dict[str, ManifestInput] = {}
+        for ann in self._annotations:
+            if ann.role == "input":
+                raw = self.get_parameter_value(ann.gt_name) or ""
+                if raw:
+                    inputs[ann.gt_name] = ManifestInput(
+                        path=self._artifact_to_path(raw),
+                        node=ann.node_name,
+                    )
+
+        knob_overrides: list[KnobOverride] = []
+        for ek in self._expose_knobs:
+            raw = self.get_parameter_value(ek.param_name)
+            if raw not in (None, ""):
+                knob_overrides.append(
+                    KnobOverride(node=ek.target_node, knob=ek.target_knob, value=_coerce_knob_value(raw))
+                )
+
+        manifest = JobManifest(
+            script=str(script_path),
+            inputs=inputs,
+            outputs={},
+            knob_overrides=knob_overrides,
+            env=env,
+            bake_output_path=str(baked_path),
+        )
+        provider = DirectSubprocessProvider(
+            nuke_exe=nuke_exe, runner_script=_BAKE_RUNNER_SCRIPT, installation=installation
+        )
+        result = provider.result(provider.submit(manifest))
+
+        if result.return_code != 0:
+            log_tail = "\n".join(result.log[-10:]) if result.log else "(no output)"
+            return NodeMessageResult(
+                success=False,
+                details=f"Bake failed (exit {result.return_code}):\n{log_tail}",
+                altered_workflow_state=False,
+            )
+        return NodeMessageResult(
+            success=True,
+            details=f"Baked copy saved to:\n{baked_path}",
+            altered_workflow_state=False,
+        )
+
+    def process(self) -> None:
+        self._clear_execution_status()
+        self._ensure_annotations()
+
+        script_path = str(self.get_parameter_value("script_path"))
+        installation = self._resolve_installation()
+        nuke_exe = self._resolve_nuke_exe()
+        frame_start = int(self.get_parameter_value("frame_start") or 1001)
+        frame_end = int(self.get_parameter_value("frame_end") or 1001)
+
+        nuke_path_dirs: list[str] = GriptapeNodes.ConfigManager().get_config_value("nuke.nuke_path") or []
+        env = self._build_env(installation)
+        if nuke_path_dirs:
+            env["NUKE_PATH"] = os.pathsep.join(nuke_path_dirs)
+
+        inputs: dict[str, ManifestInput] = {}
+        outputs: dict[str, ManifestOutput] = {}
+        output_tmp_paths: list[str] = []
+
+        for ann in self._annotations:
+            if ann.role == "input":
+                inputs[ann.gt_name] = ManifestInput(
+                    path=self._artifact_to_path(self.get_parameter_value(ann.gt_name) or ""),
+                    node=ann.node_name,
+                )
+            else:
+                suffix = _TEMP_SUFFIX.get(ann.gt_type or "", ".png")
+                tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+                tmp.close()
+                output_tmp_paths.append(tmp.name)
+                outputs[ann.gt_name] = ManifestOutput(
+                    path=tmp.name,
+                    node=ann.node_name,
+                    type=ann.gt_type or "ImageArtifact",
+                )
+
+        knob_overrides: list[KnobOverride] = []
+        for ek in self._expose_knobs:
+            raw = self.get_parameter_value(ek.param_name)
+            if raw not in (None, ""):
+                knob_overrides.append(
+                    KnobOverride(node=ek.target_node, knob=ek.target_knob, value=_coerce_knob_value(raw))
+                )
+
+        try:
+            manifest = JobManifest(
+                script=script_path,
+                inputs=inputs,
+                outputs=outputs,
+                knob_overrides=knob_overrides,
+                frame_range=[frame_start, frame_end],
+                env=env,
+            )
+            provider = DirectSubprocessProvider(
+                nuke_exe=nuke_exe, runner_script=_RUNNER_SCRIPT, installation=installation
+            )
+            result = provider.result(provider.submit(manifest))
+
+            if result.return_code != 0:
+                log_tail = "\n".join(result.log[-20:]) if result.log else "(no output)"
+                msg = f"Nuke exited with return code {result.return_code}:\n{log_tail}"
+                self._set_status_results(was_successful=False, result_details=f"FAILURE: {msg}")
+                self._handle_failure_exception(RuntimeError(msg))
+                return
+
+            for gt_name, path in result.outputs.items():
+                if gt_name not in outputs:
+                    logging.getLogger(__name__).warning("Nuke runner returned unknown output key %r; skipping", gt_name)
+                    continue
+                self.parameter_output_values[gt_name] = _path_to_artifact(outputs[gt_name].type, path)
+
+            self._set_status_results(was_successful=True, result_details="Render complete.")
+        finally:
+            for p in output_tmp_paths:
+                with contextlib.suppress(OSError):
+                    os.unlink(p)

--- a/nuke_plugin/__init__.py
+++ b/nuke_plugin/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/nuke_plugin/installer.py
+++ b/nuke_plugin/installer.py
@@ -1,0 +1,34 @@
+"""Utility functions for locating and installing the Griptape Annotator plugin.
+
+This module is importable from Griptape-side code (Python 3.12) and does not
+depend on Nuke or any third-party package.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_PLUGIN_DIR = Path(__file__).parent
+
+
+def get_plugin_path(nuke_major: int) -> Path:
+    """Return the nuke_plugin subdirectory for *nuke_major*.
+
+    Falls back to the highest available version ≤ nuke_major when an exact
+    match is not present. Raises RuntimeError if nothing is found.
+    """
+    candidate = _PLUGIN_DIR / f"nuke{nuke_major}"
+    if candidate.exists():
+        return candidate
+
+    available = sorted(
+        int(d.name.replace("nuke", ""))
+        for d in _PLUGIN_DIR.glob("nuke*")
+        if d.is_dir() and d.name.replace("nuke", "").isdigit()
+    )
+    best = max((v for v in available if v <= nuke_major), default=None)
+    if best is None:
+        raise RuntimeError(
+            f"No Griptape Annotator plugin available for Nuke {nuke_major} or earlier. Available versions: {available}"
+        )
+    return _PLUGIN_DIR / f"nuke{best}"

--- a/nuke_plugin/nuke14/__init__.py
+++ b/nuke_plugin/nuke14/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/nuke_plugin/nuke15/__init__.py
+++ b/nuke_plugin/nuke15/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/nuke_plugin/nuke16/__init__.py
+++ b/nuke_plugin/nuke16/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/nuke_plugin/nuke17/__init__.py
+++ b/nuke_plugin/nuke17/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -374,6 +374,6 @@ if not _companion or not _os.path.isdir(_companion):
     nuke.message("Griptape: cannot find companion directory for '{safe_name}'. Make sure the griptape folder is on Nuke's plugin path.")
 else:
     _btn_path = _os.path.join(_companion, "{RUN_BUTTON_FILENAME}")
-    with open(_btn_path, encoding="utf-8") as _f:
+    with open(_btn_path) as _f:
         exec(compile(_f.read(), _btn_path, "exec"), dict(globals(), **{{"__file__": _btn_path, "_config": {config_repr}}}))
 """

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -501,7 +501,6 @@ else:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
-                    encoding="utf-8",
                     bufsize=1,
                     cwd=companion,
                 )
@@ -549,7 +548,7 @@ else:
             # ------------------------------------------------------------------
             # Fallback: blocking path when Qt is not available
             # ------------------------------------------------------------------
-            result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", cwd=companion, timeout=600)
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd=companion, timeout=600)
             if result.returncode == 0:
                 try:
                     output = json.loads(result.stdout.strip())

--- a/script_parser/knob_type_map.py
+++ b/script_parser/knob_type_map.py
@@ -13,7 +13,7 @@ _MAP: dict[str, str] = {
     "Enumeration_Knob": "str",
     "File_Knob": "str",
     "Color_Knob": "str",
-    "AColor_Knob": "str",  # RGBA colour knob alias (Nuke 16 fixtures)
+    "AColor_Knob": "float",  # RGBA — setValue(float) sets the master value for all channels
     "XY_Knob": "str",
     "Array_Knob": "float",  # generic numeric (gain, gamma, saturation, …)
 }

--- a/tests/unit/test_knob_type_map.py
+++ b/tests/unit/test_knob_type_map.py
@@ -28,8 +28,8 @@ class TestGriptapeTypeForKnob:
     def test_color_knob_maps_to_str(self) -> None:
         assert griptape_type_for_knob("Color_Knob") == "str"
 
-    def test_acolor_knob_alias_maps_to_str(self) -> None:
-        assert griptape_type_for_knob("AColor_Knob") == "str"
+    def test_acolor_knob_maps_to_float(self) -> None:
+        assert griptape_type_for_knob("AColor_Knob") == "float"
 
     def test_xy_knob_maps_to_str(self) -> None:
         assert griptape_type_for_knob("XY_Knob") == "str"

--- a/tests/unit/test_nuke_plugin_installer.py
+++ b/tests/unit/test_nuke_plugin_installer.py
@@ -1,0 +1,50 @@
+"""Tests for nuke_plugin/installer.py — get_plugin_path version resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from nuke_plugin.installer import _PLUGIN_DIR, get_plugin_path
+
+
+def test_get_plugin_path_exact_match() -> None:
+    path = get_plugin_path(16)
+    assert path.exists()
+    assert path.name == "nuke16"
+    assert path.parent == _PLUGIN_DIR
+
+
+def test_get_plugin_path_fallback_to_lower() -> None:
+    # Nuke 99 doesn't exist; should fall back to the highest available version
+    available_versions = sorted(
+        int(p.name.replace("nuke", "")) for p in _PLUGIN_DIR.iterdir() if p.is_dir() and p.name.startswith("nuke")
+    )
+    highest = available_versions[-1]
+    path = get_plugin_path(99)
+    assert path.exists()
+    assert path.name == f"nuke{highest}"
+
+
+def test_get_plugin_path_exact_nuke15() -> None:
+    path = get_plugin_path(15)
+    assert path.exists()
+    assert path.name == "nuke15"
+
+
+def test_get_plugin_path_no_match_raises() -> None:
+    # Version lower than any available plugin — should raise
+    with pytest.raises(RuntimeError, match="No Griptape Annotator plugin available"):
+        get_plugin_path(1)
+
+
+def test_get_plugin_path_returns_path_object() -> None:
+    from pathlib import Path
+
+    result = get_plugin_path(16)
+    assert isinstance(result, Path)
+
+
+def test_get_plugin_path_exact_nuke14() -> None:
+    path = get_plugin_path(14)
+    assert path.exists()
+    assert path.name == "nuke14"

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -1,0 +1,381 @@
+"""Unit tests for NukeScriptNode — pure logic only, no Nuke process spawned."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nuke_nodes.nuke_script_node import _coerce_knob_value
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Module-level pure functions
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceKnobValue:
+    def test_integer_string(self) -> None:
+        assert _coerce_knob_value("42") == 42
+        assert isinstance(_coerce_knob_value("42"), int)
+
+    def test_float_string(self) -> None:
+        assert _coerce_knob_value("3.14") == pytest.approx(3.14)
+        assert isinstance(_coerce_knob_value("3.14"), float)
+
+    def test_plain_string(self) -> None:
+        assert _coerce_knob_value("hello") == "hello"
+        assert isinstance(_coerce_knob_value("hello"), str)
+
+    def test_negative_int(self) -> None:
+        assert _coerce_knob_value("-5") == -5
+
+    def test_scientific_notation(self) -> None:
+        result = _coerce_knob_value("1e3")
+        assert result == pytest.approx(1000.0)
+
+
+# ---------------------------------------------------------------------------
+# NukeScriptNode class — tested via a lightweight mock of the framework base
+# ---------------------------------------------------------------------------
+
+
+def _make_node() -> Any:
+    """Instantiate NukeScriptNode with the Griptape framework base mocked out."""
+    with patch("nuke_nodes.nuke_script_node.SuccessFailureNode.__init__", return_value=None):
+        from nuke_nodes.nuke_script_node import NukeScriptNode
+
+        # Create a per-call subclass so the `parameters` property (which requires
+        # root_ui_element from a fully-initialised base) can be safely stubbed.
+        _Stub = type("_NukeScriptNodeStub", (NukeScriptNode,), {"parameters": property(lambda self: [])})
+        node = _Stub.__new__(_Stub)
+        # Replicate what __init__ sets on the instance
+        node._dynamic_param_names = []
+        node._dynamic_group_names = []
+        node._annotations = []
+        node._expose_knobs = []
+        node._parsed_nodes = []
+        node.metadata = {}
+        node.parameter_output_values = MagicMock()  # type: ignore[assignment]
+        node.name = "NukeScriptNode1"
+
+        # Stub framework methods used by our code
+        node.add_parameter = MagicMock()
+        node.add_node_element = MagicMock()
+        node.remove_parameter_element_by_name = MagicMock()
+        node.get_parameter_value = MagicMock(return_value=None)
+        node._clear_execution_status = MagicMock()
+        node._set_status_results = MagicMock()
+        node._handle_failure_exception = MagicMock()
+        node._create_status_parameters = MagicMock()
+
+        return node
+
+
+class TestRefreshDynamicPorts:
+    def test_clears_old_ports_on_missing_file(self, tmp_path: Path) -> None:
+        node = _make_node()
+        node._dynamic_param_names = ["old_param"]
+        node._refresh_dynamic_ports(str(tmp_path / "nonexistent.nk"))
+        node.remove_parameter_element_by_name.assert_called_once_with("old_param")
+        assert node._dynamic_param_names == []
+
+    def test_reads_sidecar_and_adds_ports(self, tmp_path: Path) -> None:
+        # Use the real annotated fixture
+        nk_fixture = FIXTURES / "constant_write.nk"
+        if not nk_fixture.exists():
+            pytest.skip("constant_write.nk fixture not present")
+
+        node = _make_node()
+        node._refresh_dynamic_ports(str(nk_fixture))
+
+        # At least one parameter added for each annotation
+        assert node.add_parameter.called
+
+    def test_no_ports_added_for_unannotated_script(self, tmp_path: Path) -> None:
+        nk_fixture = FIXTURES / "no_annotations.nk"
+        if not nk_fixture.exists():
+            pytest.skip("no_annotations.nk fixture not present")
+
+        node = _make_node()
+        node._refresh_dynamic_ports(str(nk_fixture))
+        # No dynamic ports should be registered
+        assert node._dynamic_param_names == []
+
+
+class TestEnsureAnnotations:
+    def test_noop_when_annotations_already_loaded(self) -> None:
+        from script_parser.annotation import GriptapeAnnotation
+
+        node = _make_node()
+        node._annotations = [
+            GriptapeAnnotation(node_name="Read1", role="input", gt_name="src", gt_type="ImageArtifact")
+        ]
+        node.get_parameter_value = MagicMock(return_value="/some/path.nk")
+        node._ensure_annotations()
+        # get_parameter_value should not be called because we returned early
+        node.get_parameter_value.assert_not_called()
+
+    def test_noop_when_no_script_path(self) -> None:
+        node = _make_node()
+        node.get_parameter_value = MagicMock(return_value=None)
+        node._ensure_annotations()
+        assert node._annotations == []
+
+
+class TestInitMetadataGroupPreCreation:
+    def test_pre_creates_groups_from_metadata(self) -> None:
+        from nuke_nodes.nuke_script_node import NukeScriptNode
+
+        metadata: dict = {"_nuke_dynamic_groups": ["Outputs", "GradeRed"]}
+
+        node = NukeScriptNode.__new__(NukeScriptNode)
+        node.remove_node_element = MagicMock()
+        node._create_status_parameters = MagicMock()
+
+        # Track interleaved call order across add_parameter and add_node_element.
+        call_sequence: list[tuple[str, Any]] = []
+        node.add_parameter = MagicMock(side_effect=lambda p: call_sequence.append(("param", p)))
+        node.add_node_element = MagicMock(side_effect=lambda g: call_sequence.append(("group", g)))
+
+        # super().__init__() is called bound, so side_effect receives (name, meta) — no self.
+        # Use a closure to set metadata on the pre-created node instance.
+        def fake_super_init(name: str, meta: dict | None = None) -> None:
+            node.metadata = meta or {}
+
+        with (
+            patch("nuke_nodes.nuke_script_node.SuccessFailureNode.__init__", side_effect=fake_super_init),
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes"),
+            patch("nuke_nodes.nuke_script_node.merged_installations", return_value=[]),
+        ):
+            node.__init__("TestNode", metadata)
+
+        assert "Outputs" in node._dynamic_group_names
+        assert "GradeRed" in node._dynamic_group_names
+
+        # Dynamic groups must appear AFTER all static add_parameter calls in the
+        # interleaved call sequence so the node UI shows static params first.
+        last_static_param_pos = max(i for i, (kind, _) in enumerate(call_sequence) if kind == "param")
+        first_dynamic_group_pos = min(
+            i
+            for i, (kind, obj) in enumerate(call_sequence)
+            if kind == "group" and hasattr(obj, "name") and obj.name in {"Outputs", "GradeRed"}
+        )
+        assert last_static_param_pos < first_dynamic_group_pos, (
+            "dynamic groups were added before static params — ordering is wrong"
+        )
+
+
+class TestRefreshDynamicPortsMetadata:
+    def test_persists_group_names_to_metadata(self, tmp_path: Path) -> None:
+        node = _make_node()
+        node.metadata = {}
+        nk_file = tmp_path / "test.nk"
+        nk_file.write_text("")
+        node._refresh_dynamic_ports(str(nk_file))
+        assert "_nuke_dynamic_groups" in node.metadata
+        assert isinstance(node.metadata["_nuke_dynamic_groups"], list)
+
+    def test_float_exposed_knob_gets_slider_trait(self, tmp_path: Path) -> None:
+        from griptape_nodes.traits.slider import Slider
+
+        from script_parser.annotation import ExposedKnob
+
+        nk_file = tmp_path / "grade.nk"
+        nk_file.write_text("")
+
+        ek = ExposedKnob(
+            source_node="Grade1",
+            knob_ref="Grade1.multiply",
+            target_node="Grade1",
+            target_knob="multiply",
+            param_name="Grade1_multiply",
+            knob_type="AColor_Knob",
+        )
+
+        node = _make_node()
+        node.metadata = {}
+
+        # Sidecar file must exist for the os.path.exists guard to pass.
+        sidecar_file = tmp_path / "grade.gt.json"
+        sidecar_file.write_text("{}")
+
+        # read_sidecar returns (annotations, expose_knobs, is_stale).
+        with patch("nuke_nodes.nuke_script_node.read_sidecar", return_value=([], [ek], False)):
+            node._refresh_dynamic_ports(str(nk_file))
+
+        # Capture the Parameter passed to add_parameter for Grade1_multiply
+        created_params = {call.args[0].name: call.args[0] for call in node.add_parameter.call_args_list}
+        assert "Grade1_multiply" in created_params
+        param = created_params["Grade1_multiply"]
+        from griptape_nodes.exe_types.core_types import Trait
+
+        traits = param.find_elements_by_type(Trait)
+        assert any(isinstance(t, Slider) for t in traits), "float param should have Slider trait"
+
+
+class TestAfterValueSet:
+    def test_always_calls_refresh_on_script_path(self) -> None:
+        node = _make_node()
+        node._refresh_dynamic_ports = MagicMock()
+        mock_param = MagicMock()
+        mock_param.name = "script_path"
+        node.after_value_set(mock_param, "/some/script.nk")
+        node._refresh_dynamic_ports.assert_called_once_with("/some/script.nk")
+
+    def test_does_not_call_refresh_for_other_params(self) -> None:
+        node = _make_node()
+        node._refresh_dynamic_ports = MagicMock()
+        mock_param = MagicMock()
+        mock_param.name = "frame_start"
+        node.after_value_set(mock_param, 1001)
+        node._refresh_dynamic_ports.assert_not_called()
+
+
+class TestProcess:
+    def test_sets_success_status_on_zero_return_code(self, tmp_path: Path) -> None:
+        from execution.provider import JobResult, JobStatus
+        from script_parser.annotation import GriptapeAnnotation
+
+        nk_file = tmp_path / "test.nk"
+        nk_file.write_text("")
+
+        node = _make_node()
+        node._annotations = [
+            GriptapeAnnotation(node_name="Write1", role="output", gt_name="result", gt_type="ImageArtifact")
+        ]
+        node._expose_knobs = []
+
+        node.get_parameter_value = MagicMock(
+            side_effect=lambda name: {
+                "script_path": str(nk_file),
+                "nuke_executable": "/usr/bin/nuke",
+                "frame_start": 1001,
+                "frame_end": 1001,
+            }.get(name)
+        )
+
+        out_file = tmp_path / "out.png"
+        out_file.write_bytes(b"")
+        fake_result = JobResult(
+            handle="handle-123",
+            status=JobStatus.SUCCEEDED,
+            return_code=0,
+            log=[],
+            outputs={"result": str(out_file)},
+        )
+
+        with (
+            patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
+        ):
+            MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            instance = MockProvider.return_value
+            instance.submit.return_value = "handle-123"
+            instance.result.return_value = fake_result
+
+            node.process()
+
+        node._set_status_results.assert_called_once_with(was_successful=True, result_details="Render complete.")
+        node._handle_failure_exception.assert_not_called()
+
+    def test_routes_to_failure_on_nonzero_return_code(self, tmp_path: Path) -> None:
+        from execution.provider import JobResult, JobStatus
+
+        nk_file = tmp_path / "test.nk"
+        nk_file.write_text("")
+
+        node = _make_node()
+        node._annotations = []
+        node._expose_knobs = []
+
+        node.get_parameter_value = MagicMock(
+            side_effect=lambda name: {
+                "script_path": str(nk_file),
+                "nuke_executable": "/usr/bin/nuke",
+                "frame_start": 1001,
+                "frame_end": 1001,
+            }.get(name)
+        )
+
+        fake_result = JobResult(
+            handle="handle-456",
+            status=JobStatus.FAILED,
+            return_code=1,
+            log=["Error: missing licence"],
+            outputs={},
+        )
+
+        with (
+            patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
+        ):
+            MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            instance = MockProvider.return_value
+            instance.submit.return_value = "handle-456"
+            instance.result.return_value = fake_result
+
+            node.process()
+
+        call_kwargs = node._set_status_results.call_args.kwargs
+        assert call_kwargs["was_successful"] is False
+        assert "1" in call_kwargs["result_details"]
+        node._handle_failure_exception.assert_called_once()
+
+    def test_applies_zero_float_knob_override(self, tmp_path: Path) -> None:
+        from execution.provider import JobResult, JobStatus
+        from script_parser.annotation import ExposedKnob
+
+        nk_file = tmp_path / "test.nk"
+        nk_file.write_text("")
+
+        node = _make_node()
+        node._annotations = []
+        ek = ExposedKnob(
+            source_node="Grade1",
+            knob_ref="Grade1.multiply",
+            target_node="Grade1",
+            target_knob="multiply",
+            param_name="Grade1_multiply",
+            knob_type="AColor_Knob",
+        )
+        node._expose_knobs = [ek]
+
+        node.get_parameter_value = MagicMock(
+            side_effect=lambda name: {
+                "script_path": str(nk_file),
+                "nuke_executable": "/usr/bin/nuke",
+                "frame_start": 1001,
+                "frame_end": 1001,
+                "Grade1_multiply": 0.0,
+            }.get(name)
+        )
+
+        fake_result = JobResult(
+            handle="handle-789",
+            status=JobStatus.SUCCEEDED,
+            return_code=0,
+            log=[],
+            outputs={},
+        )
+
+        with (
+            patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
+        ):
+            MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            instance = MockProvider.return_value
+            instance.submit.return_value = "handle-789"
+            instance.result.return_value = fake_result
+
+            node.process()
+
+        manifest = instance.submit.call_args.args[0]
+        assert len(manifest.knob_overrides) == 1
+        assert manifest.knob_overrides[0].node == "Grade1"
+        assert manifest.knob_overrides[0].knob == "multiply"
+        assert manifest.knob_overrides[0].value == pytest.approx(0.0)

--- a/tests/unit/test_open_in_nuke.py
+++ b/tests/unit/test_open_in_nuke.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import os
+
+from nuke_nodes.nuke_script_node import _build_open_in_nuke_launch
+from nuke_runner.manifest import KnobOverride
+
+
+def test_command_does_not_use_t_flag() -> None:
+    cmd, _ = _build_open_in_nuke_launch("/usr/bin/nuke", "/comp/shot.nk", [], {})
+    assert "-t" not in cmd
+
+
+def test_command_includes_p_flag_and_startup_script() -> None:
+    cmd, _ = _build_open_in_nuke_launch("/usr/bin/nuke", "/comp/shot.nk", [], {})
+    assert cmd[0] == "/usr/bin/nuke"
+    assert "-p" in cmd
+    p_idx = cmd.index("-p")
+    startup = cmd[p_idx + 1]
+    assert startup.endswith(".py")
+    assert os.path.exists(startup)
+    # .nk path must NOT be a CLI arg — it is baked into the startup script body
+    assert "/comp/shot.nk" not in cmd
+
+
+def test_startup_script_calls_script_open() -> None:
+    cmd, _ = _build_open_in_nuke_launch("/usr/bin/nuke", "/comp/shot.nk", [], {})
+    startup_path = cmd[cmd.index("-p") + 1]
+    with open(startup_path, encoding="utf-8") as f:
+        src = f.read()
+    assert "nuke.scriptOpen(" in src
+    assert "/comp/shot.nk" in src
+
+
+def test_startup_script_contains_manifest_path() -> None:
+    cmd, _ = _build_open_in_nuke_launch("/usr/bin/nuke", "/comp/shot.nk", [], {})
+    startup_path = cmd[cmd.index("-p") + 1]
+    with open(startup_path, encoding="utf-8") as f:
+        src = f.read()
+    # The manifest path must appear as a Python string literal in the startup script
+    assert "open(" in src
+    assert ".json" in src
+
+
+def test_overrides_serialised_to_manifest() -> None:
+    overrides = [
+        KnobOverride(node="Grade1", knob="gain", value=1.4),
+        KnobOverride(node="Grade1", knob="gamma", value=0.9),
+    ]
+    cmd, _ = _build_open_in_nuke_launch("/usr/bin/nuke", "/comp/shot.nk", overrides, {})
+
+    # Find the manifest file path from the startup script source
+    startup_path = cmd[cmd.index("-p") + 1]
+    with open(startup_path, encoding="utf-8") as f:
+        src = f.read()
+    # Extract the quoted path from the open() call in the startup script
+    import re
+
+    match = re.search(r"open\((['\"][^'\"]+['\"])", src)
+    assert match, "could not find open() path in startup script"
+    manifest_path = match.group(1).strip("'\"")
+
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["knob_overrides"] == [
+        {"node": "Grade1", "knob": "gain", "value": 1.4},
+        {"node": "Grade1", "knob": "gamma", "value": 0.9},
+    ]
+
+
+def test_empty_overrides_produces_empty_array() -> None:
+    cmd, _ = _build_open_in_nuke_launch("/usr/bin/nuke", "/comp/shot.nk", [], {})
+    startup_path = cmd[cmd.index("-p") + 1]
+    with open(startup_path, encoding="utf-8") as f:
+        src = f.read()
+    import re
+
+    match = re.search(r"open\((['\"][^'\"]+['\"])", src)
+    assert match
+    manifest_path = match.group(1).strip("'\"")
+    with open(manifest_path, encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["knob_overrides"] == []


### PR DESCRIPTION
Griptape > Nuke - Adds Griptape Node that runs headless Nuke sessions - Resolves #37 

To functionally test this work locally checkout the head of the branch stack `feat/gt-to-nuke-plugin`.

# Overview
This set of PRs (33/34 and 35) add new functionality to griptape-nodes-library-nuke to a allow Griptape workflows to execute [headless](https://learn.foundry.com/nuke/developers/17.0/pythondevguide/command_line.html) Nuke sessions in the context of a Griptape workflow. A typical user workflow is:

## Installation
1. User installs `griptape-nodes-library-nuke` and registers a Nuke installation in their library settings. An example of the required settings are:

```
{
  "workspace_directory": "/home/user/griptape-nodes-example-workspace",
  "storage_backend": "local",
  
  [...snipped...]
  
  "nuke": {
    "installations": [
      {
        "display_name": "Nuke 17.0v1",
        "executable_path": "/opt/sw/Foundry/Nuke17.0v1/Nuke17.0",
        "launch_mode": "direct",
        "launch_args": "",
        "env_overrides": {},
        "notes": "",
        "annotator_nuke_version": 17
      }
    ],
    "executable": "",
    "nuke_path": [],
    "env": {},
    "annotator_nuke_version": 16
  }
}
```

2. User creates a "Nuke Script" Node in their Griptape workflow.

## Annotation

3. The user exposes the Nuke Nodes and Parameters (Knobs) that should be editable on the Griptape Node via an annotation mechanism.

Annotations are descirbed in a "sidecar" file that lives next to the nuke script with the extension "<script_name>.gt.json". A simple example sidecar file is:

```
{
  "annotations": [
    {
      "node": "Read",
      "gt_role": "input",
      "gt_name": "read",
      "gt_type": "ImageArtifact"
    },
    {
      "node": "Write",
      "gt_role": "output",
      "gt_name": "write",
      "gt_type": "ImageArtifact"
    },
    {
      "node": "GradeRed",
      "gt_expose": [
        {
          "knob": "GradeRed.black",
          "type": "AColor_Knob"
        },
        {
          "knob": "GradeRed.blackpoint",
          "type": "AColor_Knob"
        },
        {
          "knob": "GradeRed.multiply",
          "type": "AColor_Knob"
        },
        {
          "knob": "GradeRed.white",
          "type": "AColor_Knob"
        },
        {
          "knob": "GradeRed.whitepoint",
          "type": "AColor_Knob"
        }
      ]
    },
  ],
  "schema": "griptape-nuke-annotations/1.0",
  "script": "simple_comp.nk",
  "script_hash": "sha256:611ff779422e82d4e97b952793ad40ea4628a2b725a84b5a8ac42ab2172be198"
}
``` 

In this example the Nuke nodes named `Read` and `Write` are exposed as input/output ports that expect and produce `ImageArtifact` Griptape types. A subset of Knob's from the `GradeRed` node are exposed as parameters on the Griptape node. The "script_hash" contains the sha256 hash of the Nuke script when the annotation was written allowing for simple change detection.

4. Sidecar files can be written by hand, or using the plugins provided (see `feat/gt-to-nuke-plugin`).

## Execution

5. Once configured, the Griptape node is wired up as usual.

# Griptape > Nuke - Adds Griptape Node that runs headless Nuke sessions

## Technical Overview
The primary contribution of this PR is a new Griptape Node `Nuke Script` which _is a_ `SuccessFailureNode` (`nuke_nodes/nuke_script_node.py`). It presents a combination of a static parameter interface - such as which Nuke script to run and using which version of Nuke - and a dynamic parameter interface based on the contents of the parsed side car file.

1. Static UI Construction (__init__)
  
Fixed parameters are created once at construction:
 - `script_path` - ParameterString with a FileSystemPicker trait restricting to .nk
 - `nuke_installation` - Parameter with an Options trait populated by merged_installations() at init time; shows the union of engine config + system-discovered installs
 - `frame_start` / `frame_end` - plain int parameters
 - `open_in_nuke` / `refresh_ui` - ParameterButtons with bound callbacks
 - An Advanced collapsed ParameterGroup containing `nuke_executable` (override), `baked_script_path`, and `save_baked_copy`

2. Dynamic Port Management

This is the core complexity. Ports are driven by two sources read from the sidecar (.gt.json): GriptapeAnnotation records (input/output nodes) and ExposedKnob records (per-knob overrides).

`_refresh_dynamic_ports` is the full rebuild path:
1. Absorbs any orphaned user_defined params
2. Removes all tracked dynamic params and groups
3. Parses the .nk via parse_script()
4. Reads the .gt.json sidecar via read_sidecar() (warns if stale)
5. Adds one input Parameter per role="input" annotation (broad input_types list to accept images, URLs, blobs, strings)
6. Creates an "Outputs" ParameterGroup, then for each role="output" annotation: tries Parameter3D for 3D types with ImportError fallback to
generic Parameter
7. Creates per-node ParameterGroups for exposed knobs, types resolved via griptape_type_for_knob() / resolve_exposed_knob_type() against the
knob schema
8. Calls _move_status_to_bottom() to keep the status component last

`_restore_missing_ports` is the soft-rebuild path: re-reads annotations, then only adds ports missing from the already-restored param set to avoid destroying connections the engine already wired.

3. Execution (process)

1. Calls `_ensure_annotations()` (lazy re-read of sidecar if _annotations is empty after a reload)
2. Resolves the Nuke executable via override -> selected installation -> engine config fallback
3. Builds required environment variables: global nuke.env -> installation env_overrides -> foundry_LICENSE from os.environ
4. Converts each input annotation's parameter value to a local path via _artifact_to_path(): handles bare strings, http(s):// URLs (downloads to temp file), Griptape macro paths (via GetPathForMacroRequest), and raw bytes
5. Pre-creates a temp file per output (suffix determined by _TEMP_SUFFIX for 3D types, .png otherwise) and records path in ManifestOutput
6. Builds a `JobManifest` and submits it to `DirectSubprocessProvider` (blocks until Nuke exits)
7. Maps output paths back to artifacts via `_path_to_artifact()`: for 3D types attempts trimesh conversion to GLB, serves via StaticFilesManager, and wraps in ThreeDUrlArtifact with ImportError fallback

