### PR TITLE
fix: specify utf-8 encoding to prevent cp949 decode errors on Windows

### DIFF
--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -374,6 +374,6 @@ if not _companion or not _os.path.isdir(_companion):
     nuke.message("Griptape: cannot find companion directory for '{safe_name}'. Make sure the griptape folder is on Nuke's plugin path.")
 else:
     _btn_path = _os.path.join(_companion, "{RUN_BUTTON_FILENAME}")
-    with open(_btn_path) as _f:
+    with open(_btn_path, encoding="utf-8") as _f:
         exec(compile(_f.read(), _btn_path, "exec"), dict(globals(), **{{"__file__": _btn_path, "_config": {config_repr}}}))
 """

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -501,6 +501,7 @@ else:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
+                    encoding="utf-8",
                     bufsize=1,
                     cwd=companion,
                 )
@@ -548,7 +549,7 @@ else:
             # ------------------------------------------------------------------
             # Fallback: blocking path when Qt is not available
             # ------------------------------------------------------------------
-            result = subprocess.run(cmd, capture_output=True, text=True, cwd=companion, timeout=600)
+            result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", cwd=companion, timeout=600)
             if result.returncode == 0:
                 try:
                     output = json.loads(result.stdout.strip())


### PR DESCRIPTION
## Summary

- On Windows with non-UTF-8 system locales (e.g. Korean `cp949`), `open()` and `subprocess` calls using `text=True` without an explicit encoding default to the system locale codec, causing `UnicodeDecodeError` when the output contains multi-byte UTF-8 sequences
- Added `encoding="utf-8"` to `open()` in the gizmo bootstrap (`nuke_gizmo_builder.py`) and to both `subprocess.Popen` and `subprocess.run` calls in `run_button.py`

Closes griptape-ai/griptape-nodes#4504

## Test plan
- [ ] Verify workflow runs successfully on Windows with a Korean (cp949) system locale
- [ ] Verify workflow still runs correctly on macOS/Linux and English Windows (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)