### PR TITLE
fix: stop wiping the shared Nodes > Griptape menu on refresh

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -366,6 +366,10 @@ class NukeGizmoPublisher:
         ``nuke.plugins()`` to discover ALL versioned ``.gizmo`` files at call time,
         calls ``nuke.load()`` on each to force Nuke to re-read the TCL from disk,
         and rebuilds the Griptape node-creation entries on the Nodes toolbar.
+        The refresh tracks the menu items it adds (module-level list in the
+        generated code) and removes only those on each rescan, so the
+        Nodes > Griptape menu can be shared with other plugins (e.g. Nuke's
+        built-in Griptape workflow node).
 
         "Refresh Griptape Gizmos" lives on the main Nuke menu bar (not the Nodes
         toolbar) so that clicking it never triggers Nuke's node-placement mode.
@@ -394,12 +398,20 @@ _GRIPTAPE_DIR = os.path.dirname(__file__)
 # Module-level reference keeps the watcher alive (Python GC would drop a local).
 _GRIPTAPE_WATCHER = None
 
+# Labels of items THIS script added to Nodes > Griptape. The menu is shared --
+# other plugins (e.g. Nuke's built-in Griptape workflow node) may add items --
+# so a refresh must only remove entries we created, never the whole menu.
+_GRIPTAPE_MENU_ITEMS = []
+
 
 def _refresh_griptape_menu():
     \"\"\"Rescan the griptape directory and rebuild the Griptape node-creation menu.
 
     Call this after publishing a new or updated gizmo to make it available
     without restarting Nuke.
+
+    Only entries added by this script are removed and re-added; items other
+    plugins placed in the Griptape menu are left untouched.
     \"\"\"
     # Remove then re-add the path to force Nuke to re-walk the directory.
     # pluginAddPath is idempotent on an already-registered path; the remove
@@ -429,14 +441,22 @@ def _refresh_griptape_menu():
     for stem in workflows:
         workflows[stem].sort()
 
-    # Rebuild the Griptape submenu on the Nodes toolbar.
-    # Remove the existing entry first so repeated calls don't accumulate duplicates.
+    # Get-or-create the Griptape submenu on the Nodes toolbar. addMenu()
+    # returns the existing menu when one with this name already exists, so
+    # items added by other plugins (e.g. Nuke's built-in Griptape workflow
+    # node) are preserved. Never remove the menu itself.
     nodes_toolbar = nuke.menu('Nodes')
-    try:
-        nodes_toolbar.removeItem('Griptape')
-    except Exception:
-        pass
     griptape_nodes = nodes_toolbar.addMenu('Griptape')
+
+    # Remove only the entries added by a previous refresh so repeated calls
+    # don't accumulate duplicates and deleted gizmos disappear from the menu.
+    global _GRIPTAPE_MENU_ITEMS
+    for _item_name in _GRIPTAPE_MENU_ITEMS:
+        try:
+            griptape_nodes.removeItem(_item_name)
+        except Exception:
+            pass
+    _GRIPTAPE_MENU_ITEMS = []
 
     for stem in sorted(workflows):
         label = stem.replace('_', ' ').title()
@@ -450,6 +470,7 @@ def _refresh_griptape_menu():
             workflow_submenu = griptape_nodes.addMenu(label)
             for ver, node_name in versions:
                 workflow_submenu.addCommand('v{}'.format(ver), "nuke.createNode('{}')".format(node_name))
+        _GRIPTAPE_MENU_ITEMS.append(label)
 
 
 # "Refresh Griptape Gizmos" lives on the main Nuke menu bar so that clicking

--- a/tests/unit/test_nuke_gizmo_publisher_menu.py
+++ b/tests/unit/test_nuke_gizmo_publisher_menu.py
@@ -65,6 +65,32 @@ def test_menu_code_skips_watcher_when_qt_unavailable() -> None:
     assert guard_idx < watcher_idx
 
 
