### PR TITLE
fix(gizmo): redirect engine user config into bundle via XDG_CONFIG_HOME

### DIFF
--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -18,16 +18,25 @@ Output:
 
 from __future__ import annotations
 
-import argparse
-import importlib.util
-import json
-import logging
 import os
-import re
-import subprocess
 import sys
-import tempfile
 from pathlib import Path
+
+# Redirect the engine's USER config into a throwaway dir inside the bundle so
+# per-run project paths (and any other engine writes) never pollute the user's
+# global ~/.config/griptape_nodes.  Must be set before any griptape_nodes import
+# because xdg_config_home() is evaluated once at config_manager import time.
+# The guard lets run_button.py's explicit env= take precedence when set by the parent.
+if not os.environ.get("XDG_CONFIG_HOME"):
+    os.environ["XDG_CONFIG_HOME"] = str(Path(__file__).resolve().parent / ".gtn_config").replace("\\", "/")
+
+import argparse  # noqa: E402
+import importlib.util  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import re  # noqa: E402
+import subprocess  # noqa: E402
+import tempfile  # noqa: E402
 
 from dotenv import load_dotenv
 from griptape_nodes.common.project_templates import load_project_template_from_yaml

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -54,6 +54,16 @@ except ImportError:
     _SENTINEL = ""
 
 
+def _build_child_env(companion: str, base_env: dict) -> dict:
+    """Return a subprocess env with XDG_CONFIG_HOME redirected into the bundle.
+
+    Keeps all engine config writes (e.g. projects_to_register) inside the
+    throwaway companion directory instead of the user's global ~/.config.
+    companion must already be an absolute forward-slashed path.
+    """
+    return {**base_env, "XDG_CONFIG_HOME": companion + "/.gtn_config"}
+
+
 # Qt is bundled with Nuke. Try PySide6 first (Nuke 16+), fall back to PySide2 (Nuke 13–15).
 try:
     from PySide6.QtCore import Qt
@@ -267,6 +277,12 @@ if not companion or not os.path.isdir(companion):
 # TCL string encoding when the .nk file is saved and reloaded.
 companion = companion.replace("\\", "/")
 node["_companion_dir"].setValue(companion)
+
+# Build the child-process environment once.  Redirecting XDG_CONFIG_HOME into a
+# bundle-local subdir ensures the engine's user config writes (e.g. the
+# projects_to_register list) stay inside the throwaway bundle directory and never
+# pollute the user's global ~/.config/griptape_nodes.
+_child_env = _build_child_env(companion, os.environ)
 
 # -- Resolve workflow file from version subdir --
 
@@ -532,6 +548,7 @@ else:
                     text=True,
                     bufsize=1,
                     cwd=companion,
+                    env=_child_env,
                 )
                 _process_ref[0] = p
 
@@ -581,7 +598,7 @@ else:
             # ------------------------------------------------------------------
             # Fallback: blocking path when Qt is not available
             # ------------------------------------------------------------------
-            result = subprocess.run(cmd, capture_output=True, text=True, cwd=companion, timeout=600)
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd=companion, timeout=600, env=_child_env)
             if result.returncode == 0:
                 try:
                     output = _extract_runner_output(result.stdout)

