### PR TITLE
Drop storage_backend param from execute_workflow call

### DIFF
--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -256,7 +256,6 @@ def main() -> None:
     try:
         output = module.execute_workflow(
             input=flow_input,
-            storage_backend=args.storage_backend,
             project_file_path=str(project_file) if project_file.exists() else None,
         )
     except Exception as e:


### PR DESCRIPTION
## Summary

Fixes #70. Stops the bundled gizmo runner from forwarding `storage_backend` into the generated workflow's `execute_workflow()` call.

The generated `aexecute_workflow` re-splats its `**kwargs` into both the `LocalWorkflowExecutor` constructor and `executor.arun()`. In the griptape-nodes-engine, `arun → aprepare_workflow_for_run` rejects `storage_backend` as deprecated, so the call raised immediately and the workflow never ran ("Workflow execution failed"). The gizmo button never sets a non-local backend anyway, so dropping the kwarg lets the framework default to `local`.

## Note

This unblocks existing and newly-published workflows against the already-shipped engine, but the real fix belongs in the engine: a valid `execute_workflow(**kwargs)` call should not turn into an error. Tracked in griptape-ai/griptape-nodes-engine#4828.
