### PR TITLE
feat: VideoUrlArtifact inputs/outputs and ImageSequenceArtifact output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Griptape Nodes library for building workflows that run inside [Foundry Nuke](h
 - **Nuke flow-control nodes** under the `Foundry Nuke` category:
   - `NukeStartFlow` – entry point for a Nuke-targeted workflow.
   - `NukeEndFlow` – terminal node; exposes `was_successful` and `result_details`.
-- **NukeScriptNode** – runs a `.nk` script headlessly via `nuke -t`, surfaces annotated Read/Write nodes as typed input/output ports on the canvas, and supports per-knob value overrides.
+- **NukeScriptNode** – runs a `.nk` script headlessly via `nuke -t`, surfaces annotated Read/Write nodes as typed input/output ports on the canvas, and supports per-knob value overrides. Inputs accept images, video, and raw file paths; outputs can be images, image sequences, video, or 3D geometry.
 - **Griptape Annotator** – a dockable panel that runs inside the Nuke GUI for tagging I/O nodes and promoting knobs to the Griptape interface.
 - **Gizmo publisher** (`publish_gizmo/`): packages a workflow into a versioned `.gizmo` alongside a runner script and installs it into a Nuke plugin directory (default: `~/.nuke`).
 - **Auto-discovery** of Nuke installations on macOS, Windows, and Linux, plus `NUKE_PATH` segment detection for picking an install target.
@@ -37,7 +37,7 @@ Copy [.env.example](.env.example) to `.env` and set `NUKE_PATH` if you want extr
 
 ## NukeScriptNode
 
-`NukeScriptNode` lets you drive an existing Nuke script from Griptape. Point it at a `.nk` file, annotate which nodes are inputs and outputs using the Griptape Annotator panel, and the node grows typed ports matching those annotations. At run time it invokes Nuke headlessly (`nuke -t`) and returns rendered output files as `ImageUrlArtifact` values.
+`NukeScriptNode` lets you drive an existing Nuke script from Griptape. Point it at a `.nk` file, annotate which nodes are inputs and outputs using the Griptape Annotator panel, and the node grows typed ports matching those annotations. At run time it invokes Nuke headlessly (`nuke -t`) and returns rendered output files as typed Griptape artifacts.
 
 ### Quick start
 
@@ -56,9 +56,20 @@ Annotations are stored in a `<script>.gt.json` file next to the `.nk`. The Annot
 
 Knobs promoted via the Annotator panel's **Expose** tab appear as Griptape parameters grouped under their node name. Leave a field empty to use the value already in the script; set it to override before the render.
 
+### Inputs
+
+Read nodes annotated as inputs accept `str` (file path), `ImageArtifact`, `ImageUrlArtifact`, `VideoUrlArtifact`, or `BlobArtifact` values. URL-based artifacts are downloaded to a temporary file before the render.
+
 ### Outputs
 
-Write nodes annotated as outputs surface as `ImageUrlArtifact` ports in the **Outputs** group after the node runs.
+Write nodes annotated as outputs surface in the **Outputs** group after the node runs. The artifact type depends on the annotation:
+
+| Annotation type        | Griptape output                                           |
+|------------------------|-----------------------------------------------------------|
+| `ImageArtifact` / `ImageUrlArtifact` | `ImageUrlArtifact` (single rendered frame)  |
+| `VideoUrlArtifact`     | `VideoUrlArtifact` (rendered video file, e.g. `.mp4`)     |
+| `ImageSequenceArtifact`| `ListArtifact` of `ImageUrlArtifact` — one per rendered frame |
+| `ThreeDUrlArtifact` / `GLTFUrlArtifact` | `ThreeDUrlArtifact` (`.obj` or `.glb`)   |
 
 ### Advanced parameters
 

--- a/execution/direct.py
+++ b/execution/direct.py
@@ -121,7 +121,7 @@ class DirectSubprocessProvider:
         _, stderr_output = process.communicate()
         return_code = process.returncode
         status = JobStatus.SUCCEEDED if return_code == 0 else JobStatus.FAILED
-        outputs: dict[str, str] = {}
+        outputs: dict[str, str | list[str]] = {}
         out_manifest_path = self._output_manifest_paths.get(handle, None)
         if out_manifest_path and os.path.exists(out_manifest_path):
             with open(out_manifest_path, encoding="utf-8") as f:

--- a/execution/provider.py
+++ b/execution/provider.py
@@ -17,5 +17,5 @@ class JobResult:
     handle: str
     status: JobStatus
     return_code: int
-    outputs: dict[str, str] = field(default_factory=dict)
+    outputs: dict[str, str | list[str]] = field(default_factory=dict)
     log: list[str] = field(default_factory=list)

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -10,7 +10,6 @@ import shutil
 import subprocess
 import tempfile
 import urllib.request
-import uuid
 from typing import Any
 
 from griptape_nodes.common.macro_parser import ParsedMacro
@@ -20,6 +19,7 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
+from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode.events.project_events import GetPathForMacroRequest, GetPathForMacroResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -67,26 +67,30 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
             except Exception:
                 file_bytes = File(path).read_bytes()
                 serve_suffix = suffix
-        url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{serve_suffix}")
+        saved = ProjectFileDestination.from_situation(
+            filename=f"model{serve_suffix}", situation="save_node_output"
+        ).write_bytes(file_bytes)
         try:
             from griptape_nodes_library.three_d.three_d_artifact import (  # pyright: ignore[reportMissingImports]
                 ThreeDUrlArtifact,  # noqa: PLC0415
             )
         except ImportError:
-            return url
-        return ThreeDUrlArtifact(value=url)
+            return saved.location
+        return ThreeDUrlArtifact(value=saved.location)
     if gt_type == "VideoUrlArtifact":
         if not isinstance(path, str):
             raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
         file_bytes = File(path).read_bytes()
         suffix = pathlib.Path(path).suffix or ".mp4"
-        url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{suffix}")
+        saved = ProjectFileDestination.from_situation(
+            filename=f"video{suffix}", situation="save_node_output"
+        ).write_bytes(file_bytes)
         try:
             from griptape.artifacts import VideoUrlArtifact  # noqa: PLC0415
 
-            return VideoUrlArtifact(value=url)
+            return VideoUrlArtifact(value=saved.location)
         except ImportError:
-            return url
+            return saved.location
     if gt_type == "ImageSequenceArtifact":
         if not isinstance(path, list):
             raise TypeError(f"Expected list[str] for ImageSequenceArtifact, got {type(path).__name__!r}: {path!r}")
@@ -95,13 +99,11 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
 
             items = []
             for fp in path:
-                frame_bytes = File(fp).read_bytes()
                 frame_suffix = pathlib.Path(fp).suffix or ".png"
-                frame_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                    frame_bytes, f"{uuid.uuid4()}{frame_suffix}"
-                )
-                del frame_bytes
-                items.append(ImageUrlArtifact(value=frame_url))
+                frame_saved = ProjectFileDestination.from_situation(
+                    filename=f"frame{frame_suffix}", situation="save_node_output"
+                ).write_bytes(File(fp).read_bytes())
+                items.append(ImageUrlArtifact(value=frame_saved.location))
             return ListArtifact(items)
         except ImportError:
             return path
