### PR TITLE
fix: use copy+delete instead of rename when publishing over existing workflow version

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -97,11 +97,14 @@ class NukeGizmoPublisher:
             # so outputs land next to the .nk file, not inside the companion bundle.
             self._customize_project_yml(companion_base)
 
-            # Move the workflow file from companion base into the version subdir
+            # Move the workflow file from companion base into the version subdir.
+            # Use copy+delete instead of rename so re-publishing over an existing
+            # version (where dest already exists) succeeds without error.
             src_workflow = companion_base / workflow_file_path.name
             dest_workflow = version_dir / workflow_file_path.name
             if src_workflow.exists():
-                self._move_file(src_workflow, dest_workflow)
+                self._copy_file(src_workflow, dest_workflow, overwrite=True)
+                src_workflow.unlink()
 
             # Copy the runner and button scripts (shared, overwrite on each publish)
             self._packager.emit_progress(5.0, "Writing runner script...")


### PR DESCRIPTION
## Summary

- Fixes `TypeError` when re-publishing a workflow that already has a published version
- `RenameFileRequest` fails when the destination file already exists; replaced with `_copy_file(overwrite=True)` followed by `Path.unlink()` on the source, which handles both first-publish and re-publish cases correctly

Closes #74

## Test plan

- [ ] Publish a workflow for the first time — confirm it succeeds and creates `v1/<workflow>.py`
- [ ] Publish the same workflow again (current version) — confirm it overwrites without error
- [ ] Publish as a new version — confirm a new `v2/` directory is created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)