### PR TITLE
Fix Nuke Gizmo copy + saving

### DIFF
--- a/publish_gizmo/gizmo_writer.py
+++ b/publish_gizmo/gizmo_writer.py
@@ -213,12 +213,28 @@ class GizmoWriter:
         self._lines.append(f"  ypos {ypos}")
         self._lines.append(" }")
 
-    def add_read_node(self, name: str, xpos: int, ypos: int) -> None:
-        """Add a Read node with an empty file path to the internal graph."""
+    def add_read_node(self, name: str, xpos: int, ypos: int, file_expression: str | None = None) -> None:
+        """Add a Read node to the internal graph.
+
+        Args:
+            name: Nuke node name (e.g. ``GEN_READ_image``).
+            xpos: Horizontal position in the node graph.
+            ypos: Vertical position in the node graph.
+            file_expression: When provided, the Read node's ``file`` knob is set
+                to a live TCL expression ``[value <file_expression>]`` rather than
+                an empty literal.  Use this to link the Read to a persistent
+                top-level user knob so the path survives save/reload and copy-paste.
+                Example: ``"parent.image_out"``.
+        """
         self._lines.append(" Read {")
         self._lines.append("  inputs 0")
         self._lines.append(f"  name {name}")
-        self._lines.append('  file ""')
+        if file_expression is not None:
+            # The leading backslash prevents TCL from evaluating [value …] at
+            # parse time; Nuke stores it as a live expression knob instead.
+            self._lines.append(f'  file "\\[value {file_expression}]"')
+        else:
+            self._lines.append('  file ""')
         self._lines.append(f"  xpos {xpos}")
         self._lines.append(f"  ypos {ypos}")
         self._lines.append(" }")

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -241,7 +241,12 @@ class NukeGizmoBuilder:
             # Write Read nodes in reverse order so that Switch input(0) maps to
             # the first media output (matching the active_output enum index 0).
             for idx, name in enumerate(reversed(media_output_names)):
-                w.add_read_node(_read_node_name(name), xpos=idx * 200, ypos=0)
+                w.add_read_node(
+                    _read_node_name(name),
+                    xpos=idx * 200,
+                    ypos=0,
+                    file_expression=f"parent.{_output_knob_name(name)}",
+                )
             center_x = (len(media_output_names) - 1) * 100
             w.add_switch_node(
                 "SwitchOutput",
@@ -251,7 +256,12 @@ class NukeGizmoBuilder:
             )
             w.add_output_node(_output_node_name(0), xpos=center_x, ypos=200)
         elif media_output_names:
-            w.add_read_node(_read_node_name(media_output_names[0]), xpos=0, ypos=0)
+            w.add_read_node(
+                _read_node_name(media_output_names[0]),
+                xpos=0,
+                ypos=0,
+                file_expression=f"parent.{_output_knob_name(media_output_names[0])}",
+            )
             w.add_output_node(_output_node_name(0), xpos=0, ypos=100)
         else:
             w.add_output_node(_output_node_name(0), xpos=0, ypos=100, no_inputs=True)

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -233,15 +233,15 @@ class NukeGizmoPublisher:
             path_macro="griptape_outputs",
         )
 