@@ -109,13 +111,15 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
         raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
     file_bytes = File(path).read_bytes()
     suffix = pathlib.Path(path).suffix or ".png"
-    url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{suffix}")
+    saved = ProjectFileDestination.from_situation(filename=f"image{suffix}", situation="save_node_output").write_bytes(
+        file_bytes
+    )
     try:
         from griptape.artifacts import ImageUrlArtifact  # noqa: PLC0415
 
-        return ImageUrlArtifact(value=url)
+        return ImageUrlArtifact(value=saved.location)
     except ImportError:
-        return url
+        return saved.location
 
 
 def _coerce_knob_value(v: Any) -> float | int | str:

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -39,15 +39,19 @@ _RUNNER_SCRIPT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", 
 _BAKE_RUNNER_SCRIPT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "nuke_runner", "baker.py"))
 
 # Temp file suffix per gt_type — used when creating output placeholders before Nuke runs.
+# ImageSequenceArtifact is handled separately (mkdtemp + pattern path) and not listed here.
 _TEMP_SUFFIX: dict[str, str] = {
     "ThreeDUrlArtifact": ".obj",
     "GLTFUrlArtifact": ".glb",
+    "VideoUrlArtifact": ".mp4",
 }
 
 
-def _path_to_artifact(gt_type: str, path: str) -> Any:
-    """Convert a runner output file path to the appropriate Griptape artifact."""
+def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
+    """Convert a runner output file path (or list of paths) to the appropriate Griptape artifact."""
     if gt_type in {"ThreeDUrlArtifact", "GLTFUrlArtifact"}:
+        if not isinstance(path, str):
+            raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
         suffix = pathlib.Path(path).suffix.lower() or ".obj"
         if suffix in {".glb", ".gltf"}:
             file_bytes = pathlib.Path(path).read_bytes()
@@ -70,6 +74,38 @@ def _path_to_artifact(gt_type: str, path: str) -> Any:
         except ImportError:
             return url
         return ThreeDUrlArtifact(value=url)
+    if gt_type == "VideoUrlArtifact":
+        if not isinstance(path, str):
+            raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
+        file_bytes = pathlib.Path(path).read_bytes()
+        suffix = pathlib.Path(path).suffix or ".mp4"
+        url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{suffix}")
+        try:
+            from griptape.artifacts import VideoUrlArtifact  # noqa: PLC0415
+
+            return VideoUrlArtifact(value=url)
+        except ImportError:
+            return url
+    if gt_type == "ImageSequenceArtifact":
+        if not isinstance(path, list):
+            raise TypeError(f"Expected list[str] for ImageSequenceArtifact, got {type(path).__name__!r}: {path!r}")
+        try:
+            from griptape.artifacts import ImageUrlArtifact, ListArtifact  # noqa: PLC0415
+
+            items = []
+            for fp in path:
+                frame_bytes = pathlib.Path(fp).read_bytes()
+                frame_suffix = pathlib.Path(fp).suffix or ".png"
+                frame_url = GriptapeNodes.StaticFilesManager().save_static_file(
+                    frame_bytes, f"{uuid.uuid4()}{frame_suffix}"
+                )
+                del frame_bytes
+                items.append(ImageUrlArtifact(value=frame_url))
+            return ListArtifact(items)
+        except ImportError:
+            return path
+    if not isinstance(path, str):
+        raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
     file_bytes = pathlib.Path(path).read_bytes()
     suffix = pathlib.Path(path).suffix or ".png"
     url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{suffix}")
