### PR TITLE
fix: migrate NukeScriptNode scratch files to project file situation API

### DIFF
--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import atexit
-import contextlib
 import json
 import logging
 import os
@@ -10,6 +9,7 @@ import shutil
 import subprocess
 import tempfile
 import urllib.request
+import uuid
 from typing import Any
 
 from griptape_nodes.common.macro_parser import ParsedMacro
@@ -20,6 +20,7 @@ from griptape_nodes.exe_types.param_types.parameter_button import ParameterButto
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
 from griptape_nodes.files.project_file import ProjectFileDestination
+from griptape_nodes.retained_mode.events.os_events import DeleteFileRequest, WriteFileRequest, WriteFileResultSuccess
 from griptape_nodes.retained_mode.events.project_events import GetPathForMacroRequest, GetPathForMacroResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -612,7 +613,13 @@ class NukeScriptNode(SuccessFailureNode):
     # Artifact / path resolution
     # ------------------------------------------------------------------
 
-    def _artifact_to_path(self, value: Any) -> str:
+    def _artifact_to_path(
+        self,
+        value: Any,
+        name: str = "input",
+        _cleanup: list[str] | None = None,
+        situation: str = "save_temp_file",
+    ) -> str:
         """Resolve a parameter value to a local file path Nuke can read."""
         if isinstance(value, str):
             return value
@@ -627,16 +634,17 @@ class NukeScriptNode(SuccessFailureNode):
             if val.startswith(("http://", "https://")):
                 detected = os.path.splitext(val.split("?")[0])[-1]
                 suffix = detected or (".mp4" if isinstance(value, _video_type) else ".png")
-                tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
-                try:
-                    with urllib.request.urlopen(val, timeout=30) as response:  # noqa: S310
-                        tmp.write(response.read())
-                    tmp.close()
-                except Exception:
-                    tmp.close()
-                    os.unlink(tmp.name)
-                    raise
-                return tmp.name
+                _id = uuid.uuid4().hex[:8]
+                # Download the remote asset into a project-managed file so Nuke can read it
+                # by local path. UUID prefix avoids collisions when multiple nodes run in
+                # parallel. final_file_path (not resolve()) is used because the framework may
+                # rename the file under CREATE_NEW collision policy.
+                dest = ProjectFileDestination.from_situation(f"{self.name}_{name}_{_id}{suffix}", situation)
+                with urllib.request.urlopen(val, timeout=30) as response:  # noqa: S310
+                    tmp_path = self._write_scratch_file(str(dest.resolve()), response.read())
+                if _cleanup is not None:
+                    _cleanup.append(tmp_path)
+                return tmp_path
             if "{" in val:
                 try:
                     macro = ParsedMacro(val)
@@ -648,11 +656,26 @@ class NukeScriptNode(SuccessFailureNode):
                         return str(result.absolute_path)
             return val
         if isinstance(val, bytes):
-            tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
-            tmp.write(val)
-            tmp.close()
-            return tmp.name
+            _id = uuid.uuid4().hex[:8]
+            # Materialise raw bytes (e.g. BlobArtifact image data) to a file Nuke can open.
+            # Same UUID + situation strategy as the URL branch above.
+            dest = ProjectFileDestination.from_situation(f"{self.name}_{name}_{_id}.png", situation)
+            tmp_path = self._write_scratch_file(str(dest.resolve()), val)
+            if _cleanup is not None:
+                _cleanup.append(tmp_path)
+            return tmp_path
         return str(value)
+
+    def _write_scratch_file(self, path: str, content: bytes) -> str:
+        """Write content and return the canonical path actually written.
+
+        The framework may rename the file (e.g. foo_1.png) under a CREATE_NEW collision
+        policy, so callers must use final_file_path rather than the path they passed in.
+        """
+        result = GriptapeNodes.handle_request(WriteFileRequest(file_path=path, content=content))
+        if not isinstance(result, WriteFileResultSuccess):
+            raise RuntimeError(f"Failed to write scratch file: {path}")
+        return result.final_file_path
 
     def _build_env(self, installation: NukeInstallation | None) -> dict[str, str]:
         """Merge global env settings, installation overrides, and foundry_LICENSE from os.environ."""
