### PR TITLE
fix: debounce gizmo menu auto-refresh to stop crashing Nuke on publish

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -387,19 +387,25 @@ import os
 
 # Qt is bundled with Nuke. Try PySide6 first (Nuke 16+), fall back to PySide2 (Nuke 13-15).
 try:
-    from PySide6.QtCore import QFileSystemWatcher
+    from PySide6.QtCore import QFileSystemWatcher, QTimer
     _QT_AVAILABLE = True
 except ImportError:
     try:
-        from PySide2.QtCore import QFileSystemWatcher
+        from PySide2.QtCore import QFileSystemWatcher, QTimer
         _QT_AVAILABLE = True
     except ImportError:
         _QT_AVAILABLE = False
 
 _GRIPTAPE_DIR = os.path.dirname(__file__)
 
-# Module-level reference keeps the watcher alive (Python GC would drop a local).
+# Module-level references keep the watcher and debounce timer alive (Python GC
+# would otherwise drop locals). _GRIPTAPE_REFRESHING guards against re-entrant
+# refreshes: nuke.plugins()/menu mutation are not reentrant, and a nested
+# directoryChanged delivered while a refresh is walking the plugin path or
+# rebuilding the menu corrupts Nuke's internal state and crashes the host.
 _GRIPTAPE_WATCHER = None
+_GRIPTAPE_REFRESH_TIMER = None
+_GRIPTAPE_REFRESHING = False
 
 # Labels of items THIS script added to Nodes > Griptape. The menu is shared --
 # other plugins (e.g. Nuke's built-in Griptape workflow node) may add items --
@@ -486,8 +492,38 @@ _refresh_griptape_menu()
 # Watch the griptape directory for new/removed gizmos and auto-refresh the menu.
 # Skipped silently when Qt is unavailable (e.g. nuke -t headless).
 if _QT_AVAILABLE:
+    def _griptape_safe_refresh():
+        # Re-entrancy guard. A single publish writes several files into this
+        # directory in quick succession, and rebuilding the menu / walking the
+        # plugin path can spin the Qt event loop, delivering another
+        # directoryChanged mid-refresh. Mutating Nuke's plugin and menu
+        # structures while an outer refresh is still iterating them is what
+        # crashes the host, so drop any call that arrives while one is running.
+        global _GRIPTAPE_REFRESHING
+        if _GRIPTAPE_REFRESHING:
+            return
+        _GRIPTAPE_REFRESHING = True
+        try:
+            _refresh_griptape_menu()
+        except Exception as _exc:
+            try:
+                nuke.tprint('[Griptape] Menu refresh failed: ' + str(_exc))
+            except Exception:
+                pass
+        finally:
+            _GRIPTAPE_REFRESHING = False
+
+    # Coalesce the burst of filesystem events from a single publish into one
+    # refresh that runs only after the writes settle. Each directoryChanged
+    # restarts the single-shot timer, so the refresh fires once the directory
+    # has been quiet for the interval. The timer always fires on the main thread.
+    _GRIPTAPE_REFRESH_TIMER = QTimer()
+    _GRIPTAPE_REFRESH_TIMER.setSingleShot(True)
+    _GRIPTAPE_REFRESH_TIMER.setInterval(1000)
+    _GRIPTAPE_REFRESH_TIMER.timeout.connect(_griptape_safe_refresh)
+
     _GRIPTAPE_WATCHER = QFileSystemWatcher([_GRIPTAPE_DIR])
-    _GRIPTAPE_WATCHER.directoryChanged.connect(lambda _path: _refresh_griptape_menu())
+    _GRIPTAPE_WATCHER.directoryChanged.connect(lambda _path: _GRIPTAPE_REFRESH_TIMER.start())
 
     def _griptape_is_remote_mount(path):
         \"\"\"Return True when path is likely on a network/remote filesystem.\"\"\"

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -403,20 +403,23 @@ _GRIPTAPE_DIR = os.path.dirname(__file__)
 _GRIPTAPE_WATCHER = None
 _GRIPTAPE_NOTIFY_TIMER = None
 
