### PR TITLE
fix: use override=True in load_dotenv so bundled API key wins over Nuke's inherited env

### DIFF
--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -45,10 +45,13 @@ def _bootstrap_environment(nk_script_dir: str | None = None) -> None:
     """
     script_dir = Path(__file__).parent
 
-    # Load .env with python-dotenv (handles quoted values correctly)
+    # Load .env with python-dotenv (handles quoted values correctly).
+    # override=True ensures bundled secrets (e.g. GT_CLOUD_API_KEY) win over
+    # whatever the parent Nuke process happened to inherit from the system
+    # environment, which may be stale or empty.
     env_path = script_dir / ".env"
     if env_path.exists():
-        load_dotenv(env_path)
+        load_dotenv(env_path, override=True)
 
     # When a Nuke script directory is available, use it as the workspace so
     # that relative directory macros in project.yml (like ``outputs``) resolve


### PR DESCRIPTION
## Summary

- `load_dotenv` was called without `override=True`, meaning if the parent Nuke process had already inherited a stale or empty `GT_CLOUD_API_KEY` from the system environment, the bundled `.env` value would be silently ignored.
- Switching to `override=True` ensures the secrets packaged with the gizmo always take effect, regardless of what the parent process inherited.
- No system environment is modified — `os.environ` changes are scoped to the current Python process only.

## Test plan

- [x] Install a gizmo, launch from Nuke with no `GT_CLOUD_API_KEY` set in the shell; confirm workflow runs successfully (API key loaded from `.env`)
- [x] Install a gizmo, launch from Nuke with a stale/wrong `GT_CLOUD_API_KEY` in the shell; confirm the bundled key wins and the workflow runs