@@ -733,8 +756,10 @@ class NukeScriptNode(SuccessFailureNode):
             if ann.role == "input":
                 raw = self.get_parameter_value(ann.gt_name) or ""
                 if raw:
+                    # Paths are baked as absolute references into the .nk copy, so they must
+                    # outlive this call. Persist them as node outputs, not temp files.
                     inputs[ann.gt_name] = ManifestInput(
-                        path=self._artifact_to_path(raw),
+                        path=self._artifact_to_path(raw, name=ann.gt_name, situation="save_node_output"),
                         node=ann.node_name,
                     )
 
@@ -789,44 +814,65 @@ class NukeScriptNode(SuccessFailureNode):
 
         inputs: dict[str, ManifestInput] = {}
         outputs: dict[str, ManifestOutput] = {}
+        input_tmp_paths: list[str] = []
         output_tmp_paths: list[str] = []
         output_tmp_dirs: list[str] = []
-
-        for ann in self._annotations:
-            if ann.role == "input":
-                inputs[ann.gt_name] = ManifestInput(
-                    path=self._artifact_to_path(self.get_parameter_value(ann.gt_name) or ""),
-                    node=ann.node_name,
-                )
-            elif ann.gt_type == "ImageSequenceArtifact":
-                tmpdir = tempfile.mkdtemp(prefix="griptape_nuke_seq_")
-                output_tmp_dirs.append(tmpdir)
-                seq_path = os.path.join(tmpdir, "frame.%04d.png").replace("\\", "/")
-                outputs[ann.gt_name] = ManifestOutput(
-                    path=seq_path,
-                    node=ann.node_name,
-                    type="ImageSequenceArtifact",
-                )
-            else:
-                suffix = _TEMP_SUFFIX.get(ann.gt_type or "", ".png")
-                tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
-                tmp.close()
-                output_tmp_paths.append(tmp.name)
-                outputs[ann.gt_name] = ManifestOutput(
-                    path=tmp.name,
-                    node=ann.node_name,
-                    type=ann.gt_type or "ImageArtifact",
-                )
-
-        knob_overrides: list[KnobOverride] = []
-        for ek in self._expose_knobs:
-            raw = self.get_parameter_value(ek.param_name)
-            if raw not in (None, ""):
-                knob_overrides.append(
-                    KnobOverride(node=ek.target_node, knob=ek.target_knob, value=_coerce_knob_value(raw))
-                )
+        _run_id = uuid.uuid4().hex[:8]
 
         try:
+            for ann in self._annotations:
+                if ann.role == "input":
+                    inputs[ann.gt_name] = ManifestInput(
+                        path=self._artifact_to_path(
+                            self.get_parameter_value(ann.gt_name) or "",
+                            name=ann.gt_name,
+                            _cleanup=input_tmp_paths,
+                        ),
+                        node=ann.node_name,
+                    )
+                elif ann.gt_type == "ImageSequenceArtifact":
+                    seq_dest = ProjectFileDestination.from_situation(
+                        f"{self.name}_{_run_id}_{ann.gt_name}_frame.png", "save_temp_file"
+                    )
+                    # Nuke requires the output directory to exist before it starts writing
+                    # frames. WriteFileRequest has no mkdir equivalent, so we force creation
+                    # by writing a sentinel .empty file. seq_dir is derived from final_file_path
+                    # (not resolve()) in case the framework renamed the directory under
+                    # CREATE_NEW collision policy.
+                    _empty_path = self._write_scratch_file(str(pathlib.Path(seq_dest.resolve()).parent / ".empty"), b"")
+                    seq_dir = str(pathlib.Path(_empty_path).parent)
+                    seq_path = f"{seq_dir}/{ann.gt_name}_frame.%04d.png".replace("\\", "/")
+                    output_tmp_dirs.append(seq_dir)
+                    outputs[ann.gt_name] = ManifestOutput(
+                        path=seq_path,
+                        node=ann.node_name,
+                        type="ImageSequenceArtifact",
+                    )
+                else:
+                    suffix = _TEMP_SUFFIX.get(ann.gt_type or "", ".png")
+                    placeholder_dest = ProjectFileDestination.from_situation(
+                        f"{self.name}_{_run_id}_{ann.gt_name}{suffix}", "save_temp_file"
+                    )
+                    # Pre-create the output file so Nuke has a known path to write into.
+                    # The runner overwrites this placeholder; after the run _path_to_artifact
+                    # reads it and re-saves to save_node_output so downstream nodes get a
+                    # persistent URL. The placeholder is cleaned up in the finally block.
+                    placeholder_path = self._write_scratch_file(str(placeholder_dest.resolve()), b"")
+                    output_tmp_paths.append(placeholder_path)
+                    outputs[ann.gt_name] = ManifestOutput(
+                        path=placeholder_path,
+                        node=ann.node_name,
+                        type=ann.gt_type or "ImageArtifact",
+                    )
+
+            knob_overrides: list[KnobOverride] = []
+            for ek in self._expose_knobs:
+                raw = self.get_parameter_value(ek.param_name)
+                if raw not in (None, ""):
+                    knob_overrides.append(
+                        KnobOverride(node=ek.target_node, knob=ek.target_knob, value=_coerce_knob_value(raw))
+                    )
+
             manifest = JobManifest(
                 script=script_path,
                 inputs=inputs,
@@ -855,9 +901,7 @@ class NukeScriptNode(SuccessFailureNode):
 
             self._set_status_results(was_successful=True, result_details="Render complete.")
         finally:
-            for p in output_tmp_paths:
-                with contextlib.suppress(OSError):
-                    os.unlink(p)
+            for p in input_tmp_paths + output_tmp_paths:
+                GriptapeNodes.handle_request(DeleteFileRequest(path=p, workspace_only=False))
             for d in output_tmp_dirs:
-                with contextlib.suppress(OSError):
-                    shutil.rmtree(d)
+                GriptapeNodes.handle_request(DeleteFileRequest(path=d, workspace_only=False))

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -7,6 +7,12 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from griptape_nodes.retained_mode.events.os_events import (
+    DeleteFileRequest,
+    WriteFileRequest,
+    WriteFileResultFailure,
+    WriteFileResultSuccess,
+)
 
 from nuke_nodes.nuke_script_node import _coerce_knob_value, _path_to_artifact
 
@@ -18,11 +24,14 @@ FIXTURES = Path(__file__).parent / "fixtures"
 # ---------------------------------------------------------------------------
 
 
-def _mock_project_file_destination(location: str = "http://static/file") -> MagicMock:
+def _mock_project_file_destination(
+    location: str = "http://static/file", resolved_path: str = "/fake/temp/placeholder.png"
+) -> MagicMock:
     mock_saved = MagicMock()
     mock_saved.location = location
     mock_dest_instance = MagicMock()
     mock_dest_instance.write_bytes.return_value = mock_saved
+    mock_dest_instance.resolve.return_value = resolved_path
     mock_dest_cls = MagicMock()
     mock_dest_cls.from_situation.return_value = mock_dest_instance
     return mock_dest_cls
@@ -110,8 +119,16 @@ class TestPathToArtifact:
         assert isinstance(result, ImageUrlArtifact)
 
 
+def _mock_artifact_to_path_dest(resolved_path: str = "/fake/temp/input.mp4") -> MagicMock:
+    dest = MagicMock()
+    dest.resolve.return_value = resolved_path
+    mock_cls = MagicMock()
+    mock_cls.from_situation.return_value = dest
+    return mock_cls
+
+
 class TestArtifactToPath:
-    def test_video_url_artifact_http_downloads_to_mp4_temp(self, tmp_path: Path) -> None:
+    def test_video_url_artifact_http_downloads_to_project_temp(self) -> None:
         node = _make_node()
 
         try:
@@ -126,13 +143,103 @@ class TestArtifactToPath:
         fake_response.__exit__ = MagicMock(return_value=False)
         fake_response.read.return_value = b"\x00" * 8
 
-        with patch("nuke_nodes.nuke_script_node.urllib.request.urlopen", return_value=fake_response) as mock_open:
-            result = node._artifact_to_path(artifact)
+        mock_dest_cls = _mock_artifact_to_path_dest("/fake/temp/input_resolve.mp4")
+        canonical_path = "/fake/temp/input_canonical.mp4"
+
+        with (
+            patch("nuke_nodes.nuke_script_node.urllib.request.urlopen", return_value=fake_response) as mock_open,
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gtn,
+        ):
+            write_result = MagicMock(spec=WriteFileResultSuccess)
+            write_result.final_file_path = canonical_path
+            mock_gtn.handle_request.return_value = write_result
+            result = node._artifact_to_path(artifact, name="my_input")
 
         mock_open.assert_called_once()
-        assert result.endswith(".mp4")
-        # Clean up temp file
-        Path(result).unlink(missing_ok=True)
+        assert result == canonical_path
+        call_args = mock_dest_cls.from_situation.call_args
+        filename, situation = call_args[0]
+        assert situation == "save_temp_file"
+        assert "NukeScriptNode1" in filename
+        assert "my_input" in filename
+        assert filename.endswith(".mp4")
+
+    def test_video_url_artifact_http_appends_to_cleanup_list(self) -> None:
+        node = _make_node()
+
+        try:
+            from griptape.artifacts import VideoUrlArtifact
+
+            artifact = VideoUrlArtifact(value="http://example.com/clip.mp4")
+        except ImportError:
+            pytest.skip("griptape not installed")
+
+        fake_response = MagicMock()
+        fake_response.__enter__ = MagicMock(return_value=fake_response)
+        fake_response.__exit__ = MagicMock(return_value=False)
+        fake_response.read.return_value = b"\x00" * 8
+
+        cleanup: list[str] = []
+        mock_dest_cls = _mock_artifact_to_path_dest("/fake/temp/input_resolve.mp4")
+        canonical_path = "/fake/temp/input_canonical.mp4"
+
+        with (
+            patch("nuke_nodes.nuke_script_node.urllib.request.urlopen", return_value=fake_response),
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gtn,
+        ):
+            write_result = MagicMock(spec=WriteFileResultSuccess)
+            write_result.final_file_path = canonical_path
+            mock_gtn.handle_request.return_value = write_result
+            node._artifact_to_path(artifact, name="my_input", _cleanup=cleanup)
+
+        assert cleanup == [canonical_path]
+
+    def test_bytes_artifact_writes_to_project_temp_file(self) -> None:
+        node = _make_node()
+
+        class FakeArtifact:
+            value = b"\x89PNG\x00"
+
+        mock_dest_cls = _mock_artifact_to_path_dest("/fake/temp/input_resolve.png")
+        canonical_path = "/fake/temp/input_canonical.png"
+        cleanup: list[str] = []
+
+        with (
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gtn,
+        ):
+            write_result = MagicMock(spec=WriteFileResultSuccess)
+            write_result.final_file_path = canonical_path
+            mock_gtn.handle_request.return_value = write_result
+            result = node._artifact_to_path(FakeArtifact(), name="img_in", _cleanup=cleanup)
+
+        assert result == canonical_path
+        call_args = mock_dest_cls.from_situation.call_args
+        filename, situation = call_args[0]
+        assert situation == "save_temp_file"
+        assert "NukeScriptNode1" in filename
+        assert "img_in" in filename
+        assert filename.endswith(".png")
+        assert cleanup == [canonical_path]
+
+    def test_bytes_artifact_raises_on_write_failure(self) -> None:
+        node = _make_node()
+
+        class FakeArtifact:
+            value = b"\x89PNG\x00"
+
+        mock_dest_cls = _mock_artifact_to_path_dest("/fake/temp/input.png")
+        mock_failure = MagicMock(spec=WriteFileResultFailure)
+
+        with (
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as mock_gtn,
+        ):
+            mock_gtn.handle_request.return_value = mock_failure
+            with pytest.raises(RuntimeError, match="scratch file"):
+                node._artifact_to_path(FakeArtifact(), name="img_in")
 
     def test_video_url_artifact_local_path_returned_unchanged(self) -> None:
         node = _make_node()
@@ -410,6 +517,9 @@ class TestProcess:
             patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            write_result = MagicMock(spec=WriteFileResultSuccess)
+            write_result.final_file_path = "/fake/temp/placeholder.png"
+            MockGT.handle_request.return_value = write_result
             instance = MockProvider.return_value
             instance.submit.return_value = "handle-123"
             instance.result.return_value = fake_result
@@ -451,6 +561,7 @@ class TestProcess:
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            MockGT.handle_request.return_value = MagicMock(spec=WriteFileResultSuccess)
             instance = MockProvider.return_value
             instance.submit.return_value = "handle-456"
             instance.result.return_value = fake_result
@@ -501,11 +612,14 @@ class TestProcess:
         saved1, saved2 = MagicMock(), MagicMock()
         saved1.location = "http://s/f1.png"
         saved2.location = "http://s/f2.png"
+        # seq_dest: used by process() to resolve the sequence directory
+        seq_dest = MagicMock()
+        seq_dest.resolve.return_value = "/fake/temp/frames_frame.png"
         dest1, dest2 = MagicMock(), MagicMock()
         dest1.write_bytes.return_value = saved1
         dest2.write_bytes.return_value = saved2
         mock_dest_cls = MagicMock()
-        mock_dest_cls.from_situation.side_effect = [dest1, dest2]
+        mock_dest_cls.from_situation.side_effect = [seq_dest, dest1, dest2]
         mock_file = MagicMock()
         mock_file.read_bytes.return_value = b"\x89PNG"
 
@@ -516,6 +630,10 @@ class TestProcess:
             patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            # final_file_path for the .empty sentinel — seq_dir is derived from its parent
+            write_result = MagicMock(spec=WriteFileResultSuccess)
+            write_result.final_file_path = "/fake/temp/.empty"
+            MockGT.handle_request.return_value = write_result
             instance = MockProvider.return_value
             instance.submit.return_value = "handle-seq"
             instance.result.return_value = fake_result
@@ -570,6 +688,7 @@ class TestProcess:
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            MockGT.handle_request.return_value = MagicMock(spec=WriteFileResultSuccess)
             instance = MockProvider.return_value
             instance.submit.return_value = "handle-789"
             instance.result.return_value = fake_result
@@ -581,3 +700,60 @@ class TestProcess:
         assert manifest.knob_overrides[0].node == "Grade1"
         assert manifest.knob_overrides[0].knob == "multiply"
         assert manifest.knob_overrides[0].value == pytest.approx(0.0)
+
+    def test_mid_loop_failure_still_cleans_up_earlier_files(self, tmp_path: Path) -> None:
+        from script_parser.annotation import GriptapeAnnotation
+
+        nk_file = tmp_path / "test.nk"
+        nk_file.write_text("")
+
+        node = _make_node()
+        node._annotations = [
+            GriptapeAnnotation(node_name="Write1", role="output", gt_name="out1", gt_type="ImageArtifact"),
+            GriptapeAnnotation(node_name="Write2", role="output", gt_name="out2", gt_type="ImageArtifact"),
+        ]
+        node._expose_knobs = []
+        node.get_parameter_value = MagicMock(
+            side_effect=lambda name: {
+                "script_path": str(nk_file),
+                "nuke_executable": "/usr/bin/nuke",
+                "frame_start": 1001,
+                "frame_end": 1001,
+            }.get(name)
+        )
+
+        resolve_path_1 = "/fake/temp/out1_resolve.png"
+        canonical_path_1 = "/fake/temp/out1_canonical.png"
+        dest1, dest2 = MagicMock(), MagicMock()
+        dest1.resolve.return_value = resolve_path_1
+        dest2.resolve.return_value = "/fake/temp/out2_resolve.png"
+        mock_dest_cls = MagicMock()
+        mock_dest_cls.from_situation.side_effect = [dest1, dest2]
+
+        write_success = MagicMock(spec=WriteFileResultSuccess)
+        write_success.final_file_path = canonical_path_1
+        write_failure = MagicMock(spec=WriteFileResultFailure)
+
+        call_count = {"n": 0}
+
+        def handle_request_side_effect(request: object) -> object:
+            if isinstance(request, WriteFileRequest):
+                call_count["n"] += 1
+                return write_success if call_count["n"] == 1 else write_failure
+            return MagicMock(spec=WriteFileResultSuccess)
+
+        with (
+            patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
+            patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider"),
+        ):
+            MockGT.ConfigManager.return_value.get_config_value.return_value = None
+            MockGT.handle_request.side_effect = handle_request_side_effect
+
+            with pytest.raises(RuntimeError):
+                node.process()
+
+        delete_calls = [c for c in MockGT.handle_request.call_args_list if isinstance(c.args[0], DeleteFileRequest)]
+        deleted_paths = {c.args[0].path for c in delete_calls}
+        assert canonical_path_1 in deleted_paths
+        assert resolve_path_1 not in deleted_paths


### PR DESCRIPTION
Replaces raw `tempfile` usage in `NukeScriptNode` scratch-file handling with the
Griptape project file lifecycle APIs (`WriteFileRequest` / `DeleteFileRequest` /
`ProjectFileDestination`), so intermediate inputs/outputs are tracked within the
project system rather than landing unmanaged in the OS temp directory.

> **Note:** `tempfile.mkdtemp()` in `_build_open_in_nuke_launch` is intentionally
> out of scope — it creates a process-scoped directory for passing a startup manifest
> to the Nuke GUI subprocess and is cleaned up via `atexit`. It is not a render
> scratch file and does not need project lifecycle tracking.

## Changes

### Project-managed file I/O
- New `_write_scratch_file(path, content)` helper — writes via `WriteFileRequest`
  and returns `final_file_path` (the framework may rename files under a CREATE_NEW
  collision policy, so callers must use this rather than the pre-resolved path).
- New `_SITUATION_TEMP = "save_temp_file"` and `_SITUATION_OUTPUT = "save_node_output"`
  constants for situation keys.
- New `_SCRATCH_INPUT_FILENAME` and `_SCRATCH_OUTPUT_FILENAME` format-string constants
  for scratch filename patterns (address review feedback to avoid hardcoding).
- `DeleteFileRequest` replaces `os.unlink` / `shutil.rmtree` in cleanup. Cleanup
  failures are caught, logged as warnings, and do not surface as execution errors.

### `_artifact_to_path()` refactoring
- Added `name`, `situation`, and `_cleanup` parameters.
- String paths: attempts `File(value).resolve()` (handles both macro strings and
  plain paths); falls back to original string on `FileLoadError`.
- Macro strings (`{outputs}/file.png`): resolved via `GetPathForMacroRequest`.
- Raw bytes and URL downloads: materialised to `save_temp_file` project files
  instead of `tempfile.NamedTemporaryFile`. UUID-prefixed filenames avoid
  collisions when multiple nodes run concurrently.

### `process()` overhaul
- `try/finally` scope expanded to wrap the entire annotation loop so files written
  in earlier iterations are cleaned up even if a later write fails.
- Sequence output: pre-creates a sentinel file to establish the output directory
  (relying on `WriteFileRequest`'s `create_parents=True` default); derives
  `seq_dir` from `final_file_path`.
- Non-sequence output: pre-creates empty placeholder files at `save_temp_file`;
  after the run, outputs are re-saved to `save_node_output` for downstream nodes.

### Config access centralisation
All `ConfigManager().get_config_value(...)` calls replaced by a `_get_config(key)`
helper that uses `GetConfigValueRequest` for consistency with the rest of the
retained-mode API.

### Annotation persistence for For Loop deserialization
`_annotations` and `_expose_knobs` are now serialised to node metadata by
`_refresh_dynamic_ports` and restored in `__init__`. When nodes are deserialised
inside For Loops, `after_value_set` is suppressed, so annotations must survive
via metadata to avoid empty outputs.

### Sidecar staleness fix
Logic corrected from `if not is_stale: load` (silently skipped stale sidecars,
causing empty outputs in For Loops) to: always load, print a warning if stale.

### Tests
- Renamed existing tests to reflect project-file behaviour.
- Added tests for: bytes materialisation, cleanup-list tracking, macro path
  resolution, string fallback, metadata round-trip, mid-loop failure cleanup,
  and cleanup-failure non-propagation.

Resolves #84 
Resolves #64