--- a/tests/unit/test_run_button_env.py
+++ b/tests/unit/test_run_button_env.py
@@ -1,0 +1,117 @@
+"""Tests for run_button._build_child_env — the bundle config isolation helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# run_button.py is exec'd in Nuke's interpreter and references nuke/Qt at module
+# scope, so it can't be imported normally.  Import only the pure helper by
+# inserting the source dir and importing the function via exec into a namespace.
+_RUN_BUTTON = Path(__file__).parent.parent.parent / "publish_gizmo" / "run_button.py"
+
+
+def _load_build_child_env():
+    """Extract _build_child_env from run_button.py without running its top-level Nuke code."""
+    source = _RUN_BUTTON.read_text(encoding="utf-8")
+    # Isolate just the function definition.
+    lines = source.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("def _build_child_env("))
+    # Collect lines until the next top-level definition or blank-then-non-blank pair.
+    body_lines = []
+    for line in lines[start:]:
+        if body_lines and line and not line[0].isspace() and not line.startswith("def _build_child_env"):
+            break
+        body_lines.append(line)
+    ns: dict = {}
+    exec("\n".join(body_lines), ns)  # noqa: S102
+    return ns["_build_child_env"]
+
+
+_build_child_env = _load_build_child_env()
+
+
+class TestBuildChildEnv:
+    def test_sets_xdg_config_home_inside_bundle(self) -> None:
+        """XDG_CONFIG_HOME must point at <companion>/.gtn_config."""
+        env = _build_child_env("/some/bundle", {})
+        assert env["XDG_CONFIG_HOME"] == "/some/bundle/.gtn_config"
+
+    def test_xdg_config_home_is_absolute(self) -> None:
+        env = _build_child_env("/abs/path/bundle", {})
+        assert Path(env["XDG_CONFIG_HOME"]).is_absolute()
+
+    def test_xdg_config_home_uses_forward_slashes(self) -> None:
+        """Forward slashes required — Nuke/TCL treats backslashes as escapes."""
+        env = _build_child_env("C:/Users/jadan/.nuke/griptape/myWorkflow", {})
+        assert "\\" not in env["XDG_CONFIG_HOME"]
+
+    def test_preserves_all_base_env_keys(self) -> None:
+        """All existing env keys must be present in the child env."""
+        base = {"PATH": "/usr/bin", "HOME": "/home/user", "CUSTOM_VAR": "value"}
+        env = _build_child_env("/bundle", base)
+        for key, value in base.items():
+            assert env[key] == value
+
+    def test_does_not_mutate_base_env(self) -> None:
+        base = {"PATH": "/usr/bin"}
+        original_base = dict(base)
+        _build_child_env("/bundle", base)
+        assert base == original_base
+
+
+class TestRunnerXdgConfigHomeImportOrder:
+    """Guard the import-ordering invariant: XDG_CONFIG_HOME must be set before
+    any griptape_nodes import so the engine's config path is frozen correctly."""
+
+    def test_xdg_config_home_set_before_griptape_import(self) -> None:
+        """The env guard block must appear before the first 'from griptape_nodes' line."""
+        source = (Path(__file__).parent.parent.parent / "publish_gizmo" / "nuke_workflow_runner.py").read_text(
+            encoding="utf-8"
+        )
+        lines = source.splitlines()
+
+        xdg_line = next(
+            (i for i, line in enumerate(lines) if "XDG_CONFIG_HOME" in line and "os.environ" in line),
+            None,
+        )
+        griptape_line = next(
+            (i for i, line in enumerate(lines) if line.startswith("from griptape_nodes")),
+            None,
+        )
+
+        assert xdg_line is not None, "XDG_CONFIG_HOME guard not found in nuke_workflow_runner.py"
+        assert griptape_line is not None, "No 'from griptape_nodes' import found in nuke_workflow_runner.py"
+        assert xdg_line < griptape_line, (
+            f"XDG_CONFIG_HOME guard (line {xdg_line + 1}) must precede "
+            f"first griptape_nodes import (line {griptape_line + 1})"
+        )
+
+    def test_runner_respects_parent_xdg_config_home(self) -> None:
+        """If XDG_CONFIG_HOME is already set by the parent, the runner must not overwrite it."""
+        import os
+
+        sentinel = "/parent/set/config/home"
+        original = os.environ.get("XDG_CONFIG_HOME")
+        os.environ["XDG_CONFIG_HOME"] = sentinel
+        try:
+            # Re-exec only the guard block from the runner.
+            source = (Path(__file__).parent.parent.parent / "publish_gizmo" / "nuke_workflow_runner.py").read_text(
+                encoding="utf-8"
+            )
+            lines = source.splitlines()
+            # Find the guard block: `if not os.environ.get("XDG_CONFIG_HOME"):` and its body.
+            start = next(i for i, line in enumerate(lines) if 'os.environ.get("XDG_CONFIG_HOME")' in line)
+            block_lines = []
+            for line in lines[start:]:
+                if block_lines and line and not line[0].isspace():
+                    break
+                block_lines.append(line)
+            exec("\n".join(block_lines), {"os": os, "Path": Path})  # noqa: S102
+            assert os.environ["XDG_CONFIG_HOME"] == sentinel, (
+                "Runner must not overwrite parent-provided XDG_CONFIG_HOME"
+            )
+        finally:
+            if original is None:
+                os.environ.pop("XDG_CONFIG_HOME", None)
+            else:
+                os.environ["XDG_CONFIG_HOME"] = original


### PR DESCRIPTION
## Summary

- When a gizmo runs, the headless engine subprocess persists every loaded `project.yml` path into the user's **global** `~/.config/griptape_nodes/griptape_nodes_config.json` under `projects_to_register`. These paths are never pruned, so deleted or moved gizmos leave dead entries that cause `ERROR: File not found` + `WARNING: Failed to load registered project ... on startup` spam on **every** subsequent engine boot — including the user's main Griptape app.
- The runner also creates per-run temp `project.yml` files (`griptape_nuke_run_*.yml`) which get registered the same way and deleted immediately after, leaving permanently broken entries.
- Fix: set `XDG_CONFIG_HOME` to `<companion>/.gtn_config` in the subprocess environment so the engine's user config writes stay inside the throwaway bundle directory and never touch the user's global config.

## Changes

- **`publish_gizmo/run_button.py`** — adds `_build_child_env()` helper and passes `env=_child_env` (with `XDG_CONFIG_HOME` set) to both `subprocess.Popen` and `subprocess.run` calls that launch the engine
- **`publish_gizmo/nuke_workflow_runner.py`** — guard-sets `XDG_CONFIG_HOME` at the top of the file before any `griptape_nodes` import as a belt-and-suspenders fallback for direct invocations (the engine's config path is frozen at `config_manager` import time)
- **`tests/unit/test_run_button_env.py`** — 7 new tests covering helper correctness, forward-slash safety, import ordering invariant, and parent-env respect

## Verified safe
- **Secrets**: bundle `.env` is loaded via `load_dotenv(override=True)` into OS env — the highest-priority secret source. Redirecting `XDG_CONFIG_HOME` only moves the lowest-priority fallback.
- **Libraries / model cache**: key off `XDG_DATA_HOME` / `HF_HUB_CACHE`, not config home — untouched.
- **Empty user config**: the engine merges defaults → user → workspace fine with an absent user layer.

## Notes
- **Already-published bundles need a re-publish** to pick up the fix.
- The root engine-side issue (no stale-entry pruning, `persist_path=True` hardcoded on `LoadProjectTemplateRequest`) remains and should be addressed upstream in `griptape-nodes` to clean already-polluted user configs.

## Test plan
- [ ] `make check` passes
- [ ] `uv run pytest tests/unit/` passes (189 tests)
- [ ] Publish a gizmo from updated source; run it in Nuke; confirm `<companion>/.gtn_config/griptape_nodes/griptape_nodes_config.json` is created with the run's entries and the user's global `projects_to_register` is unchanged
- [ ] Restart main Griptape engine after a gizmo run; confirm no new startup warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)