-        workflow_name = companion_base.name
         template.situations["save_node_output"] = SituationTemplate(
             name="save_node_output",
             description="Node generates and saves output (Nuke gizmo)",
-            # Drop node_name and version-index suffixes so the artist's chosen
-            # filename is preserved exactly.  {sub_dirs?:/} passes through any
-            # relative subdirectory the artist typed (e.g. "renders/comp.exr"
-            # lands under griptape_outputs/<workflow>/renders/comp.exr).
-            macro=f"{{outputs}}/{workflow_name}/{{sub_dirs?:/}}{{file_name_base}}.{{file_extension}}",
+            # No workflow-name subdirectory: files land directly under {outputs}.
+            # When Output Directory is set at runtime, {outputs} is redirected there,
+            # so files go directly into the artist's chosen directory.
+            # {sub_dirs?:/} passes through any relative subdirectory the artist typed
+            # (e.g. "renders/comp.exr" lands under griptape_outputs/renders/comp.exr).
+            macro="{outputs}/{sub_dirs?:/}{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -241,6 +241,11 @@ class NukeGizmoPublisher:
             # so files go directly into the artist's chosen directory.
             # {sub_dirs?:/} passes through any relative subdirectory the artist typed
             # (e.g. "renders/comp.exr" lands under griptape_outputs/renders/comp.exr).
+            # Note: ":/" is a separator FORMAT (appended to the value), not a default —
+            # when sub_dirs is absent the whole token including its separator is dropped,
+            # so the result is "{outputs}/comp.exr" (single slash, no "//").
+            # sub_dirs carries no trailing slash, so "{sub_dirs?}" alone would yield
+            # "renderscomp.exr".
             macro="{outputs}/{sub_dirs?:/}{file_name_base}.{file_extension}",
             policy=SituationPolicy(
                 on_collision=SituationFilePolicy.OVERWRITE,

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -237,9 +237,13 @@ class NukeGizmoPublisher:
         template.situations["save_node_output"] = SituationTemplate(
             name="save_node_output",
             description="Node generates and saves output (Nuke gizmo)",
-            macro=f"{{outputs}}/{workflow_name}/{{node_name?:_}}{{file_name_base}}_v{{_index?:04}}.{{file_extension}}",
+            # Drop node_name and version-index suffixes so the artist's chosen
+            # filename is preserved exactly.  {sub_dirs?:/} passes through any
+            # relative subdirectory the artist typed (e.g. "renders/comp.exr"
+            # lands under griptape_outputs/<workflow>/renders/comp.exr).
+            macro=f"{{outputs}}/{workflow_name}/{{sub_dirs?:/}}{{file_name_base}}.{{file_extension}}",
             policy=SituationPolicy(
-                on_collision=SituationFilePolicy.CREATE_NEW,
+                on_collision=SituationFilePolicy.OVERWRITE,
                 create_dirs=True,
             ),
             fallback="save_file",

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -26,10 +26,12 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from dotenv import load_dotenv
 from griptape_nodes.common.project_templates import load_project_template_from_yaml
+from griptape_nodes.common.project_templates.directory import DirectoryDefinition
 from griptape_nodes.common.project_templates.validation import ProjectValidationInfo, ProjectValidationStatus
 from output_protocol import emit_payload
 
@@ -254,16 +256,50 @@ def main() -> None:
         sys.exit(1)
 
     script_dir = Path(__file__).parent
-    project_file = script_dir / "project.yml"
+    bundle_project_file = script_dir / "project.yml"
+
+    # When an output directory is specified, build a per-run temp project.yml that
+    # redirects {outputs} to the requested directory.  The bundle's situation macro
+    # and OVERWRITE policy are kept exactly as authored — only the directory changes.
+    # This makes the engine's actual save path agree with the path we report to Nuke.
+    # The bundle file itself is never modified.
+    temp_project_file = None
+    project_file_path: str | None = str(bundle_project_file) if bundle_project_file.exists() else None
+
+    if args.output_dir and bundle_project_file.exists():
+        validation_info = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
+        template = load_project_template_from_yaml(bundle_project_file.read_text(encoding="utf-8"), validation_info)
+        if template is not None:
+            template.directories["outputs"] = DirectoryDefinition(
+                name="outputs",
+                path_macro=args.output_dir,
+            )
+            tmp = tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".yml",
+                prefix="griptape_nuke_run_",
+                delete=False,
+                encoding="utf-8",
+            )
+            tmp.write(template.to_yaml())
+            tmp.close()
+            temp_project_file = tmp.name
+            project_file_path = temp_project_file
 
     try:
         output = module.execute_workflow(
             input=flow_input,
-            project_file_path=str(project_file) if project_file.exists() else None,
+            project_file_path=project_file_path,
         )
     except Exception as e:
         emit_payload({"error": f"Workflow execution failed: {e}"})
         sys.exit(1)
+    finally:
+        if temp_project_file is not None:
+            try:
+                Path(temp_project_file).unlink(missing_ok=True)
+            except OSError:
+                pass
 
     workspace_dir = Path(args.nk_script_dir) if args.nk_script_dir else None
     macro_map = _build_macro_map(Path(__file__).parent, workspace_dir=workspace_dir)

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -45,10 +45,13 @@ def _bootstrap_environment(nk_script_dir: str | None = None) -> None:
     """
     script_dir = Path(__file__).parent
 
-    # Load .env with python-dotenv (handles quoted values correctly)
+    # Load .env with python-dotenv (handles quoted values correctly).
+    # override=True ensures bundled secrets (e.g. GT_CLOUD_API_KEY) win over
+    # whatever the parent Nuke process happened to inherit from the system
+    # environment, which may be stale or empty.
     env_path = script_dir / ".env"
     if env_path.exists():
-        load_dotenv(env_path)
+        load_dotenv(env_path, override=True)
 
     # When a Nuke script directory is available, use it as the workspace so
     # that relative directory macros in project.yml (like ``outputs``) resolve

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -48,12 +48,12 @@ def _bootstrap_environment(nk_script_dir: str | None = None) -> None:
     script_dir = Path(__file__).parent
 
     # Load .env with python-dotenv (handles quoted values correctly).
-    # override=True ensures bundled secrets (e.g. GT_CLOUD_API_KEY) win over
-    # whatever the parent Nuke process happened to inherit from the system
-    # environment, which may be stale or empty.
+    # override=False: the bundled .env only fills env vars the parent Nuke
+    # process did not already set, so a pipeline/farm job can supply its own
+    # credentials (e.g. per-job GT_CLOUD_API_KEY) without being clobbered.
     env_path = script_dir / ".env"
     if env_path.exists():
-        load_dotenv(env_path, override=True)
+        load_dotenv(env_path, override=False)
 
     # When a Nuke script directory is available, use it as the workspace so
     # that relative directory macros in project.yml (like ``outputs``) resolve
@@ -281,10 +281,10 @@ def main() -> None:
                 delete=False,
                 encoding="utf-8",
             )
+            temp_project_file = tmp.name  # register for cleanup before any write can raise
+            project_file_path = temp_project_file
             tmp.write(template.to_yaml())
             tmp.close()
-            temp_project_file = tmp.name
-            project_file_path = temp_project_file
 
     try:
         output = module.execute_workflow(

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -26,7 +26,6 @@ Qt (PySide2 or PySide6) is bundled with Nuke and available here.
 
 import json
 import os
-from pathlib import Path
 import platform
 import shutil
 import subprocess
@@ -34,6 +33,7 @@ import sys
 import tempfile
 import threading
 import time
+from pathlib import Path
 
 # run_button.py is exec'd (not imported) by the gizmo bootstrap, so __file__'s
 # directory is not added to sys.path automatically. Insert it so that

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -33,7 +33,6 @@ import sys
 import tempfile
 import threading
 import time
-from pathlib import Path
 
 # run_button.py is exec'd (not imported) by the gizmo bootstrap, so __file__'s
 # directory is not added to sys.path automatically. Insert it so that
@@ -305,19 +304,6 @@ else:
             print(f"[Griptape] knob '{_k}' -> type={type(inputs[_k]).__name__!r} value={inputs[_k]!r}")
         else:
             print(f"[Griptape] knob '{_k}' -> NOT FOUND on node")
-
-    # -- Resolve bare filenames against output_dir --
-    # When the artist sets an Output Directory on the gizmo and a workflow input
-    # is a relative filename (e.g. output_file="julia_test.jpg"), combine them
-    # into an absolute path so SaveImage bypasses the project macro and writes
-    # exactly where the artist expects.  Already-absolute paths are left alone.
-    if output_dir:
-        _output_dir_path = Path(output_dir)
-        for _k in list(inputs.keys()):
-            _v = inputs[_k]
-            if isinstance(_v, str) and _v and not Path(_v).is_absolute():
-                inputs[_k] = str(_output_dir_path / _v)
-                print(f"[Griptape] resolved '{_k}' -> {inputs[_k]!r}")
 
     # -- Render media inputs from upstream Nuke connections to temp files --
 

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -26,6 +26,7 @@ Qt (PySide2 or PySide6) is bundled with Nuke and available here.
 
 import json
 import os
+from pathlib import Path
 import platform
 import shutil
 import subprocess
@@ -304,6 +305,19 @@ else:
             print(f"[Griptape] knob '{_k}' -> type={type(inputs[_k]).__name__!r} value={inputs[_k]!r}")
         else:
             print(f"[Griptape] knob '{_k}' -> NOT FOUND on node")
+
+    # -- Resolve bare filenames against output_dir --
+    # When the artist sets an Output Directory on the gizmo and a workflow input
+    # is a relative filename (e.g. output_file="julia_test.jpg"), combine them
+    # into an absolute path so SaveImage bypasses the project macro and writes
+    # exactly where the artist expects.  Already-absolute paths are left alone.
+    if output_dir:
+        _output_dir_path = Path(output_dir)
+        for _k in list(inputs.keys()):
+            _v = inputs[_k]
+            if isinstance(_v, str) and _v and not Path(_v).is_absolute():
+                inputs[_k] = str(_output_dir_path / _v)
+                print(f"[Griptape] resolved '{_k}' -> {inputs[_k]!r}")
 
     # -- Render media inputs from upstream Nuke connections to temp files --
 

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -491,10 +491,11 @@ else:
                                         node.begin()
                                         _r = nuke.toNode(_read_name)  # noqa: F821
                                         if _r:
-                                            # Forward slashes are required: Nuke's TCL
-                                            # layer interprets backslashes as escape
-                                            # sequences when .nk files are saved/reloaded.
-                                            _r["file"].setValue(str(_mv).replace("\\", "/"))
+                                            # The Read node's file knob is expression-linked
+                                            # to the top-level output knob (set above via
+                                            # _output_knob_map), so we only need to trigger
+                                            # a reload — not overwrite the expression with
+                                            # a literal path.
                                             try:
                                                 _r["reload"].execute()
                                             except Exception:
@@ -597,7 +598,11 @@ else:
                                     node.begin()
                                     _r = nuke.toNode(_read_name)  # noqa: F821
                                     if _r:
-                                        _r["file"].setValue(str(_mv).replace("\\", "/"))
+                                        # The Read node's file knob is expression-linked
+                                        # to the top-level output knob (set above via
+                                        # _output_knob_map), so we only need to trigger
+                                        # a reload — not overwrite the expression with
+                                        # a literal path.
                                         try:
                                             _r["reload"].execute()
                                         except Exception:

--- a/tests/unit/test_nuke_gizmo_builder.py
+++ b/tests/unit/test_nuke_gizmo_builder.py
@@ -12,10 +12,28 @@ def _minimal_shape(input_params: dict[str, dict]) -> dict:
     }
 
 
+def _shape_with_output(output_params: dict[str, dict]) -> dict:
+    return {
+        "input": {"Nuke Start Flow": {}},
+        "output": {"Nuke End Flow": output_params},
+    }
+
+
 def _generate_gizmo(input_params: dict[str, dict]) -> str:
     builder = NukeGizmoBuilder(
         workflow_name="test_workflow",
         workflow_shape=_minimal_shape(input_params),
+        companion_dir="/tmp/test",
+        workflow_file="/tmp/test/test_workflow.json",
+        current_version=1,
+    )
+    return builder.generate()
+
+
+def _generate_gizmo_with_output(output_params: dict[str, dict]) -> str:
+    builder = NukeGizmoBuilder(
+        workflow_name="test_workflow",
+        workflow_shape=_shape_with_output(output_params),
         companion_dir="/tmp/test",
         workflow_file="/tmp/test/test_workflow.json",
         current_version=1,
@@ -130,3 +148,81 @@ class TestSubclassDefaultsRejectedByStrictTypeCheck:
         lines = gizmo.splitlines()
         value_lines = [line for line in lines if line.strip().startswith("scale ")]
         assert value_lines == []
+
+
+class TestReadNodeExpressionLink:
+    """Internal Read nodes must expression-link their file knob to the
+    persistent top-level output knob so the path survives .nk save/reload
+    and copy-paste (Nuke does not serialize internal gizmo-node edits into
+    the .nk).
+    """
+
+    def test_single_media_output_read_node_links_to_output_knob(self) -> None:
+        """A single image output generates a Read whose file is linked to image_out."""
+        gizmo = _generate_gizmo_with_output(
+            {
+                "image": {
+                    "type": "ImageUrlArtifact",
+                    "default_value": "",
+                    "mode_allowed_output": True,
+                    "ui_options": {},
+                }
+            }
+        )
+        # The internal Read node must carry the TCL expression, not an empty literal.
+        assert r'file "\[value parent.image_out]"' in gizmo
+        # Sanity: the top-level output knob must still be declared.
+        assert "image_out" in gizmo
+
+    def test_single_media_output_no_literal_file_empty(self) -> None:
+        """The hardcoded 'file ""' must not appear when an expression is used."""
+        gizmo = _generate_gizmo_with_output(
+            {
+                "result": {
+                    "type": "ImageUrlArtifact",
+                    "default_value": "",
+                    "mode_allowed_output": True,
+                    "ui_options": {},
+                }
+            }
+        )
+        # Expression-linked Read must not fall back to the empty literal.
+        assert 'file ""' not in gizmo
+
+    def test_multiple_media_outputs_each_read_links_to_its_own_knob(self) -> None:
+        """Multiple image outputs each get a Read linked to their own *_out knob."""
+        gizmo = _generate_gizmo_with_output(
+            {
+                "alpha": {
+                    "type": "ImageUrlArtifact",
+                    "default_value": "",
+                    "mode_allowed_output": True,
+                    "ui_options": {},
+                },
+                "beauty": {
+                    "type": "ImageUrlArtifact",
+                    "default_value": "",
+                    "mode_allowed_output": True,
+                    "ui_options": {},
+                },
+            }
+        )
+        assert r'file "\[value parent.alpha_out]"' in gizmo
+        assert r'file "\[value parent.beauty_out]"' in gizmo
+        # No empty literals anywhere.
+        assert 'file ""' not in gizmo
+
+    def test_non_media_output_does_not_produce_read_node(self) -> None:
+        """A plain string output has no Read node and no expression."""
+        gizmo = _generate_gizmo_with_output(
+            {
+                "caption": {
+                    "type": "str",
+                    "default_value": "",
+                    "mode_allowed_output": True,
+                    "ui_options": {},
+                }
+            }
+        )
+        assert "GEN_READ" not in gizmo
+        assert r"\[value" not in gizmo


### PR DESCRIPTION
## Problem
Publishing a Griptape workflow as a Nuke gizmo produced three bugs: 
- saved image landed in the wrong location (inside the companion bundle instead of the artist's chosen directory)
- the result path disappeared after saving/reloading or copy-pasting the gizmo 
- re-runs kept creating new versioned files instead of overwriting.

## Solutions

- Relative output filenames are now joined with the Output Directory knob value (if it is set) into an absolute path before the workflow runs, so SaveImage writes exactly where the artist expects. If it's not set, it uses traditional media file saving.
- Internal Read nodes now carry a live TCL expression [value parent.image_out] instead of a hardcoded empty file "", so the displayed result persists through .nk save/reload and copy-paste
- The save_node_output situation macro no longer injects the node name or an auto-incrementing version index, and the collision policy is now OVERWRITE so re-runs overwrite in place