### PR TITLE
Register libraries in published env bootstrap

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -19,8 +18,12 @@ from griptape_nodes.common.project_templates.validation import (
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.flow_events import GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.os_events import (
+    CopyFileRequest,
+    CopyFileResultSuccess,
     ReadFileRequest,
     ReadFileResultSuccess,
+    RenameFileRequest,
+    RenameFileResultSuccess,
     WriteFileRequest,
     WriteFileResultSuccess,
 )
@@ -98,12 +101,25 @@ class NukeGizmoPublisher:
             src_workflow = companion_base / workflow_file_path.name
             dest_workflow = version_dir / workflow_file_path.name
             if src_workflow.exists():
-                shutil.move(str(src_workflow), str(dest_workflow))
+                self._move_file(src_workflow, dest_workflow)
 
             # Copy the runner and button scripts (shared, overwrite on each publish)
             self._packager.emit_progress(5.0, "Writing runner script...")
-            shutil.copy2(Path(__file__).parent / "nuke_workflow_runner.py", companion_base / "run_workflow.py")
-            shutil.copy2(Path(__file__).parent / "run_button.py", companion_base / "run_button.py")
+            self._copy_file(
+                Path(__file__).parent / "nuke_workflow_runner.py",
+                companion_base / "run_workflow.py",
+                overwrite=True,
+            )
+            self._copy_file(
+                Path(__file__).parent / "run_button.py",
+                companion_base / "run_button.py",
+                overwrite=True,
+            )
+            self._copy_file(
+                Path(__file__).parent / "register_libraries_script.py",
+                companion_base / "register_libraries_script.py",
+                overwrite=True,
+            )
 
             available_versions = self._collect_versions(companion_base)
 
@@ -141,6 +157,38 @@ class NukeGizmoPublisher:
         except Exception as e:
             logger.exception("Failed to publish workflow '%s'", self._workflow_name)
             return PublishWorkflowResultFailure(result_details=f"Failed to publish workflow: {e}")
+
+    # -- File copy helpers --
+
+    @classmethod
+    def _copy_file(cls, source_path: str | Path, destination_path: str | Path, *, overwrite: bool = False) -> None:
+        """Copies a file from source to destination using OS events for cross-platform compatibility."""
+        copy_file_result = GriptapeNodes.handle_request(
+            CopyFileRequest(
+                source_path=str(source_path),
+                destination_path=str(destination_path),
+                overwrite=overwrite,
+            )
+        )
+        if not isinstance(copy_file_result, CopyFileResultSuccess):
+            details = f"Failed to copy file from '{source_path}' to '{destination_path}'."
+            logger.error(details)
+            raise TypeError(details)
+
+    @classmethod
+    def _move_file(cls, source_path: str | Path, destination_path: str | Path) -> None:
+        """Moves a file from source to destination using OS events for cross-platform compatibility."""
+        rename_result = GriptapeNodes.handle_request(
+            RenameFileRequest(
+                old_path=str(source_path),
+                new_path=str(destination_path),
+                workspace_only=False,
+            )
+        )
+        if not isinstance(rename_result, RenameFileResultSuccess):
+            details = f"Failed to move file from '{source_path}' to '{destination_path}'."
+            logger.error(details)
+            raise TypeError(details)
 
     # -- Project template customisation --
 

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -208,6 +208,19 @@ def main() -> None:
     # Bootstrap environment before loading workflow (needs .env for API keys etc.)
     _bootstrap_environment(nk_script_dir=args.nk_script_dir)
 
+    # Eagerly register the bundled libraries before the workflow module loads.
+    # The workflow uses name-based RegisterLibraryFromFileRequest, which only
+    # succeeds if the library is already known to the engine — and the
+    # libraries_to_register entries in griptape_nodes_config.json are not
+    # always picked up on a fresh user machine.
+    try:
+        from register_libraries_script import register_bundled_libraries
+
+        register_bundled_libraries()
+    except Exception as e:
+        print(json.dumps({"error": f"Failed to register bundled libraries: {e}"}))
+        sys.exit(1)
+
     # Download HuggingFace models if a download script was bundled at publish time.
     # If a local HuggingFace cache already exists on this machine, point the subprocess
     # at it via HF_HUB_CACHE so that cached models are reused instead of re-downloaded.

--- a/publish_gizmo/register_libraries_script.py
+++ b/publish_gizmo/register_libraries_script.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+logger = logging.getLogger("griptape_nodes")
+
+
+def register_bundled_libraries() -> None:
+    """Register every library JSON listed in the companion's griptape_nodes_config.json.
+
+    Paths in the config are stored relative to the companion bundle so the bundle stays
+    portable; resolve them against this script's directory.
+    """
+    bundle_dir = Path(__file__).parent
+    config_path = bundle_dir / "griptape_nodes_config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    relative_paths = config["app_events"]["on_app_initialization_complete"]["libraries_to_register"]
+
+    for rel in relative_paths:
+        library_path = (bundle_dir / rel).resolve()
+        logger.info("Registering library from %s", library_path)
+        result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_path)))
+        if result.failed():
+            msg = f"Failed to register library: {library_path}"
+            raise ValueError(msg)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    register_bundled_libraries()


### PR DESCRIPTION
## Summary

- Fix #56 by eagerly registering the bundled libraries before the gizmo's workflow loads. The published workflow uses name-based `RegisterLibraryFromFileRequest`, which only succeeds if the library is already known to the engine — and the relative paths in the bundle's `griptape_nodes_config.json` are not always picked up on a fresh user machine, so the runner failed with `Library 'Nuke Nodes Library' not found` before the workflow ran.
- New `publish_gizmo/register_libraries_script.py` reads the companion's `griptape_nodes_config.json`, resolves each `libraries_to_register` entry against the bundle directory, and registers it via `RegisterLibraryFromFileRequest(file_path=...)`.
- `nuke_workflow_runner.py` imports and calls `register_bundled_libraries()` after env bootstrap and before the workflow module loads.
- `nuke_gizmo_publisher.py` copies the new script into the companion at publish time.
- Refactored the publisher to route file copies/moves through the engine's `CopyFileRequest` / `RenameFileRequest` events (mirroring the Griptape Cloud library's `_copy_file` pattern) for cross-platform safety. Also fixes a latent bug where `CopyFileRequest`'s `overwrite=False` default would have failed re-publishes — the runner/button/register-script copies now pass `overwrite=True`, matching the prior `shutil.copy2` semantics.

Closes #56

## Test plan

- [ ] Publish a gizmo from the Griptape canvas.
- [ ] Trigger the gizmo in Nuke on a machine where the Nuke library is **not** already in the user's `griptape_nodes_config.json` and confirm the workflow runs end-to-end (previously failed with `Library 'Nuke Nodes Library' not found`).
- [ ] Re-publish the same gizmo and confirm the runner/button/register-script files are overwritten without error.
- [ ] Verify on Windows (where `RenameFileRequest` / `CopyFileRequest` cross-platform handling matters most).