+def test_menu_code_never_removes_entire_griptape_menu() -> None:
+    """Wiping Nodes > Griptape deletes third-party items (e.g. Nuke's built-in
+    Griptape workflow node) — refresh must only touch entries it added (issue #69)."""
+    code = _extract_menu_code()
+    assert "nodes_toolbar.removeItem('Griptape')" not in code
+    assert 'nodes_toolbar.removeItem("Griptape")' not in code
+
+
+def test_menu_code_tracks_and_removes_only_own_menu_items() -> None:
+    """Refresh must record added labels and remove only tracked items before re-populating."""
+    code = _extract_menu_code()
+    assert "_GRIPTAPE_MENU_ITEMS = []" in code
+    assert "griptape_nodes.removeItem(" in code
+    assert "_GRIPTAPE_MENU_ITEMS.append(" in code
+    # Tracked-item removal must precede re-population.
+    assert code.index("griptape_nodes.removeItem(") < code.index("griptape_nodes.addCommand(")
+
+
+def test_menu_code_reuses_existing_griptape_menu() -> None:
+    """addMenu returns the existing menu when present — get-or-create, never recreate."""
+    code = _extract_menu_code()
+    assert "nodes_toolbar.addMenu('Griptape')" in code
+    # addMenu (get-or-create) must come before any removeItem on the submenu.
+    assert code.index("nodes_toolbar.addMenu('Griptape')") < code.index("griptape_nodes.removeItem(")
+
+
 def test_menu_code_warns_on_remote_mount() -> None:
     """Must include remote-mount heuristic and print warning inside the Qt guard block.
 


### PR DESCRIPTION
Fixes #69

## Problem

The auto-generated `~/.nuke/griptape/menu.py` removed the **entire** `Nodes > Griptape` menu and rebuilt it from scratch in `_refresh_griptape_menu()`:

```python
nodes_toolbar.removeItem('Griptape')
griptape_nodes = nodes_toolbar.addMenu('Griptape')
```

This runs at Nuke startup, on every `QFileSystemWatcher.directoryChanged` event, and via the manual "Refresh Griptape Gizmos" command — so any items other plugins placed in that menu (e.g. Nuke's upcoming built-in Griptape workflow node) were destroyed.

## Fix

The approach suggested in the issue: the generated `menu.py` now keeps a module-level `_GRIPTAPE_MENU_ITEMS` list of the labels it added, and on each refresh:

1. Gets-or-creates the Griptape submenu via `addMenu()` (returns the existing menu when present — the standard Nuke shared-menu pattern; the menu itself is never removed).
2. Removes **only** the tracked entries from the previous refresh, then clears the list.
3. Re-populates from the fresh disk scan, recording each added label.

This preserves all prior behavior: deleted gizmos still vanish from the menu (every tracked item is removed before re-adding), repeated refreshes don't accumulate duplicates, and multi-version submenus are rebuilt fresh each time (tracked by their label; `removeItem(label)` removes the whole submenu).

The "Refresh Griptape Gizmos" command on the main menu bar is also covered — no code path removes any `Griptape` menu anymore.

## Rollout note

`menu.py` is regenerated on each gizmo publish, so existing installs pick up the fix on the user's next publish.

## Testing

- 3 new AST-based unit tests asserting the destructive pattern is gone, the tracking list exists with removal-before-population ordering, and get-or-create `addMenu` precedes the targeted removal. All 159 unit tests pass; `make check` clean.
- Verified the generated `menu.py` string compiles.
- Live-verified in Nuke: simulated a third-party item (`nuke.menu('Nodes').addMenu('Griptape').addCommand('FakeFoundryItem', ...)`) both from the Script Editor and from a startup `~/.nuke/menu.py` (registering before our plugin menu.py runs, matching Foundry's startup order). The item survived manual refreshes, the file-watcher refresh on a fresh gizmo publish, and a full Nuke restart, alongside all gizmo entries (including multi-version submenus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)