### PR TITLE
fix: specify encoding="utf-8" on /proc/self/mountinfo read

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -482,7 +482,7 @@ if _QT_AVAILABLE:
                 norm = os.path.normpath(path)
                 best_mp = ''
                 best_fs = ''
-                with open('/proc/self/mountinfo') as _f:
+                with open('/proc/self/mountinfo', encoding='utf-8') as _f:
                     for _line in _f:
                         _parts = _line.split()
                         # Field 4 is the mount point; field after ' - ' is fs type.


### PR DESCRIPTION
## Summary

- Fixes #66 — sibling fix to engine PR griptape-ai/griptape-nodes-engine#4750 (issue griptape-ai/griptape-nodes-engine#4709)
- Adds `encoding="utf-8"` to the `/proc/self/mountinfo` read in `publish_gizmo/nuke_gizmo_publisher.py:485`
- Practical risk is low (Linux-only, mountinfo is ASCII), but matching the engine fix keeps the codebase consistent

## Files changed

- `publish_gizmo/nuke_gizmo_publisher.py:485` — `open('/proc/self/mountinfo') as _f` → `open('/proc/self/mountinfo', encoding='utf-8') as _f`

## Test plan

- [ ] Lint/format clean
- [ ] No-op on macOS/Linux (already UTF-8 by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)