@@ -433,7 +469,7 @@ class NukeScriptNode(SuccessFailureNode):
             param = Parameter(
                 name=ann.gt_name,
                 type=ann.gt_type or "str",
-                input_types=["str", "ImageArtifact", "ImageUrlArtifact", "BlobArtifact"],
+                input_types=["str", "ImageArtifact", "ImageUrlArtifact", "BlobArtifact", "VideoUrlArtifact"],
                 default_value="",
                 display_name=ann.gt_label or ann.gt_name,
                 tooltip=f"Input path for Nuke node {ann.node_name!r}",
@@ -479,6 +515,18 @@ class NukeScriptNode(SuccessFailureNode):
                         user_defined=True,
                         parent_element_name="Outputs",
                     )
+            elif ann.gt_type == "ImageSequenceArtifact":
+                param = Parameter(
+                    name=ann.gt_name,
+                    type="list",
+                    default_value="",
+                    display_name=ann.gt_label or ann.gt_name,
+                    tooltip=f"Image sequence output from Nuke node {ann.node_name!r}",
+                    allow_input=False,
+                    allow_property=False,
+                    user_defined=True,
+                    parent_element_name="Outputs",
+                )
             else:
                 param = Parameter(
                     name=ann.gt_name,
@@ -563,10 +611,17 @@ class NukeScriptNode(SuccessFailureNode):
         """Resolve a parameter value to a local file path Nuke can read."""
         if isinstance(value, str):
             return value
+        try:
+            from griptape.artifacts import VideoUrlArtifact  # noqa: PLC0415
+
+            _video_type: type = VideoUrlArtifact
+        except ImportError:
+            _video_type = type(None)
         val = getattr(value, "value", None)
         if isinstance(val, str):
             if val.startswith(("http://", "https://")):
-                suffix = os.path.splitext(val.split("?")[0])[-1] or ".png"
+                detected = os.path.splitext(val.split("?")[0])[-1]
+                suffix = detected or (".mp4" if isinstance(value, _video_type) else ".png")
                 tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
                 try:
                     with urllib.request.urlopen(val, timeout=30) as response:  # noqa: S310
@@ -730,12 +785,22 @@ class NukeScriptNode(SuccessFailureNode):
         inputs: dict[str, ManifestInput] = {}
         outputs: dict[str, ManifestOutput] = {}
         output_tmp_paths: list[str] = []
+        output_tmp_dirs: list[str] = []
 
         for ann in self._annotations:
             if ann.role == "input":
                 inputs[ann.gt_name] = ManifestInput(
                     path=self._artifact_to_path(self.get_parameter_value(ann.gt_name) or ""),
                     node=ann.node_name,
+                )
+            elif ann.gt_type == "ImageSequenceArtifact":
+                tmpdir = tempfile.mkdtemp(prefix="griptape_nuke_seq_")
+                output_tmp_dirs.append(tmpdir)
+                seq_path = os.path.join(tmpdir, "frame.%04d.png").replace("\\", "/")
+                outputs[ann.gt_name] = ManifestOutput(
+                    path=seq_path,
+                    node=ann.node_name,
+                    type="ImageSequenceArtifact",
                 )
             else:
                 suffix = _TEMP_SUFFIX.get(ann.gt_type or "", ".png")
@@ -788,3 +853,6 @@ class NukeScriptNode(SuccessFailureNode):
             for p in output_tmp_paths:
                 with contextlib.suppress(OSError):
                     os.unlink(p)
+            for d in output_tmp_dirs:
+                with contextlib.suppress(OSError):
+                    shutil.rmtree(d)

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -19,6 +19,7 @@ from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, Pa
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.events.project_events import GetPathForMacroRequest, GetPathForMacroResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -54,7 +55,7 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
             raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
         suffix = pathlib.Path(path).suffix.lower() or ".obj"
         if suffix in {".glb", ".gltf"}:
-            file_bytes = pathlib.Path(path).read_bytes()
+            file_bytes = File(path).read_bytes()
             serve_suffix = suffix
         else:
             try:
@@ -64,7 +65,7 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
                 file_bytes = scene.export(file_type="glb")  # pyright: ignore[reportAttributeAccessIssue,reportCallIssue]
                 serve_suffix = ".glb"
             except Exception:
-                file_bytes = pathlib.Path(path).read_bytes()
+                file_bytes = File(path).read_bytes()
                 serve_suffix = suffix
         url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{serve_suffix}")
         try:
@@ -77,7 +78,7 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
     if gt_type == "VideoUrlArtifact":
         if not isinstance(path, str):
             raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
-        file_bytes = pathlib.Path(path).read_bytes()
+        file_bytes = File(path).read_bytes()
         suffix = pathlib.Path(path).suffix or ".mp4"
         url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{suffix}")
         try:
@@ -94,7 +95,7 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
 
             items = []
             for fp in path:
-                frame_bytes = pathlib.Path(fp).read_bytes()
+                frame_bytes = File(fp).read_bytes()
                 frame_suffix = pathlib.Path(fp).suffix or ".png"
                 frame_url = GriptapeNodes.StaticFilesManager().save_static_file(
                     frame_bytes, f"{uuid.uuid4()}{frame_suffix}"
@@ -106,7 +107,7 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
             return path
     if not isinstance(path, str):
         raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
-    file_bytes = pathlib.Path(path).read_bytes()
+    file_bytes = File(path).read_bytes()
     suffix = pathlib.Path(path).suffix or ".png"
     url = GriptapeNodes.StaticFilesManager().save_static_file(file_bytes, f"{uuid.uuid4()}{suffix}")
     try:

--- a/nuke_plugin/griptape_annotator_panel.py
+++ b/nuke_plugin/griptape_annotator_panel.py
@@ -32,8 +32,11 @@ _PANEL_TITLE = "Griptape Annotator"
 _TILE_COLOR_ROLE = 0x5FAD4EFF
 _TILE_COLOR_EXPOSE = 0x9B59B6FF
 
+# Artifact types available when marking a node as an input.
+_INPUT_ARTIFACT_TYPES = ["ImageArtifact", "VideoUrlArtifact"]
+
 # Artifact types available when marking a node as an output.
-_OUTPUT_ARTIFACT_TYPES = ["ImageArtifact", "ThreeDUrlArtifact"]
+_OUTPUT_ARTIFACT_TYPES = ["ImageArtifact", "VideoUrlArtifact", "ImageSequenceArtifact", "ThreeDUrlArtifact"]
 
 # Knobs that are never useful to expose — purely internal Nuke state
 _INTERNAL_KNOBS = frozenset(
@@ -558,7 +561,16 @@ class GriptapeAnnotatorWidget(QtWidgets.QWidget):
             if not ok:
                 return
         else:
-            gt_type = "ImageArtifact"
+            gt_type, ok = QtWidgets.QInputDialog.getItem(
+                self,
+                "Input Artifact Type",
+                f"Select the Griptape artifact type for {node_name!r}:",
+                _INPUT_ARTIFACT_TYPES,
+                0,
+                False,
+            )
+            if not ok:
+                return
 
         self._annotations = [a for a in self._annotations if a["node"] != node_name]
         self._annotations.append(
@@ -707,7 +719,14 @@ def _gt_mark_node(role: str) -> None:
             return
         gt_type = _OUTPUT_ARTIFACT_TYPES[choice]
     else:
-        gt_type = "ImageArtifact"
+        choice = nuke.choice(
+            "Select the Griptape artifact type:",
+            "Input Type",
+            _INPUT_ARTIFACT_TYPES,
+        )
+        if choice is None:
+            return
+        gt_type = _INPUT_ARTIFACT_TYPES[choice]
 
     data = _read_sidecar(sidecar_path)
     annotations = [a for a in data.get("annotations", []) if a.get("node") != node.name()]

--- a/nuke_runner/manifest.py
+++ b/nuke_runner/manifest.py
@@ -18,13 +18,16 @@ class ManifestInput:
 
 @dataclass
 class ManifestOutput:
-    path: str
+    path: str | list[str]
     node: str
     format: str = "png"
     type: str = "ImageArtifact"
 
     def __post_init__(self) -> None:
-        self.path = self.path.replace("\\", "/")
+        if isinstance(self.path, list):
+            self.path = [p.replace("\\", "/") for p in self.path]
+        else:
+            self.path = self.path.replace("\\", "/")
 
 
 @dataclass

--- a/nuke_runner/runner.py
+++ b/nuke_runner/runner.py
@@ -10,7 +10,9 @@ Logs go to stderr; the final output manifest JSON is written to --output-manifes
 from __future__ import annotations
 
 import argparse
+import glob as _glob
 import json
+import re
 import sys
 
 import nuke  # type: ignore[import-not-found]
@@ -18,6 +20,7 @@ import nuke  # type: ignore[import-not-found]
 # Artifact types whose output is written by a Nuke execute call on a file-knob node.
 _EXECUTE_TYPES = {
     "ImageArtifact",
+    "ImageSequenceArtifact",
     "ImageUrlArtifact",
     "VideoArtifact",
     "VideoUrlArtifact",
@@ -32,7 +35,7 @@ def main() -> None:
     # parse_known_args: nuke -t may inject extra positional args
     args, _ = parser.parse_known_args()
 
-    outputs: dict[str, str] = {}
+    outputs: dict[str, str | list[str]] = {}
     errors: list[str] = []
 
     try:
@@ -99,7 +102,12 @@ def main() -> None:
             print(f"executing {spec['node']} frames {first}-{last} → {out_path}", file=sys.stderr)
             try:
                 nuke.execute(spec["node"], first, last)
-                outputs[gt_name] = out_path
+                if artifact_type == "ImageSequenceArtifact":
+                    glob_pattern = re.sub(r"%0?\d*d", "*", out_path)
+                    frame_paths = sorted(_glob.glob(glob_pattern))
+                    outputs[gt_name] = frame_paths
+                else:
+                    outputs[gt_name] = out_path
             except Exception as exc:
                 msg = f"ERROR: execute failed for {spec['node']!r}: {exc}"
                 print(msg, file=sys.stderr)

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -121,9 +121,7 @@ class NukeGizmoPublisher:
                 overwrite=True,
             )
             self._copy_file(
-                Path(__file__).parent / "output_protocol.py", 
-                companion_base / "output_protocol.py",
-                overwrite=True
+                Path(__file__).parent / "output_protocol.py", companion_base / "output_protocol.py", overwrite=True
             )
 
             available_versions = self._collect_versions(companion_base)

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -99,3 +99,38 @@ def test_bake_output_path_defaults_empty() -> None:
     assert m.bake_output_path == ""
     restored = JobManifest.from_json(m.to_json())
     assert restored.bake_output_path == ""
+
+
+def test_manifest_output_path_accepts_list() -> None:
+    output = ManifestOutput(path=["/tmp/f.0001.exr", "/tmp/f.0002.exr"], node="Write1", type="ImageSequenceArtifact")
+    assert isinstance(output.path, list)
+    assert output.path == ["/tmp/f.0001.exr", "/tmp/f.0002.exr"]
+
+
+def test_manifest_output_list_path_round_trips_json() -> None:
+    m = JobManifest(
+        script="/tmp/test.nk",
+        outputs={
+            "frames": ManifestOutput(
+                path=["/tmp/f.0001.exr", "/tmp/f.0002.exr"],
+                node="Write1",
+                type="ImageSequenceArtifact",
+            )
+        },
+    )
+    restored = JobManifest.from_json(m.to_json())
+    assert restored.outputs["frames"].path == ["/tmp/f.0001.exr", "/tmp/f.0002.exr"]
+
+
+def test_manifest_output_list_path_normalises_backslashes() -> None:
+    output = ManifestOutput(
+        path=["C:\\tmp\\f.0001.exr", "C:\\tmp\\f.0002.exr"],
+        node="Write1",
+        type="ImageSequenceArtifact",
+    )
+    assert output.path == ["C:/tmp/f.0001.exr", "C:/tmp/f.0002.exr"]
+
+
+def test_manifest_output_str_path_normalisation_unchanged() -> None:
+    output = ManifestOutput(path="C:\\tmp\\out.png", node="WriteNode")
+    assert output.path == "C:/tmp/out.png"

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nuke_nodes.nuke_script_node import _coerce_knob_value
+from nuke_nodes.nuke_script_node import _coerce_knob_value, _path_to_artifact
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -16,6 +16,125 @@ FIXTURES = Path(__file__).parent / "fixtures"
 # ---------------------------------------------------------------------------
 # Module-level pure functions
 # ---------------------------------------------------------------------------
+
+
+def _mock_static_files_manager(url: str = "http://static/file") -> MagicMock:
+    mgr = MagicMock()
+    mgr.save_static_file.return_value = url
+    return mgr
+
+
+class TestPathToArtifact:
+    def test_video_url_artifact_returns_video_url_artifact(self, tmp_path: Path) -> None:
+        video_file = tmp_path / "clip.mp4"
+        video_file.write_bytes(b"\x00" * 16)
+
+        mock_mgr = _mock_static_files_manager("http://static/clip.mp4")
+
+        with (
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
+            patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
+        ):
+            mock_gt.StaticFilesManager.return_value = mock_mgr
+            mock_uuid.uuid4.return_value = "test-uuid"
+            result = _path_to_artifact("VideoUrlArtifact", str(video_file))
+
+        from griptape.artifacts import VideoUrlArtifact
+
+        assert isinstance(result, VideoUrlArtifact)
+        assert result.value == "http://static/clip.mp4"
+
+    def test_image_sequence_artifact_returns_list_artifact(self, tmp_path: Path) -> None:
+        f1 = tmp_path / "frame.0001.png"
+        f2 = tmp_path / "frame.0002.png"
+        f1.write_bytes(b"\x89PNG")
+        f2.write_bytes(b"\x89PNG")
+
+        mock_mgr = MagicMock()
+        mock_mgr.save_static_file.side_effect = ["http://s/f1.png", "http://s/f2.png"]
+
+        with (
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
+            patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
+        ):
+            mock_gt.StaticFilesManager.return_value = mock_mgr
+            mock_uuid.uuid4.side_effect = ["uuid1", "uuid2"]
+            result = _path_to_artifact("ImageSequenceArtifact", [str(f1), str(f2)])
+
+        from griptape.artifacts import ImageUrlArtifact, ListArtifact
+
+        assert isinstance(result, ListArtifact)
+        assert len(result.value) == 2
+        assert all(isinstance(item, ImageUrlArtifact) for item in result.value)
+
+    def test_image_sequence_artifact_empty_list_returns_empty_list_artifact(self) -> None:
+        with patch("nuke_nodes.nuke_script_node.GriptapeNodes"):
+            result = _path_to_artifact("ImageSequenceArtifact", [])
+
+        from griptape.artifacts import ListArtifact
+
+        assert isinstance(result, ListArtifact)
+        assert len(result.value) == 0
+
+    def test_image_sequence_artifact_raises_type_error_for_str_path(self) -> None:
+        with pytest.raises(TypeError, match="ImageSequenceArtifact"):
+            _path_to_artifact("ImageSequenceArtifact", "/tmp/frame.%04d.png")
+
+    def test_image_artifact_unchanged(self, tmp_path: Path) -> None:
+        img_file = tmp_path / "out.png"
+        img_file.write_bytes(b"\x89PNG")
+
+        mock_mgr = _mock_static_files_manager("http://static/out.png")
+
+        with (
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
+            patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
+        ):
+            mock_gt.StaticFilesManager.return_value = mock_mgr
+            mock_uuid.uuid4.return_value = "test-uuid"
+            result = _path_to_artifact("ImageArtifact", str(img_file))
+
+        from griptape.artifacts import ImageUrlArtifact
+
+        assert isinstance(result, ImageUrlArtifact)
+
+
+class TestArtifactToPath:
+    def test_video_url_artifact_http_downloads_to_mp4_temp(self, tmp_path: Path) -> None:
+        node = _make_node()
+
+        try:
+            from griptape.artifacts import VideoUrlArtifact
+
+            artifact = VideoUrlArtifact(value="http://example.com/clip.mp4")
+        except ImportError:
+            pytest.skip("griptape not installed")
+
+        fake_response = MagicMock()
+        fake_response.__enter__ = MagicMock(return_value=fake_response)
+        fake_response.__exit__ = MagicMock(return_value=False)
+        fake_response.read.return_value = b"\x00" * 8
+
+        with patch("nuke_nodes.nuke_script_node.urllib.request.urlopen", return_value=fake_response) as mock_open:
+            result = node._artifact_to_path(artifact)
+
+        mock_open.assert_called_once()
+        assert result.endswith(".mp4")
+        # Clean up temp file
+        Path(result).unlink(missing_ok=True)
+
+    def test_video_url_artifact_local_path_returned_unchanged(self) -> None:
+        node = _make_node()
+
+        try:
+            from griptape.artifacts import VideoUrlArtifact
+
+            artifact = VideoUrlArtifact(value="/local/clip.mp4")
+        except ImportError:
+            pytest.skip("griptape not installed")
+
+        result = node._artifact_to_path(artifact)
+        assert result == "/local/clip.mp4"
 
 
 class TestCoerceKnobValue:
@@ -325,6 +444,63 @@ class TestProcess:
         assert call_kwargs["was_successful"] is False
         assert "1" in call_kwargs["result_details"]
         node._handle_failure_exception.assert_called_once()
+
+    def test_sequence_output_produces_list_artifact(self, tmp_path: Path) -> None:
+        from execution.provider import JobResult, JobStatus
+        from script_parser.annotation import GriptapeAnnotation
+
+        nk_file = tmp_path / "test.nk"
+        nk_file.write_text("")
+
+        # Create fake frame files
+        f1 = tmp_path / "frame.0001.png"
+        f2 = tmp_path / "frame.0002.png"
+        f1.write_bytes(b"\x89PNG")
+        f2.write_bytes(b"\x89PNG")
+
+        node = _make_node()
+        node._annotations = [
+            GriptapeAnnotation(node_name="Write1", role="output", gt_name="frames", gt_type="ImageSequenceArtifact")
+        ]
+        node._expose_knobs = []
+
+        node.get_parameter_value = MagicMock(
+            side_effect=lambda name: {
+                "script_path": str(nk_file),
+                "nuke_executable": "/usr/bin/nuke",
+                "frame_start": 1001,
+                "frame_end": 1002,
+            }.get(name)
+        )
+
+        fake_result = JobResult(
+            handle="handle-seq",
+            status=JobStatus.SUCCEEDED,
+            return_code=0,
+            log=[],
+            outputs={"frames": [str(f1), str(f2)]},
+        )
+
+        mock_mgr = MagicMock()
+        mock_mgr.save_static_file.side_effect = ["http://s/f1.png", "http://s/f2.png"]
+
+        with (
+            patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
+        ):
+            MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            MockGT.StaticFilesManager.return_value = mock_mgr
+            instance = MockProvider.return_value
+            instance.submit.return_value = "handle-seq"
+            instance.result.return_value = fake_result
+
+            node.process()
+
+        from griptape.artifacts import ListArtifact
+
+        output_val = node.parameter_output_values.__setitem__.call_args[0][1]
+        assert isinstance(output_val, ListArtifact)
+        assert len(output_val.value) == 2
 
     def test_applies_zero_float_knob_override(self, tmp_path: Path) -> None:
         from execution.provider import JobResult, JobStatus

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -18,10 +18,14 @@ FIXTURES = Path(__file__).parent / "fixtures"
 # ---------------------------------------------------------------------------
 
 
-def _mock_static_files_manager(url: str = "http://static/file") -> MagicMock:
-    mgr = MagicMock()
-    mgr.save_static_file.return_value = url
-    return mgr
+def _mock_project_file_destination(location: str = "http://static/file") -> MagicMock:
+    mock_saved = MagicMock()
+    mock_saved.location = location
+    mock_dest_instance = MagicMock()
+    mock_dest_instance.write_bytes.return_value = mock_saved
+    mock_dest_cls = MagicMock()
+    mock_dest_cls.from_situation.return_value = mock_dest_instance
+    return mock_dest_cls
 
 
 class TestPathToArtifact:
@@ -29,18 +33,14 @@ class TestPathToArtifact:
         video_file = tmp_path / "clip.mp4"
         video_file.write_bytes(b"\x00" * 16)
 
-        mock_mgr = _mock_static_files_manager("http://static/clip.mp4")
-
+        mock_dest_cls = _mock_project_file_destination("http://static/clip.mp4")
         mock_file = MagicMock()
         mock_file.read_bytes.return_value = b"\x00" * 16
 
         with (
-            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
-            patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
             patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
         ):
-            mock_gt.StaticFilesManager.return_value = mock_mgr
-            mock_uuid.uuid4.return_value = "test-uuid"
             result = _path_to_artifact("VideoUrlArtifact", str(video_file))
 
         from griptape.artifacts import VideoUrlArtifact
@@ -54,19 +54,22 @@ class TestPathToArtifact:
         f1.write_bytes(b"\x89PNG")
         f2.write_bytes(b"\x89PNG")
 
-        mock_mgr = MagicMock()
-        mock_mgr.save_static_file.side_effect = ["http://s/f1.png", "http://s/f2.png"]
+        saved1, saved2 = MagicMock(), MagicMock()
+        saved1.location = "http://s/f1.png"
+        saved2.location = "http://s/f2.png"
+        dest1, dest2 = MagicMock(), MagicMock()
+        dest1.write_bytes.return_value = saved1
+        dest2.write_bytes.return_value = saved2
+        mock_dest_cls = MagicMock()
+        mock_dest_cls.from_situation.side_effect = [dest1, dest2]
 
         mock_file = MagicMock()
         mock_file.read_bytes.return_value = b"\x89PNG"
 
         with (
-            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
-            patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
             patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
         ):
-            mock_gt.StaticFilesManager.return_value = mock_mgr
-            mock_uuid.uuid4.side_effect = ["uuid1", "uuid2"]
             result = _path_to_artifact("ImageSequenceArtifact", [str(f1), str(f2)])
 
         from griptape.artifacts import ImageUrlArtifact, ListArtifact
@@ -92,18 +95,14 @@ class TestPathToArtifact:
         img_file = tmp_path / "out.png"
         img_file.write_bytes(b"\x89PNG")
 
-        mock_mgr = _mock_static_files_manager("http://static/out.png")
-
+        mock_dest_cls = _mock_project_file_destination("http://static/out.png")
         mock_file = MagicMock()
         mock_file.read_bytes.return_value = b"\x89PNG"
 
         with (
-            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
-            patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
             patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
         ):
-            mock_gt.StaticFilesManager.return_value = mock_mgr
-            mock_uuid.uuid4.return_value = "test-uuid"
             result = _path_to_artifact("ImageArtifact", str(img_file))
 
         from griptape.artifacts import ImageUrlArtifact
@@ -400,6 +399,7 @@ class TestProcess:
             outputs={"result": str(out_file)},
         )
 
+        mock_dest_cls = _mock_project_file_destination("http://static/out.png")
         mock_file = MagicMock()
         mock_file.read_bytes.return_value = b"\x89PNG"
 
@@ -407,6 +407,7 @@ class TestProcess:
             patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
             patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
             instance = MockProvider.return_value
@@ -497,15 +498,24 @@ class TestProcess:
             outputs={"frames": [str(f1), str(f2)]},
         )
 
-        mock_mgr = MagicMock()
-        mock_mgr.save_static_file.side_effect = ["http://s/f1.png", "http://s/f2.png"]
+        saved1, saved2 = MagicMock(), MagicMock()
+        saved1.location = "http://s/f1.png"
+        saved2.location = "http://s/f2.png"
+        dest1, dest2 = MagicMock(), MagicMock()
+        dest1.write_bytes.return_value = saved1
+        dest2.write_bytes.return_value = saved2
+        mock_dest_cls = MagicMock()
+        mock_dest_cls.from_situation.side_effect = [dest1, dest2]
+        mock_file = MagicMock()
+        mock_file.read_bytes.return_value = b"\x89PNG"
 
         with (
             patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
+            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
-            MockGT.StaticFilesManager.return_value = mock_mgr
             instance = MockProvider.return_value
             instance.submit.return_value = "handle-seq"
             instance.result.return_value = fake_result

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -31,9 +31,13 @@ class TestPathToArtifact:
 
         mock_mgr = _mock_static_files_manager("http://static/clip.mp4")
 
+        mock_file = MagicMock()
+        mock_file.read_bytes.return_value = b"\x00" * 16
+
         with (
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
             patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
+            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
         ):
             mock_gt.StaticFilesManager.return_value = mock_mgr
             mock_uuid.uuid4.return_value = "test-uuid"
@@ -53,9 +57,13 @@ class TestPathToArtifact:
         mock_mgr = MagicMock()
         mock_mgr.save_static_file.side_effect = ["http://s/f1.png", "http://s/f2.png"]
 
+        mock_file = MagicMock()
+        mock_file.read_bytes.return_value = b"\x89PNG"
+
         with (
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
             patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
+            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
         ):
             mock_gt.StaticFilesManager.return_value = mock_mgr
             mock_uuid.uuid4.side_effect = ["uuid1", "uuid2"]
@@ -86,9 +94,13 @@ class TestPathToArtifact:
 
         mock_mgr = _mock_static_files_manager("http://static/out.png")
 
+        mock_file = MagicMock()
+        mock_file.read_bytes.return_value = b"\x89PNG"
+
         with (
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gt,
             patch("nuke_nodes.nuke_script_node.uuid") as mock_uuid,
+            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
         ):
             mock_gt.StaticFilesManager.return_value = mock_mgr
             mock_uuid.uuid4.return_value = "test-uuid"
@@ -388,9 +400,13 @@ class TestProcess:
             outputs={"result": str(out_file)},
         )
 
+        mock_file = MagicMock()
+        mock_file.read_bytes.return_value = b"\x89PNG"
+
         with (
             patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
+            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
             instance = MockProvider.return_value

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,144 @@
+"""Unit tests for nuke_runner/runner.py — nuke module mocked out."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock the nuke module before any import of runner
+sys.modules.setdefault("nuke", MagicMock())
+
+_nuke: Any = sys.modules["nuke"]
+
+
+def _run_main(manifest: dict, tmp_path: Path) -> dict:
+    """Write manifest to disk, call main(), return parsed output manifest."""
+    manifest_path = tmp_path / "manifest.json"
+    output_path = tmp_path / "output.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    from nuke_runner.runner import main
+
+    with patch("sys.argv", ["runner.py", "--manifest", str(manifest_path), "--output-manifest", str(output_path)]):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+    assert exc_info.value.code == 0, f"runner exited non-zero: {output_path.read_text()}"
+    return json.loads(output_path.read_text())
+
+
+def _base_manifest(outputs: dict | None = None) -> dict:
+    return {
+        "schema": "griptape-nuke-runner/1.0",
+        "script": "/fake/comp.nk",
+        "frame_range": [1001, 1001],
+        "inputs": {},
+        "outputs": outputs or {},
+        "knob_overrides": [],
+        "env": {},
+        "bake_output_path": "",
+    }
+
+
+class TestExecuteTypes:
+    def test_contains_video_url_artifact(self) -> None:
+        from nuke_runner.runner import _EXECUTE_TYPES
+
+        assert "VideoUrlArtifact" in _EXECUTE_TYPES
+
+    def test_contains_image_sequence_artifact(self) -> None:
+        from nuke_runner.runner import _EXECUTE_TYPES
+
+        assert "ImageSequenceArtifact" in _EXECUTE_TYPES
+
+    def test_contains_image_artifact(self) -> None:
+        from nuke_runner.runner import _EXECUTE_TYPES
+
+        assert "ImageArtifact" in _EXECUTE_TYPES
+
+
+class TestVideoUrlArtifactOutput:
+    def test_writes_string_path_for_video(self, tmp_path: Path) -> None:
+        out_file = tmp_path / "render.mp4"
+        out_file.write_bytes(b"")
+
+        manifest = _base_manifest(
+            outputs={"clip": {"path": str(out_file), "node": "Write1", "type": "VideoUrlArtifact"}}
+        )
+
+        _nuke.scriptOpen = MagicMock()
+        _nuke.root.return_value = MagicMock()
+        _nuke.root.return_value.__getitem__ = MagicMock(return_value=MagicMock())
+        _nuke.toNode.return_value = MagicMock()
+        _nuke.execute = MagicMock()
+
+        result = _run_main(manifest, tmp_path)
+        assert result["outputs"]["clip"] == str(out_file).replace("\\", "/")
+
+
+class TestNonExecutableArtifactSkipped:
+    def test_unknown_type_not_in_outputs(self, tmp_path: Path) -> None:
+        manifest = _base_manifest(
+            outputs={"cam": {"path": "/tmp/cam.json", "node": "Camera1", "type": "CameraMatrixArtifact"}}
+        )
+
+        _nuke.scriptOpen = MagicMock()
+        _nuke.root.return_value = MagicMock()
+        _nuke.root.return_value.__getitem__ = MagicMock(return_value=MagicMock())
+        _nuke.toNode = MagicMock()
+        _nuke.execute = MagicMock()
+
+        result = _run_main(manifest, tmp_path)
+        assert "cam" not in result["outputs"]
+        _nuke.execute.assert_not_called()
+
+
+class TestImageSequenceArtifactOutput:
+    def test_globs_rendered_frames_and_writes_list(self, tmp_path: Path) -> None:
+        seq_dir = tmp_path / "seq"
+        seq_dir.mkdir()
+        pattern = str(seq_dir / "frame.%04d.png")
+
+        # Create fake rendered frame files
+        (seq_dir / "frame.1001.png").write_bytes(b"\x89PNG")
+        (seq_dir / "frame.1002.png").write_bytes(b"\x89PNG")
+
+        manifest = _base_manifest(
+            outputs={"frames": {"path": pattern, "node": "Write1", "type": "ImageSequenceArtifact"}}
+        )
+
+        _nuke.scriptOpen = MagicMock()
+        _nuke.root.return_value = MagicMock()
+        _nuke.root.return_value.__getitem__ = MagicMock(return_value=MagicMock())
+        _nuke.toNode.return_value = MagicMock()
+        _nuke.execute = MagicMock()
+
+        result = _run_main(manifest, tmp_path)
+        frames = result["outputs"]["frames"]
+        assert isinstance(frames, list)
+        assert len(frames) == 2
+        assert all("frame." in p for p in frames)
+
+    def test_empty_glob_writes_empty_list(self, tmp_path: Path) -> None:
+        seq_dir = tmp_path / "emptyseq"
+        seq_dir.mkdir()
+        pattern = str(seq_dir / "frame.%04d.png")
+
+        manifest = _base_manifest(
+            outputs={"frames": {"path": pattern, "node": "Write1", "type": "ImageSequenceArtifact"}}
+        )
+
+        _nuke.scriptOpen = MagicMock()
+        _nuke.root.return_value = MagicMock()
+        _nuke.root.return_value.__getitem__ = MagicMock(return_value=MagicMock())
+        _nuke.toNode.return_value = MagicMock()
+        _nuke.execute = MagicMock()
+
+        result = _run_main(manifest, tmp_path)
+        frames = result["outputs"]["frames"]
+        assert isinstance(frames, list)
+        assert frames == []


### PR DESCRIPTION
# Overview
Add support for `VideoUrlArtifacts` for Nuke `Read`/`Write` nodes and support the ability for the NukeScriptNode to present ImageUrlArtifacts as a list (to support rendering to frames).

# Summary
- VideoUrlArtifact inputs — all annotated Read node input ports now accept VideoUrlArtifact in addition to str,
ImageArtifact, ImageUrlArtifact, and BlobArtifact. URL-based video artifacts are downloaded to a temp file (.mp4) before the
render.
- VideoUrlArtifact outputs — Write nodes annotated as VideoUrlArtifact render and return a VideoUrlArtifact via the static
files manager.
- ImageSequenceArtifact outputs — Write nodes annotated as ImageSequenceArtifact render a numbered frame sequence into a temp
 directory (frame.%04d.png). After execution, the runner globs the rendered frames and returns them as a ListArtifact of
ImageUrlArtifact values — one per frame.
- Manifest — ManifestOutput.path is now str | list[str] to carry the frame path list for sequences through the runner → node
boundary.

Fixes griptape-ai/griptape-nodes-library-nuke#54