### PR TITLE
fix: sentinel-frame runner output to survive rich/ANSI stdout pollution

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -121,9 +121,7 @@ class NukeGizmoPublisher:
                 overwrite=True,
             )
             self._copy_file(
-                Path(__file__).parent / "output_protocol.py", 
-                companion_base / "output_protocol.py",
-                overwrite=True
+                Path(__file__).parent / "output_protocol.py", companion_base / "output_protocol.py", overwrite=True
             )
 
             available_versions = self._collect_versions(companion_base)

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -42,11 +42,16 @@ if _companion_dir not in sys.path:
     sys.path.insert(0, _companion_dir)
 
 try:
+    from output_protocol import OUTPUT_SENTINEL_BEGIN
     from output_protocol import extract_payload as _extract_runner_output
+
+    _SENTINEL = OUTPUT_SENTINEL_BEGIN
 except ImportError:
     # Fallback for older companion bundles that pre-date output_protocol.py.
     def _extract_runner_output(stdout_text: str) -> dict:  # type: ignore[misc]
         return json.loads(stdout_text.strip())
+
+    _SENTINEL = ""
 
 
 # Qt is bundled with Nuke. Try PySide6 first (Nuke 16+), fall back to PySide2 (Nuke 13–15).
@@ -536,6 +541,10 @@ else:
                 def _read_stdout():
                     for line in iter(p.stdout.readline, ""):
                         stdout_lines.append(line)
+                        if _SENTINEL and _SENTINEL in line:
+                            continue
+                        with _log_lock:
+                            _pending_log_lines.append(line)
 
                 def _read_stderr():
                     for line in iter(p.stderr.readline, ""):

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -29,9 +29,17 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
 import tempfile
 import threading
 import time
+
+# run_button.py is exec'd (not imported) by the gizmo bootstrap, so __file__'s
+# directory is not added to sys.path automatically. Insert it so that
+# output_protocol (a sibling in the companion bundle) can be imported.
+_companion_dir = os.path.dirname(os.path.abspath(__file__))
+if _companion_dir not in sys.path:
+    sys.path.insert(0, _companion_dir)
 
 try:
     from output_protocol import extract_payload as _extract_runner_output


### PR DESCRIPTION
## Summary
closes #51 
- **Root cause**: Griptape's `RichHandler` writes formatted log output to stdout, polluting the buffer that `run_button.py` was parsing with `json.loads()` — causing "Expecting ',' delimiter" errors.
- **Fix**: Introduces `publish_gizmo/output_protocol.py` with `emit_payload` / `extract_payload` using `<<<GTN_OUTPUT_BEGIN>>>` / `<<<GTN_OUTPUT_END>>>` sentinel markers so the JSON payload can be extracted regardless of surrounding log noise.
- **Bonus**: Tees runner stdout (minus the payload line) to the progress dialog so per-node `INFO Running…/Done` logs are now visible to the user.

## What changed

| File | Change |
|---|---|
| `publish_gizmo/output_protocol.py` | New — sentinel protocol shared by runner and run_button |
| `publish_gizmo/nuke_workflow_runner.py` | All `print(json.dumps(...))` → `emit_payload(...)` |
| `publish_gizmo/run_button.py` | Uses `extract_payload`; adds `sys.path` fix so the import works when exec'd; tees stdout to dialog |
| `publish_gizmo/nuke_gizmo_publisher.py` | Copies `output_protocol.py` into companion bundle at publish time |
| `pyproject.toml` | `extraPaths` so pyright resolves `publish_gizmo/` imports from tests |
| `tests/unit/test_output_protocol.py` | 11 unit tests for emit/extract, ANSI pollution, backwards compat |
| `tests/unit/test_workflow_runner_output.py` | 4 integration-style unit tests for the runner output contract |

## Test plan

- [ ] `make check` passes (format + lint + types)
- [ ] `uv run pytest tests/unit/` — 132 tests pass
- [ ] Re-publish a gizmo from Griptape and run it in Nuke — no "Expecting ',' delimiter" error
- [ ] Progress dialog shows per-node log lines during execution
- [ ] Outputs populate gizmo knobs correctly after run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)