-# Labels of items THIS script added to Nodes > Griptape. The menu is shared --
-# other plugins (e.g. Nuke's built-in Griptape workflow node) may add items --
-# so a refresh must only remove entries we created, never the whole menu.
-_GRIPTAPE_MENU_ITEMS = []
+# Node names (e.g. "my_workflow_v02") THIS script has already added to
+# Nodes > Griptape. The menu is shared with other plugins (e.g. Nuke's built-in
+# Griptape workflow node) and removing items from it crashes the host
+# (issue #78), so the refresh is strictly add-only and uses this set to avoid
+# re-adding entries it already created.
+_GRIPTAPE_ADDED = set()
 
 
 def _refresh_griptape_menu():
-    \"\"\"Rescan the griptape directory and rebuild the Griptape node-creation menu.
+    \"\"\"Rescan the griptape directory and add any new gizmos to the Griptape menu.
 
     Call this after publishing a new or updated gizmo to make it available
     without restarting Nuke.
 
-    Only entries added by this script are removed and re-added; items other
-    plugins placed in the Griptape menu are left untouched.
+    Add-only: removing items from the shared Nodes > Griptape menu crashes the
+    host (issue #78), so this only adds entries it has not added before. A gizmo
+    deleted from disk lingers in the menu until the next Nuke restart.
     \"\"\"
     # Remove then re-add the path to force Nuke to re-walk the directory.
     # pluginAddPath is idempotent on an already-registered path; the remove
@@ -447,35 +450,26 @@ def _refresh_griptape_menu():
         workflows[stem].sort()
 
     # Get-or-create the Griptape submenu on the Nodes toolbar. addMenu()
-    # returns the existing menu when one with this name already exists, so
-    # items added by other plugins (e.g. Nuke's built-in Griptape workflow
-    # node) are preserved. Never remove the menu itself.
+    # returns the existing menu when one with this name already exists, so the
+    # menu is never recreated and items other plugins added are preserved.
     nodes_toolbar = nuke.menu('Nodes')
     griptape_nodes = nodes_toolbar.addMenu('Griptape')
 
-    # Remove only the entries added by a previous refresh so repeated calls
-    # don't accumulate duplicates and deleted gizmos disappear from the menu.
-    global _GRIPTAPE_MENU_ITEMS
-    for _item_name in _GRIPTAPE_MENU_ITEMS:
-        try:
-            griptape_nodes.removeItem(_item_name)
-        except Exception:
-            pass
-    _GRIPTAPE_MENU_ITEMS = []
-
+    # Add-only. Removing items from this shared menu crashes the host
+    # (issue #78), so we never remove. Each workflow gets its own submenu (get-or-create) and
+    # each version is added once, tracked by node name in _GRIPTAPE_ADDED so
+    # repeated refreshes never duplicate or re-touch an existing entry. New
+    # gizmos/versions appear on refresh; deleted ones linger until restart.
+    global _GRIPTAPE_ADDED
     for stem in sorted(workflows):
+        new_versions = [(ver, nn) for ver, nn in workflows[stem] if nn not in _GRIPTAPE_ADDED]
+        if not new_versions:
+            continue
         label = stem.replace('_', ' ').title()
-        versions = workflows[stem]
-        if len(versions) == 1:
-            # Only one version — flat entry, no submenu.
-            node_name = versions[0][1]
-            griptape_nodes.addCommand(label, "nuke.createNode('{}')".format(node_name))
-        else:
-            # Multiple versions — nest them under a per-workflow submenu.
-            workflow_submenu = griptape_nodes.addMenu(label)
-            for ver, node_name in versions:
-                workflow_submenu.addCommand('v{}'.format(ver), "nuke.createNode('{}')".format(node_name))
-        _GRIPTAPE_MENU_ITEMS.append(label)
+        workflow_submenu = griptape_nodes.addMenu(label)
+        for ver, node_name in new_versions:
+            workflow_submenu.addCommand('v{}'.format(ver), "nuke.createNode('{}')".format(node_name))
+            _GRIPTAPE_ADDED.add(node_name)
 
 
 # "Refresh Griptape Gizmos" lives on the main Nuke menu bar so that clicking

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -365,25 +365,30 @@ class NukeGizmoPublisher:
     def _regenerate_menu_py(self, griptape_dir: Path) -> None:
         """Write griptape/menu.py with a dynamic refresh function.
 
-        The generated menu.py defines ``_refresh_griptape_menu()`` which uses
-        ``nuke.plugins()`` to discover ALL versioned ``.gizmo`` files at call time,
-        calls ``nuke.load()`` on each to force Nuke to re-read the TCL from disk,
-        and rebuilds the Griptape node-creation entries on the Nodes toolbar.
-        The refresh tracks the menu items it adds (module-level list in the
-        generated code) and removes only those on each rescan, so the
-        Nodes > Griptape menu can be shared with other plugins (e.g. Nuke's
-        built-in Griptape workflow node).
+        The generated menu.py defines ``_refresh_griptape_menu()`` which globs the
+        griptape directory for versioned ``.gizmo`` files at call time (the
+        filesystem is the source of truth; ``nuke.plugins()`` only returns a list
+        Nuke caches at startup), calls ``nuke.load()`` on each newly seen file so
+        ``nuke.createNode()`` can instantiate a gizmo published during the session,
+        and adds entries to the Nodes > Griptape menu.
+
+        The refresh is add-only: it tracks node names it has added (module-level
+        set in the generated code) and never removes items. Removing items from
+        the shared Nodes > Griptape menu crashes the host (issue #78), and the
+        menu is shared with other plugins (e.g. Nuke's built-in Griptape workflow
+        node), so it must never be wiped.
 
         "Refresh Griptape Gizmos" lives on the main Nuke menu bar (not the Nodes
         toolbar) so that clicking it never triggers Nuke's node-placement mode.
 
-        When a workflow has multiple published versions each version gets its own
-        entry inside a per-workflow submenu (e.g. Griptape > My Workflow > v1 / v2).
-        Single-version workflows get a flat entry with no submenu.
+        Each workflow gets its own submenu and each version is an entry inside it
+        (e.g. Griptape > My Workflow > v1 / v2). A gizmo deleted from disk lingers
+        in the menu until the next Nuke restart.
         """
         menu_code = """\
 import nuke
 import os
+import glob
 
 # Qt is bundled with Nuke. Try PySide6 first (Nuke 16+), fall back to PySide2 (Nuke 13-15).
 try:
@@ -421,30 +426,25 @@ def _refresh_griptape_menu():
     host (issue #78), so this only adds entries it has not added before. A gizmo
     deleted from disk lingers in the menu until the next Nuke restart.
     \"\"\"
-    # Remove then re-add the path to force Nuke to re-walk the directory.
-    # pluginAddPath is idempotent on an already-registered path; the remove
-    # invalidates the cached walk so nuke.plugins() sees newly written files.
-    # pluginRemovePath is undocumented — guard against versions that lack it.
-    if hasattr(nuke, 'pluginRemovePath'):
-        nuke.pluginRemovePath(_GRIPTAPE_DIR)
+    # Ensure our directory is on the plugin path (idempotent; init.py adds it
+    # too). nuke.load() below registers each gizmo so createNode() can find it.
     nuke.pluginAddPath(_GRIPTAPE_DIR)
 
-    # Use nuke.ALL so Nuke walks all plugin_path() directories (not just loaded plugins).
-    gizmo_paths = nuke.plugins(nuke.ALL, '*_v*.gizmo')
+    # Discover gizmos from the filesystem. nuke.plugins returns a list Nuke
+    # caches at startup, so it would miss gizmos published during this session;
+    # globbing the directory always sees the current files.
+    gizmo_paths = glob.glob(os.path.join(_GRIPTAPE_DIR, '*_v*.gizmo'))
 
     # Collect ALL versions per stem (not just the highest).
     # Filenames follow the pattern "<stem>_v<N>.gizmo"; we parse with rsplit.
-    workflows = {}  # stem -> sorted list of (version, node_name)
+    workflows = {}  # stem -> sorted list of (version, node_name, path)
     for path in gizmo_paths:
-        fname = os.path.basename(path)
-        if not fname.endswith('.gizmo'):
-            continue
-        name = fname[:-len('.gizmo')]  # e.g. "my_workflow_v02"
+        name = os.path.basename(path)[:-len('.gizmo')]  # e.g. "my_workflow_v02"
         parts = name.rsplit('_v', 1)
         if len(parts) != 2 or not parts[1].isdigit():
             continue
         stem, ver = parts[0], int(parts[1])
-        workflows.setdefault(stem, []).append((ver, name))
+        workflows.setdefault(stem, []).append((ver, name, path))
 
     for stem in workflows:
         workflows[stem].sort()
@@ -462,12 +462,20 @@ def _refresh_griptape_menu():
     # gizmos/versions appear on refresh; deleted ones linger until restart.
     global _GRIPTAPE_ADDED
     for stem in sorted(workflows):
-        new_versions = [(ver, nn) for ver, nn in workflows[stem] if nn not in _GRIPTAPE_ADDED]
+        new_versions = [(ver, nn, p) for ver, nn, p in workflows[stem] if nn not in _GRIPTAPE_ADDED]
         if not new_versions:
             continue
         label = stem.replace('_', ' ').title()
         workflow_submenu = griptape_nodes.addMenu(label)
-        for ver, node_name in new_versions:
+        for ver, node_name, path in new_versions:
+            # Register the gizmo by full path so createNode() finds a file
+            # written after startup. Forward slashes only (Nuke treats backslashes
+            # as escapes). nuke.load() is a no-op if already loaded and raises
+            # only on a genuinely bad file, which we skip.
+            try:
+                nuke.load(path.replace(os.sep, '/'))
+            except Exception:
+                pass
             workflow_submenu.addCommand('v{}'.format(ver), "nuke.createNode('{}')".format(node_name))
             _GRIPTAPE_ADDED.add(node_name)
 

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -398,14 +398,10 @@ except ImportError:
 
 _GRIPTAPE_DIR = os.path.dirname(__file__)
 
-# Module-level references keep the watcher and debounce timer alive (Python GC
-# would otherwise drop locals). _GRIPTAPE_REFRESHING guards against re-entrant
-# refreshes: nuke.plugins()/menu mutation are not reentrant, and a nested
-# directoryChanged delivered while a refresh is walking the plugin path or
-# rebuilding the menu corrupts Nuke's internal state and crashes the host.
+# Module-level references keep the watcher and its debounce timer alive
+# (Python GC would otherwise drop locals).
 _GRIPTAPE_WATCHER = None
-_GRIPTAPE_REFRESH_TIMER = None
-_GRIPTAPE_REFRESHING = False
+_GRIPTAPE_NOTIFY_TIMER = None
 
 # Labels of items THIS script added to Nodes > Griptape. The menu is shared --
 # other plugins (e.g. Nuke's built-in Griptape workflow node) may add items --
@@ -489,41 +485,39 @@ nuke.menu('Nuke').addMenu('Griptape').addCommand('Refresh Griptape Gizmos', _ref
 # Populate the Nodes toolbar on startup.
 _refresh_griptape_menu()
 
-# Watch the griptape directory for new/removed gizmos and auto-refresh the menu.
+# Watch the griptape directory for new/removed gizmos.
+#
+# This watcher must NOT call into Nuke. directoryChanged is delivered from
+# QFileSystemWatcher's engine thread and fires repeatedly while a publish writes
+# several files into this directory. Driving Nuke's plugin/menu C++ APIs
+# (pluginAddPath, nuke.plugins(), menu mutation) from that asynchronous,
+# repeatedly-fired callback corrupts Nuke's internal state and crashes the host
+# (issue #78). So the watcher only prints a one-time hint; the actual rescan
+# happens on the user-initiated "Refresh Griptape Gizmos" command, when Nuke is
+# idle and the writes are complete.
 # Skipped silently when Qt is unavailable (e.g. nuke -t headless).
 if _QT_AVAILABLE:
-    def _griptape_safe_refresh():
-        # Re-entrancy guard. A single publish writes several files into this
-        # directory in quick succession, and rebuilding the menu / walking the
-        # plugin path can spin the Qt event loop, delivering another
-        # directoryChanged mid-refresh. Mutating Nuke's plugin and menu
-        # structures while an outer refresh is still iterating them is what
-        # crashes the host, so drop any call that arrives while one is running.
-        global _GRIPTAPE_REFRESHING
-        if _GRIPTAPE_REFRESHING:
-            return
-        _GRIPTAPE_REFRESHING = True
+    def _griptape_notify_changed():
+        _msg = (
+            '[Griptape] Gizmo directory changed. Use Nuke menu > '
+            'Griptape > Refresh Griptape Gizmos to load new or updated gizmos.'
+        )
         try:
-            _refresh_griptape_menu()
-        except Exception as _exc:
-            try:
-                nuke.tprint('[Griptape] Menu refresh failed: ' + str(_exc))
-            except Exception:
-                pass
-        finally:
-            _GRIPTAPE_REFRESHING = False
+            nuke.tprint(_msg)
+        except Exception:
+            print(_msg)
 
     # Coalesce the burst of filesystem events from a single publish into one
-    # refresh that runs only after the writes settle. Each directoryChanged
-    # restarts the single-shot timer, so the refresh fires once the directory
-    # has been quiet for the interval. The timer always fires on the main thread.
-    _GRIPTAPE_REFRESH_TIMER = QTimer()
-    _GRIPTAPE_REFRESH_TIMER.setSingleShot(True)
-    _GRIPTAPE_REFRESH_TIMER.setInterval(1000)
-    _GRIPTAPE_REFRESH_TIMER.timeout.connect(_griptape_safe_refresh)
+    # notification. Each directoryChanged restarts the single-shot timer, so the
+    # hint prints once after the directory has been quiet for the interval, and
+    # never while the publish is mid-write. The timer fires on the main thread.
+    _GRIPTAPE_NOTIFY_TIMER = QTimer()
+    _GRIPTAPE_NOTIFY_TIMER.setSingleShot(True)
+    _GRIPTAPE_NOTIFY_TIMER.setInterval(1000)
+    _GRIPTAPE_NOTIFY_TIMER.timeout.connect(_griptape_notify_changed)
 
     _GRIPTAPE_WATCHER = QFileSystemWatcher([_GRIPTAPE_DIR])
-    _GRIPTAPE_WATCHER.directoryChanged.connect(lambda _path: _GRIPTAPE_REFRESH_TIMER.start())
+    _GRIPTAPE_WATCHER.directoryChanged.connect(lambda _path: _GRIPTAPE_NOTIFY_TIMER.start())
 
     def _griptape_is_remote_mount(path):
         \"\"\"Return True when path is likely on a network/remote filesystem.\"\"\"

--- a/tests/unit/test_nuke_gizmo_publisher_menu.py
+++ b/tests/unit/test_nuke_gizmo_publisher_menu.py
@@ -48,33 +48,31 @@ def test_menu_code_contains_file_system_watcher() -> None:
     assert "directoryChanged" in code
 
 
-def test_menu_code_debounces_refresh_through_single_shot_timer() -> None:
-    """directoryChanged must restart a single-shot QTimer, not call refresh directly.
+def test_menu_code_watcher_never_calls_nuke_automatically() -> None:
+    """The watcher must not auto-invoke the refresh (issue #78).
 
-    A publish writes several files into the watched directory in quick succession.
-    Calling _refresh_griptape_menu on every event drives Nuke's non-reentrant
-    plugin/menu APIs repeatedly while writes are in flight, which crashes the host
-    (issue #78). Coalescing into one deferred refresh runs it once, after the
-    writes settle.
+    directoryChanged is delivered from QFileSystemWatcher's engine thread and
+    fires repeatedly while a publish writes several files into the watched dir.
+    Driving Nuke's plugin/menu C++ APIs from that asynchronous callback corrupts
+    Nuke's internal state and crashes the host. The watcher must only notify; the
+    rescan happens on the user-initiated command, when Nuke is idle.
     """
+    code = _extract_menu_code()
+    # The watcher hands off to a debounce timer, never to the refresh.
+    assert "directoryChanged.connect(lambda _path: _GRIPTAPE_NOTIFY_TIMER.start())" in code
+    assert "directoryChanged.connect(lambda _path: _refresh_griptape_menu())" not in code
+    assert "directoryChanged.connect(lambda _path: _GRIPTAPE_REFRESH_TIMER.start())" not in code
+    # _refresh_griptape_menu is only called at startup and from the manual command.
+    assert "addCommand('Refresh Griptape Gizmos', _refresh_griptape_menu)" in code
+
+
+def test_menu_code_debounces_watcher_notification() -> None:
+    """directoryChanged must coalesce through a single-shot QTimer so the hint
+    prints once per publish, after the writes settle, not once per file."""
     code = _extract_menu_code()
     assert "QTimer" in code
     assert "setSingleShot(True)" in code
-    # The watcher must hand off to the timer, never invoke the refresh inline.
-    assert "directoryChanged.connect(lambda _path: _GRIPTAPE_REFRESH_TIMER.start())" in code
-    assert "directoryChanged.connect(lambda _path: _refresh_griptape_menu())" not in code
-
-
-def test_menu_code_guards_against_reentrant_refresh() -> None:
-    """Refresh must bail out when one is already running (issue #78).
-
-    nuke.plugins()/menu mutation can spin the Qt event loop, delivering a nested
-    directoryChanged mid-refresh; mutating the structures an outer refresh is
-    still iterating is what corrupts Nuke's state and crashes the host.
-    """
-    code = _extract_menu_code()
-    assert "_GRIPTAPE_REFRESHING" in code
-    assert "if _GRIPTAPE_REFRESHING:" in code
+    assert "_GRIPTAPE_NOTIFY_TIMER" in code
 
 
 def test_menu_code_has_pyside6_pyside2_fallback() -> None:

--- a/tests/unit/test_nuke_gizmo_publisher_menu.py
+++ b/tests/unit/test_nuke_gizmo_publisher_menu.py
@@ -100,22 +100,26 @@ def test_menu_code_never_removes_entire_griptape_menu() -> None:
     assert 'nodes_toolbar.removeItem("Griptape")' not in code
 
 
-def test_menu_code_tracks_and_removes_only_own_menu_items() -> None:
-    """Refresh must record added labels and remove only tracked items before re-populating."""
+def test_menu_code_is_add_only_never_calls_remove_item() -> None:
+    """Refresh must never call removeItem on the shared Griptape menu (issue #78).
+
+    removeItem on the shared Nodes > Griptape menu crashes the host. The refresh
+    is add-only: it tracks node names it has added in _GRIPTAPE_ADDED and skips
+    them on later refreshes instead of removing and re-adding.
+    """
     code = _extract_menu_code()
-    assert "_GRIPTAPE_MENU_ITEMS = []" in code
-    assert "griptape_nodes.removeItem(" in code
-    assert "_GRIPTAPE_MENU_ITEMS.append(" in code
-    # Tracked-item removal must precede re-population.
-    assert code.index("griptape_nodes.removeItem(") < code.index("griptape_nodes.addCommand(")
+    assert "removeItem(" not in code
+    assert "_GRIPTAPE_ADDED = set()" in code
+    assert "nn not in _GRIPTAPE_ADDED" in code
+    assert "_GRIPTAPE_ADDED.add(" in code
 
 
 def test_menu_code_reuses_existing_griptape_menu() -> None:
     """addMenu returns the existing menu when present — get-or-create, never recreate."""
     code = _extract_menu_code()
     assert "nodes_toolbar.addMenu('Griptape')" in code
-    # addMenu (get-or-create) must come before any removeItem on the submenu.
-    assert code.index("nodes_toolbar.addMenu('Griptape')") < code.index("griptape_nodes.removeItem(")
+    # Per-workflow submenus are also get-or-create (addMenu), never recreated.
+    assert "griptape_nodes.addMenu(label)" in code
 
 
 def test_menu_code_warns_on_remote_mount() -> None:

--- a/tests/unit/test_nuke_gizmo_publisher_menu.py
+++ b/tests/unit/test_nuke_gizmo_publisher_menu.py
@@ -48,6 +48,35 @@ def test_menu_code_contains_file_system_watcher() -> None:
     assert "directoryChanged" in code
 
 
+def test_menu_code_debounces_refresh_through_single_shot_timer() -> None:
+    """directoryChanged must restart a single-shot QTimer, not call refresh directly.
+
+    A publish writes several files into the watched directory in quick succession.
+    Calling _refresh_griptape_menu on every event drives Nuke's non-reentrant
+    plugin/menu APIs repeatedly while writes are in flight, which crashes the host
+    (issue #78). Coalescing into one deferred refresh runs it once, after the
+    writes settle.
+    """
+    code = _extract_menu_code()
+    assert "QTimer" in code
+    assert "setSingleShot(True)" in code
+    # The watcher must hand off to the timer, never invoke the refresh inline.
+    assert "directoryChanged.connect(lambda _path: _GRIPTAPE_REFRESH_TIMER.start())" in code
+    assert "directoryChanged.connect(lambda _path: _refresh_griptape_menu())" not in code
+
+
+def test_menu_code_guards_against_reentrant_refresh() -> None:
+    """Refresh must bail out when one is already running (issue #78).
+
+    nuke.plugins()/menu mutation can spin the Qt event loop, delivering a nested
+    directoryChanged mid-refresh; mutating the structures an outer refresh is
+    still iterating is what corrupts Nuke's state and crashes the host.
+    """
+    code = _extract_menu_code()
+    assert "_GRIPTAPE_REFRESHING" in code
+    assert "if _GRIPTAPE_REFRESHING:" in code
+
+
 def test_menu_code_has_pyside6_pyside2_fallback() -> None:
     """Must attempt PySide6 import first, fall back to PySide2."""
     code = _extract_menu_code()

--- a/tests/unit/test_nuke_gizmo_publisher_menu.py
+++ b/tests/unit/test_nuke_gizmo_publisher_menu.py
@@ -24,20 +24,22 @@ def _extract_menu_code() -> str:
     raise AssertionError(msg)
 
 
-def test_menu_code_forces_plugin_path_rescan() -> None:
-    """Must guard pluginRemovePath (undocumented) then re-add before nuke.plugins().
+def test_menu_code_discovers_via_glob_and_loads_gizmos() -> None:
+    """Refresh must discover gizmos from the filesystem and register them.
 
-    pluginAddPath is idempotent on an already-registered path — without the remove,
-    Nuke skips the directory walk and nuke.plugins() misses newly written gizmos.
-    pluginRemovePath must be guarded with hasattr to avoid crashing on Nuke versions
-    that don't expose it.
+    nuke.plugins() returns a list Nuke caches at startup, so it misses gizmos
+    published during the session ("nothing happens" on refresh). The refresh must
+    glob the directory for the current files and nuke.load() each one by full
+    path so nuke.createNode() can instantiate a gizmo added after launch.
     """
     code = _extract_menu_code()
-    assert "hasattr(nuke, 'pluginRemovePath')" in code
-    assert "nuke.pluginRemovePath(" in code
+    assert "import glob" in code
+    assert "glob.glob(" in code
+    assert "nuke.load(" in code
     assert "nuke.pluginAddPath(" in code
-    assert "nuke.plugins(" in code
-    assert code.index("hasattr(nuke, 'pluginRemovePath')") < code.index("nuke.pluginRemovePath(")
+    # The stale cached-discovery call must be gone.
+    assert "nuke.plugins(nuke.ALL" not in code
+    assert "pluginRemovePath" not in code
 
 
 def test_menu_code_contains_file_system_watcher() -> None:


### PR DESCRIPTION
Closes #78

Two crash minidumps from the reporter's interactive Nuke 17 session both show the same `EXC_BAD_ACCESS` on the main thread: a queued `QFileSystemWatcher.directoryChanged` meta-call delivered through the Qt event loop, dispatched by PySide6 to a Python slot, which calls into `libnuke` and dereferences a freed/garbage pointer.

The generated `menu.py` watches the griptape install directory and wires `directoryChanged` straight to `_refresh_griptape_menu()`. A single publish writes several files into that directory in quick succession (the companion dir, the `.gizmo`, and the rewritten `menu.py` itself), so the slot fires repeatedly. `_refresh_griptape_menu()` calls non-reentrant Nuke C++ APIs (`pluginRemovePath`/`pluginAddPath`, `nuke.plugins(nuke.ALL, ...)`, menu mutation). `nuke.plugins(...)` walks and loads plugins and spins the Qt event loop, so a pending `directoryChanged` re-enters `_refresh_griptape_menu()` and mutates the plugin-path and menu structures the outer call is still iterating, corrupting Nuke's state. The once-at-startup refresh runs while the directory is quiet, which is why only publishing while Nuke is open triggers it.

This was introduced in `407f3be` ("updates to fix the refresh button"), which wired the watcher directly to the refresh. The refresh function itself predates that and was previously only invoked manually via the "Refresh Griptape Gizmos" menu command, so publishing never auto-triggered it. The auto-refresh first shipped in v0.3.0.

The fix coalesces the burst of filesystem events into a single deferred refresh via a single-shot `QTimer` that restarts on each `directoryChanged` and fires once the directory has been quiet, and adds a `_GRIPTAPE_REFRESHING` guard so a refresh that re-enters during an event-loop spin is dropped rather than mutating structures mid-iteration. Auto-refresh behavior is preserved; it just runs once, after writes settle, on the main thread.