### PR TITLE
feat: replace ImageSequenceArtifact with engine-native Sequence type

### DIFF
--- a/execution/direct.py
+++ b/execution/direct.py
@@ -121,7 +121,7 @@ class DirectSubprocessProvider:
         _, stderr_output = process.communicate()
         return_code = process.returncode
         status = JobStatus.SUCCEEDED if return_code == 0 else JobStatus.FAILED
-        outputs: dict[str, str | list[str]] = {}
+        outputs: dict[str, str] = {}
         out_manifest_path = self._output_manifest_paths.get(handle, None)
         if out_manifest_path and os.path.exists(out_manifest_path):
             with open(out_manifest_path, encoding="utf-8") as f:

--- a/execution/provider.py
+++ b/execution/provider.py
@@ -17,5 +17,5 @@ class JobResult:
     handle: str
     status: JobStatus
     return_code: int
-    outputs: dict[str, str | list[str]] = field(default_factory=dict)
+    outputs: dict[str, str] = field(default_factory=dict)
     log: list[str] = field(default_factory=list)

--- a/griptape-nodes-library.json
+++ b/griptape-nodes-library.json
@@ -6,16 +6,14 @@
         "author": "Griptape",
         "description": "Library for Nuke nodes",
         "library_version": "0.3.0",
-        "engine_version": "0.81.0",
+        "engine_version": "0.93.0",
         "tags": [
             "Griptape",
             "AI",
             "Nuke"
         ],
         "dependencies": {
-            "pip_dependencies": [
-                "trimesh>=4.12.2"
-            ]
+            "pip_dependencies": []
         }
     },
     "categories": [

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -20,7 +20,11 @@ from griptape_nodes.exe_types.param_types.parameter_button import ParameterButto
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
 from griptape_nodes.files.project_file import ProjectFileDestination
-from griptape_nodes.retained_mode.events.os_events import DeleteFileRequest, WriteFileRequest, WriteFileResultSuccess
+from griptape_nodes.retained_mode.events.os_events import (
+    DeleteFileRequest,
+    WriteFileRequest,
+    WriteFileResultSuccess,
+)
 from griptape_nodes.retained_mode.events.project_events import GetPathForMacroRequest, GetPathForMacroResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -40,8 +44,6 @@ from script_parser.sidecar import read_knob_schema, read_sidecar
 _RUNNER_SCRIPT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "nuke_runner", "runner.py"))
 _BAKE_RUNNER_SCRIPT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "nuke_runner", "baker.py"))
 
-# Temp file suffix per gt_type — used when creating output placeholders before Nuke runs.
-# ImageSequenceArtifact is handled separately (mkdtemp + pattern path) and not listed here.
 _TEMP_SUFFIX: dict[str, str] = {
     "ThreeDUrlArtifact": ".obj",
     "GLTFUrlArtifact": ".glb",
@@ -49,8 +51,8 @@ _TEMP_SUFFIX: dict[str, str] = {
 }
 
 
-def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
-    """Convert a runner output file path (or list of paths) to the appropriate Griptape artifact."""
+def _path_to_artifact(gt_type: str, path: str) -> Any:
+    """Convert a runner output file path to the appropriate Griptape artifact."""
     if gt_type in {"ThreeDUrlArtifact", "GLTFUrlArtifact"}:
         if not isinstance(path, str):
             raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
@@ -92,22 +94,6 @@ def _path_to_artifact(gt_type: str, path: str | list[str]) -> Any:
             return VideoUrlArtifact(value=saved.location)
         except ImportError:
             return saved.location
-    if gt_type == "ImageSequenceArtifact":
-        if not isinstance(path, list):
-            raise TypeError(f"Expected list[str] for ImageSequenceArtifact, got {type(path).__name__!r}: {path!r}")
-        try:
-            from griptape.artifacts import ImageUrlArtifact, ListArtifact  # noqa: PLC0415
-
-            items = []
-            for fp in path:
-                frame_suffix = pathlib.Path(fp).suffix or ".png"
-                frame_saved = ProjectFileDestination.from_situation(
-                    filename=f"frame{frame_suffix}", situation="save_node_output"
-                ).write_bytes(File(fp).read_bytes())
-                items.append(ImageUrlArtifact(value=frame_saved.location))
-            return ListArtifact(items)
-        except ImportError:
-            return path
     if not isinstance(path, str):
         raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
     file_bytes = File(path).read_bytes()
@@ -475,7 +461,14 @@ class NukeScriptNode(SuccessFailureNode):
             param = Parameter(
                 name=ann.gt_name,
                 type=ann.gt_type or "str",
-                input_types=["str", "ImageArtifact", "ImageUrlArtifact", "BlobArtifact", "VideoUrlArtifact"],
+                input_types=[
+                    "str",
+                    "ImageArtifact",
+                    "ImageUrlArtifact",
+                    "BlobArtifact",
+                    "VideoUrlArtifact",
+                    "Sequence",
+                ],
                 default_value="",
                 display_name=ann.gt_label or ann.gt_name,
                 tooltip=f"Input path for Nuke node {ann.node_name!r}",
@@ -524,8 +517,9 @@ class NukeScriptNode(SuccessFailureNode):
             elif ann.gt_type == "ImageSequenceArtifact":
                 param = Parameter(
                     name=ann.gt_name,
-                    type="list",
-                    default_value="",
+                    type="Sequence",
+                    output_type="Sequence",
+                    default_value=None,
                     display_name=ann.gt_label or ann.gt_name,
                     tooltip=f"Image sequence output from Nuke node {ann.node_name!r}",
                     allow_input=False,
@@ -621,6 +615,13 @@ class NukeScriptNode(SuccessFailureNode):
         situation: str = "save_temp_file",
     ) -> str:
         """Resolve a parameter value to a local file path Nuke can read."""
+        try:
+            from griptape_nodes.common.sequences import Sequence as GtSequence  # type: ignore  # noqa: PLC0415
+
+            if isinstance(value, GtSequence):
+                return (value.directory + "/" + value.pattern).replace("\\", "/")
+        except ImportError:
+            pass
         if isinstance(value, str):
             return value
         try:
@@ -816,7 +817,6 @@ class NukeScriptNode(SuccessFailureNode):
         outputs: dict[str, ManifestOutput] = {}
         input_tmp_paths: list[str] = []
         output_tmp_paths: list[str] = []
-        output_tmp_dirs: list[str] = []
         _run_id = uuid.uuid4().hex[:8]
 
         try:
@@ -831,18 +831,9 @@ class NukeScriptNode(SuccessFailureNode):
                         node=ann.node_name,
                     )
                 elif ann.gt_type == "ImageSequenceArtifact":
-                    seq_dest = ProjectFileDestination.from_situation(
-                        f"{self.name}_{_run_id}_{ann.gt_name}_frame.png", "save_temp_file"
-                    )
-                    # Nuke requires the output directory to exist before it starts writing
-                    # frames. WriteFileRequest has no mkdir equivalent, so we force creation
-                    # by writing a sentinel .empty file. seq_dir is derived from final_file_path
-                    # (not resolve()) in case the framework renamed the directory under
-                    # CREATE_NEW collision policy.
-                    _empty_path = self._write_scratch_file(str(pathlib.Path(seq_dest.resolve()).parent / ".empty"), b"")
-                    seq_dir = str(pathlib.Path(_empty_path).parent)
-                    seq_path = f"{seq_dir}/{ann.gt_name}_frame.%04d.png".replace("\\", "/")
-                    output_tmp_dirs.append(seq_dir)
+                    seq_dest = ProjectFileDestination.from_situation("frame_####.png", "save_node_output")
+                    seq_path = str(seq_dest.resolve()).replace("\\", "/")
+                    os.makedirs(os.path.dirname(seq_path), exist_ok=True)
                     outputs[ann.gt_name] = ManifestOutput(
                         path=seq_path,
                         node=ann.node_name,
@@ -897,11 +888,26 @@ class NukeScriptNode(SuccessFailureNode):
                 if gt_name not in outputs:
                     logging.getLogger(__name__).warning("Nuke runner returned unknown output key %r; skipping", gt_name)
                     continue
-                self.parameter_output_values[gt_name] = _path_to_artifact(outputs[gt_name].type, path)
+                ann_type = outputs[gt_name].type
+                if ann_type == "ImageSequenceArtifact":
+                    from griptape_nodes.retained_mode.events.os_events import ScanSequencesRequest  # type: ignore  # noqa: PLC0415, I001
+                    from griptape_nodes.retained_mode.events.os_events import ScanSequencesResultSuccess  # type: ignore  # noqa: PLC0415, I001
+
+                    scan_result = GriptapeNodes.handle_request(
+                        ScanSequencesRequest(
+                            path=path,
+                            start_number=frame_start,
+                            end_number=frame_end,
+                        )
+                    )
+                    if isinstance(scan_result, ScanSequencesResultSuccess) and scan_result.sequences:  # pyright: ignore[reportAttributeAccessIssue]
+                        self.parameter_output_values[gt_name] = scan_result.sequences[0]  # pyright: ignore[reportAttributeAccessIssue]
+                    else:
+                        raise RuntimeError(f"No frames found for sequence at {path!r}")
+                else:
+                    self.parameter_output_values[gt_name] = _path_to_artifact(ann_type, path)
 
             self._set_status_results(was_successful=True, result_details="Render complete.")
         finally:
             for p in input_tmp_paths + output_tmp_paths:
                 GriptapeNodes.handle_request(DeleteFileRequest(path=p, workspace_only=False))
-            for d in output_tmp_dirs:
-                GriptapeNodes.handle_request(DeleteFileRequest(path=d, workspace_only=False))

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -56,22 +56,15 @@ def _path_to_artifact(gt_type: str, path: str) -> Any:
     if gt_type in {"ThreeDUrlArtifact", "GLTFUrlArtifact"}:
         if not isinstance(path, str):
             raise TypeError(f"Expected str path for {gt_type!r}, got {type(path).__name__!r}: {path!r}")
-        suffix = pathlib.Path(path).suffix.lower() or ".obj"
-        if suffix in {".glb", ".gltf"}:
-            file_bytes = File(path).read_bytes()
-            serve_suffix = suffix
-        else:
-            try:
-                import trimesh  # pyright: ignore[reportMissingImports]  # noqa: PLC0415
-
-                scene = trimesh.load(path)
-                file_bytes = scene.export(file_type="glb")  # pyright: ignore[reportAttributeAccessIssue,reportCallIssue]
-                serve_suffix = ".glb"
-            except Exception:
-                file_bytes = File(path).read_bytes()
-                serve_suffix = suffix
+        suffix = pathlib.Path(path).suffix.lower() or ".glb"
+        if suffix not in {".glb", ".gltf"}:
+            raise ValueError(
+                f"3D output {gt_type!r} requires a .glb or .gltf file; got {suffix!r}. "
+                "Configure Nuke's Write node to export GLB directly."
+            )
+        file_bytes = File(path).read_bytes()
         saved = ProjectFileDestination.from_situation(
-            filename=f"model{serve_suffix}", situation="save_node_output"
+            filename=f"model{suffix}", situation="save_node_output"
         ).write_bytes(file_bytes)
         try:
             from griptape_nodes_library.three_d.three_d_artifact import (  # pyright: ignore[reportMissingImports]
@@ -514,6 +507,7 @@ class NukeScriptNode(SuccessFailureNode):
                         user_defined=True,
                         parent_element_name="Outputs",
                     )
+            # ImageSequenceArtifact: backward-compat for sidecars annotated before engine 0.93
             elif ann.gt_type in ("ImageSequenceArtifact", "Sequence"):
                 param = Parameter(
                     name=ann.gt_name,
@@ -830,6 +824,7 @@ class NukeScriptNode(SuccessFailureNode):
                         ),
                         node=ann.node_name,
                     )
+                # ImageSequenceArtifact: backward-compat for sidecars annotated before engine 0.93
                 elif ann.gt_type in ("ImageSequenceArtifact", "Sequence"):
                     macro_result = GriptapeNodes.handle_request(
                         GetPathForMacroRequest(
@@ -840,7 +835,9 @@ class NukeScriptNode(SuccessFailureNode):
                     if not isinstance(macro_result, GetPathForMacroResultSuccess):
                         raise RuntimeError(f"Could not resolve output path for sequence {ann.gt_name!r}")
                     seq_path = str(macro_result.absolute_path).replace("\\", "/")
-                    os.makedirs(os.path.dirname(seq_path), exist_ok=True)
+                    from griptape_nodes.retained_mode.events.os_events import MakeDirectoryRequest  # noqa: PLC0415
+
+                    GriptapeNodes.handle_request(MakeDirectoryRequest(path=os.path.dirname(seq_path)))
                     outputs[ann.gt_name] = ManifestOutput(
                         path=seq_path,
                         node=ann.node_name,

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -514,7 +514,7 @@ class NukeScriptNode(SuccessFailureNode):
                         user_defined=True,
                         parent_element_name="Outputs",
                     )
-            elif ann.gt_type == "ImageSequenceArtifact":
+            elif ann.gt_type in ("ImageSequenceArtifact", "Sequence"):
                 param = Parameter(
                     name=ann.gt_name,
                     type="Sequence",
@@ -830,7 +830,7 @@ class NukeScriptNode(SuccessFailureNode):
                         ),
                         node=ann.node_name,
                     )
-                elif ann.gt_type == "ImageSequenceArtifact":
+                elif ann.gt_type in ("ImageSequenceArtifact", "Sequence"):
                     macro_result = GriptapeNodes.handle_request(
                         GetPathForMacroRequest(
                             parsed_macro=ParsedMacro("{outputs}/nuke/{node_name}/{param_name}/frame_####.png"),
@@ -844,7 +844,7 @@ class NukeScriptNode(SuccessFailureNode):
                     outputs[ann.gt_name] = ManifestOutput(
                         path=seq_path,
                         node=ann.node_name,
-                        type="ImageSequenceArtifact",
+                        type="Sequence",
                     )
                 else:
                     suffix = _TEMP_SUFFIX.get(ann.gt_type or "", ".png")
@@ -896,7 +896,7 @@ class NukeScriptNode(SuccessFailureNode):
                     logging.getLogger(__name__).warning("Nuke runner returned unknown output key %r; skipping", gt_name)
                     continue
                 ann_type = outputs[gt_name].type
-                if ann_type == "ImageSequenceArtifact":
+                if ann_type == "Sequence":
                     from griptape_nodes.retained_mode.events.os_events import ScanSequencesRequest  # type: ignore  # noqa: PLC0415, I001
                     from griptape_nodes.retained_mode.events.os_events import ScanSequencesResultSuccess  # type: ignore  # noqa: PLC0415, I001
 

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -23,8 +23,6 @@ from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode.events.os_events import (
     DeleteFileRequest,
     MakeDirectoryRequest,
-    ScanSequencesRequest,  # type: ignore[attr-defined]
-    ScanSequencesResultSuccess,  # type: ignore[attr-defined]
     WriteFileRequest,
     WriteFileResultSuccess,
 )
@@ -895,6 +893,16 @@ class NukeScriptNode(SuccessFailureNode):
                     continue
                 ann_type = outputs[gt_name].type
                 if ann_type == "Sequence":
+                    try:
+                        from griptape_nodes.retained_mode.events.os_events import (  # type: ignore[attr-defined]  # noqa: PLC0415
+                            ScanSequencesRequest,
+                            ScanSequencesResultSuccess,
+                        )
+                    except ImportError as exc:
+                        raise RuntimeError(
+                            "Sequence output scanning requires griptape-nodes with ScanSequencesRequest support "
+                            "(upgrade to the version that ships this feature)."
+                        ) from exc
                     scan_result = GriptapeNodes.handle_request(
                         ScanSequencesRequest(
                             path=path,

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -23,6 +23,8 @@ from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode.events.os_events import (
     DeleteFileRequest,
     MakeDirectoryRequest,
+    ScanSequencesRequest,
+    ScanSequencesResultSuccess,
     WriteFileRequest,
     WriteFileResultSuccess,
 )
@@ -893,16 +895,6 @@ class NukeScriptNode(SuccessFailureNode):
                     continue
                 ann_type = outputs[gt_name].type
                 if ann_type == "Sequence":
-                    try:
-                        from griptape_nodes.retained_mode.events.os_events import (  # type: ignore[attr-defined]  # noqa: PLC0415
-                            ScanSequencesRequest,
-                            ScanSequencesResultSuccess,
-                        )
-                    except ImportError as exc:
-                        raise RuntimeError(
-                            "Sequence output scanning requires griptape-nodes with ScanSequencesRequest support "
-                            "(upgrade to the version that ships this feature)."
-                        ) from exc
                     scan_result = GriptapeNodes.handle_request(
                         ScanSequencesRequest(
                             path=path,
@@ -910,8 +902,8 @@ class NukeScriptNode(SuccessFailureNode):
                             end_number=frame_end,
                         )
                     )
-                    if isinstance(scan_result, ScanSequencesResultSuccess) and scan_result.sequences:  # pyright: ignore[reportAttributeAccessIssue]
-                        self.parameter_output_values[gt_name] = scan_result.sequences[0]  # pyright: ignore[reportAttributeAccessIssue]
+                    if isinstance(scan_result, ScanSequencesResultSuccess) and scan_result.sequences:
+                        self.parameter_output_values[gt_name] = scan_result.sequences[0]
                     else:
                         raise RuntimeError(f"No frames found for sequence at {path!r}")
                 else:

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -22,6 +22,9 @@ from griptape_nodes.files.file import File
 from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode.events.os_events import (
     DeleteFileRequest,
+    MakeDirectoryRequest,
+    ScanSequencesRequest,  # type: ignore[attr-defined]
+    ScanSequencesResultSuccess,  # type: ignore[attr-defined]
     WriteFileRequest,
     WriteFileResultSuccess,
 )
@@ -835,8 +838,6 @@ class NukeScriptNode(SuccessFailureNode):
                     if not isinstance(macro_result, GetPathForMacroResultSuccess):
                         raise RuntimeError(f"Could not resolve output path for sequence {ann.gt_name!r}")
                     seq_path = str(macro_result.absolute_path).replace("\\", "/")
-                    from griptape_nodes.retained_mode.events.os_events import MakeDirectoryRequest  # noqa: PLC0415
-
                     GriptapeNodes.handle_request(MakeDirectoryRequest(path=os.path.dirname(seq_path)))
                     outputs[ann.gt_name] = ManifestOutput(
                         path=seq_path,
@@ -894,9 +895,6 @@ class NukeScriptNode(SuccessFailureNode):
                     continue
                 ann_type = outputs[gt_name].type
                 if ann_type == "Sequence":
-                    from griptape_nodes.retained_mode.events.os_events import ScanSequencesRequest  # type: ignore  # noqa: PLC0415, I001
-                    from griptape_nodes.retained_mode.events.os_events import ScanSequencesResultSuccess  # type: ignore  # noqa: PLC0415, I001
-
                     scan_result = GriptapeNodes.handle_request(
                         ScanSequencesRequest(
                             path=path,

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -831,8 +831,15 @@ class NukeScriptNode(SuccessFailureNode):
                         node=ann.node_name,
                     )
                 elif ann.gt_type == "ImageSequenceArtifact":
-                    seq_dest = ProjectFileDestination.from_situation("frame_####.png", "save_node_output")
-                    seq_path = str(seq_dest.resolve()).replace("\\", "/")
+                    macro_result = GriptapeNodes.handle_request(
+                        GetPathForMacroRequest(
+                            parsed_macro=ParsedMacro("{outputs}/nuke/{node_name}/{param_name}/frame_####.png"),
+                            variables={"node_name": self.name, "param_name": ann.gt_name},
+                        )
+                    )
+                    if not isinstance(macro_result, GetPathForMacroResultSuccess):
+                        raise RuntimeError(f"Could not resolve output path for sequence {ann.gt_name!r}")
+                    seq_path = str(macro_result.absolute_path).replace("\\", "/")
                     os.makedirs(os.path.dirname(seq_path), exist_ok=True)
                     outputs[ann.gt_name] = ManifestOutput(
                         path=seq_path,

--- a/nuke_plugin/griptape_annotator_panel.py
+++ b/nuke_plugin/griptape_annotator_panel.py
@@ -36,7 +36,7 @@ _TILE_COLOR_EXPOSE = 0x9B59B6FF
 _INPUT_ARTIFACT_TYPES = ["ImageArtifact", "VideoUrlArtifact"]
 
 # Artifact types available when marking a node as an output.
-_OUTPUT_ARTIFACT_TYPES = ["ImageArtifact", "VideoUrlArtifact", "ImageSequenceArtifact", "ThreeDUrlArtifact"]
+_OUTPUT_ARTIFACT_TYPES = ["ImageArtifact", "VideoUrlArtifact", "Sequence", "ThreeDUrlArtifact"]
 
 # Knobs that are never useful to expose — purely internal Nuke state
 _INTERNAL_KNOBS = frozenset(

--- a/nuke_runner/manifest.py
+++ b/nuke_runner/manifest.py
@@ -24,6 +24,11 @@ class ManifestOutput:
     type: str = "ImageArtifact"
 
     def __post_init__(self) -> None:
+        if not isinstance(self.path, str):
+            raise TypeError(
+                f"ManifestOutput.path must be str (schema {SCHEMA_VERSION} removed list support); "
+                f"got {type(self.path).__name__!r}"
+            )
         self.path = self.path.replace("\\", "/")
 
 

--- a/nuke_runner/manifest.py
+++ b/nuke_runner/manifest.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
-SCHEMA_VERSION = "griptape-nuke-runner/1.0"
+SCHEMA_VERSION = "griptape-nuke-runner/1.1"
 
 
 @dataclass
@@ -18,16 +18,13 @@ class ManifestInput:
 
 @dataclass
 class ManifestOutput:
-    path: str | list[str]
+    path: str
     node: str
     format: str = "png"
     type: str = "ImageArtifact"
 
     def __post_init__(self) -> None:
-        if isinstance(self.path, list):
-            self.path = [p.replace("\\", "/") for p in self.path]
-        else:
-            self.path = self.path.replace("\\", "/")
+        self.path = self.path.replace("\\", "/")
 
 
 @dataclass

--- a/nuke_runner/runner.py
+++ b/nuke_runner/runner.py
@@ -18,7 +18,7 @@ import nuke  # type: ignore[import-not-found]
 # Artifact types whose output is written by a Nuke execute call on a file-knob node.
 _EXECUTE_TYPES = {
     "ImageArtifact",
-    "ImageSequenceArtifact",
+    "Sequence",
     "ImageUrlArtifact",
     "VideoArtifact",
     "VideoUrlArtifact",

--- a/nuke_runner/runner.py
+++ b/nuke_runner/runner.py
@@ -10,9 +10,7 @@ Logs go to stderr; the final output manifest JSON is written to --output-manifes
 from __future__ import annotations
 
 import argparse
-import glob as _glob
 import json
-import re
 import sys
 
 import nuke  # type: ignore[import-not-found]
@@ -35,7 +33,7 @@ def main() -> None:
     # parse_known_args: nuke -t may inject extra positional args
     args, _ = parser.parse_known_args()
 
-    outputs: dict[str, str | list[str]] = {}
+    outputs: dict[str, str] = {}
     errors: list[str] = []
 
     try:
@@ -102,12 +100,7 @@ def main() -> None:
             print(f"executing {spec['node']} frames {first}-{last} → {out_path}", file=sys.stderr)
             try:
                 nuke.execute(spec["node"], first, last)
-                if artifact_type == "ImageSequenceArtifact":
-                    glob_pattern = re.sub(r"%0?\d*d", "*", out_path)
-                    frame_paths = sorted(_glob.glob(glob_pattern))
-                    outputs[gt_name] = frame_paths
-                else:
-                    outputs[gt_name] = out_path
+                outputs[gt_name] = out_path
             except Exception as exc:
                 msg = f"ERROR: execute failed for {spec['node']!r}: {exc}"
                 print(msg, file=sys.stderr)

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -69,6 +69,8 @@ class NukeGizmoPublisher:
 
             self._packager.emit_progress(5.0, "Saving workflow...")
             workflow = WorkflowRegistry.get_workflow_by_name(self._workflow_name)
+            if not workflow.file_path:
+                return PublishWorkflowResultFailure(result_details="Workflow has no file path; save it first.")
             save_result = GriptapeNodes.handle_request(SaveWorkflowRequest(file_name=Path(workflow.file_path).stem))
             if not isinstance(save_result, SaveWorkflowResultSuccess):
                 return PublishWorkflowResultFailure(result_details="Failed to save workflow before packaging.")

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -122,8 +122,11 @@ def _build_macro_map(script_dir: Path, workspace_dir: Path | None = None) -> dic
     # Absolute path_macros (e.g. from a legacy publish) are kept as-is.
     result = {}
     for dir_def in template.directories.values():
-        value = dir_def.path_macro
-        if value and not Path(value).is_absolute():
+        raw = dir_def.path_macro
+        value: str | None = raw if isinstance(raw, str) else raw.select()
+        if not value:
+            continue
+        if not Path(value).is_absolute():
             value = str(base_dir / value)
         # Normalize to forward slashes: Nuke/TCL treats backslashes as escape
         # characters when saving .nk files, which silently mangles Windows paths.

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -123,7 +123,7 @@ def _build_macro_map(script_dir: Path, workspace_dir: Path | None = None) -> dic
     result = {}
     for dir_def in template.directories.values():
         raw = dir_def.path_macro
-        value: str | None = raw if isinstance(raw, str) else raw.select()
+        value: str | None = raw if isinstance(raw, str) else raw.select() if hasattr(raw, "select") else None
         if not value:
             continue
         if not Path(value).is_absolute():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Dan Hutchinson", email = "dan.hutchinson@foundry.com" }]
 readme = "README.md"
 requires-python = "~=3.12.0"
 dependencies = [
-    "griptape-nodes>=0.81.0",
+    "griptape-nodes>=0.93.0",
 ]
 
 [build-system]

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -104,11 +104,11 @@ def test_bake_output_path_defaults_empty() -> None:
 def test_manifest_output_sequence_pattern_path_round_trips() -> None:
     m = JobManifest(
         script="/tmp/test.nk",
-        outputs={"frames": ManifestOutput(path="/out/frame_####.png", node="Write1", type="ImageSequenceArtifact")},
+        outputs={"frames": ManifestOutput(path="/out/frame_####.png", node="Write1", type="Sequence")},
     )
     restored = JobManifest.from_json(m.to_json())
     assert restored.outputs["frames"].path == "/out/frame_####.png"
-    assert restored.outputs["frames"].type == "ImageSequenceArtifact"
+    assert restored.outputs["frames"].type == "Sequence"
 
 
 def test_manifest_output_str_path_normalisation_unchanged() -> None:

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -82,6 +82,19 @@ def test_manifest_from_json_rejects_wrong_schema_version() -> None:
         JobManifest.from_json(bad_json)
 
 
+def test_manifest_from_json_rejects_v1_0_schema() -> None:
+    """schema 1.0 used list[str] paths; 1.1 reader must reject it cleanly."""
+    old_json = PRD_CANONICAL_JSON.replace(SCHEMA_VERSION, "griptape-nuke-runner/1.0")
+    with pytest.raises(ValueError, match="Unsupported manifest schema"):
+        JobManifest.from_json(old_json)
+
+
+def test_manifest_output_raises_type_error_for_list_path() -> None:
+    """Direct construction with a list raises TypeError, not AttributeError."""
+    with pytest.raises(TypeError, match="must be str"):
+        ManifestOutput(path=["/tmp/f.0001.exr", "/tmp/f.0002.exr"], node="Write1")  # type: ignore[arg-type]
+
+
 def test_manifest_default_output_format_is_png() -> None:
     output = ManifestOutput(path="/tmp/out.png", node="WriteNode")
     assert output.format == "png"

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -6,7 +6,7 @@ from nuke_runner.manifest import SCHEMA_VERSION, JobManifest, ManifestInput, Man
 
 # Canonical JSON from PRD §7.4
 PRD_CANONICAL_JSON = """{
-  "schema": "griptape-nuke-runner/1.0",
+  "schema": "griptape-nuke-runner/1.1",
   "script": "/path/to/my_comp.nk",
   "frame_range": [1001, 1001],
   "inputs": {
@@ -101,34 +101,14 @@ def test_bake_output_path_defaults_empty() -> None:
     assert restored.bake_output_path == ""
 
 
-def test_manifest_output_path_accepts_list() -> None:
-    output = ManifestOutput(path=["/tmp/f.0001.exr", "/tmp/f.0002.exr"], node="Write1", type="ImageSequenceArtifact")
-    assert isinstance(output.path, list)
-    assert output.path == ["/tmp/f.0001.exr", "/tmp/f.0002.exr"]
-
-
-def test_manifest_output_list_path_round_trips_json() -> None:
+def test_manifest_output_sequence_pattern_path_round_trips() -> None:
     m = JobManifest(
         script="/tmp/test.nk",
-        outputs={
-            "frames": ManifestOutput(
-                path=["/tmp/f.0001.exr", "/tmp/f.0002.exr"],
-                node="Write1",
-                type="ImageSequenceArtifact",
-            )
-        },
+        outputs={"frames": ManifestOutput(path="/out/frame_####.png", node="Write1", type="ImageSequenceArtifact")},
     )
     restored = JobManifest.from_json(m.to_json())
-    assert restored.outputs["frames"].path == ["/tmp/f.0001.exr", "/tmp/f.0002.exr"]
-
-
-def test_manifest_output_list_path_normalises_backslashes() -> None:
-    output = ManifestOutput(
-        path=["C:\\tmp\\f.0001.exr", "C:\\tmp\\f.0002.exr"],
-        node="Write1",
-        type="ImageSequenceArtifact",
-    )
-    assert output.path == ["C:/tmp/f.0001.exr", "C:/tmp/f.0002.exr"]
+    assert restored.outputs["frames"].path == "/out/frame_####.png"
+    assert restored.outputs["frames"].type == "ImageSequenceArtifact"
 
 
 def test_manifest_output_str_path_normalisation_unchanged() -> None:

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -379,6 +379,23 @@ class TestRefreshDynamicPorts:
         assert created["frames"].type == "Sequence"
         assert created["frames"].output_type == "Sequence"
 
+    def test_image_sequence_artifact_backward_compat_port_is_sequence_type(self, tmp_path: Path) -> None:
+        from script_parser.annotation import GriptapeAnnotation
+
+        nk_file = tmp_path / "compat.nk"
+        nk_file.write_text("")
+        (tmp_path / "compat.gt.json").write_text("{}")
+        ann = GriptapeAnnotation(node_name="Write1", role="output", gt_name="frames", gt_type="ImageSequenceArtifact")
+
+        node = _make_node()
+        with patch("nuke_nodes.nuke_script_node.read_sidecar", return_value=([ann], [], False)):
+            node._refresh_dynamic_ports(str(nk_file))
+
+        created = {c.args[0].name: c.args[0] for c in node.add_parameter.call_args_list}
+        assert "frames" in created
+        assert created["frames"].type == "Sequence"
+        assert created["frames"].output_type == "Sequence"
+
     def test_input_port_includes_sequence_in_input_types(self, tmp_path: Path) -> None:
         from script_parser.annotation import GriptapeAnnotation
 
@@ -694,7 +711,6 @@ class TestProcess:
         with (
             patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
-            patch("nuke_nodes.nuke_script_node.os.makedirs"),
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
             MockGT.handle_request.side_effect = _handle_request
@@ -703,6 +719,11 @@ class TestProcess:
             instance.result.return_value = fake_result
 
             node.process()
+
+        from griptape_nodes.retained_mode.events.os_events import MakeDirectoryRequest
+
+        mkdir_calls = [c for c in MockGT.handle_request.call_args_list if isinstance(c.args[0], MakeDirectoryRequest)]
+        assert len(mkdir_calls) == 1
 
         output_val = node.parameter_output_values.__setitem__.call_args[0][1]
         assert isinstance(output_val, GtSequence)

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -57,49 +57,6 @@ class TestPathToArtifact:
         assert isinstance(result, VideoUrlArtifact)
         assert result.value == "http://static/clip.mp4"
 
-    def test_image_sequence_artifact_returns_list_artifact(self, tmp_path: Path) -> None:
-        f1 = tmp_path / "frame.0001.png"
-        f2 = tmp_path / "frame.0002.png"
-        f1.write_bytes(b"\x89PNG")
-        f2.write_bytes(b"\x89PNG")
-
-        saved1, saved2 = MagicMock(), MagicMock()
-        saved1.location = "http://s/f1.png"
-        saved2.location = "http://s/f2.png"
-        dest1, dest2 = MagicMock(), MagicMock()
-        dest1.write_bytes.return_value = saved1
-        dest2.write_bytes.return_value = saved2
-        mock_dest_cls = MagicMock()
-        mock_dest_cls.from_situation.side_effect = [dest1, dest2]
-
-        mock_file = MagicMock()
-        mock_file.read_bytes.return_value = b"\x89PNG"
-
-        with (
-            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
-            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
-        ):
-            result = _path_to_artifact("ImageSequenceArtifact", [str(f1), str(f2)])
-
-        from griptape.artifacts import ImageUrlArtifact, ListArtifact
-
-        assert isinstance(result, ListArtifact)
-        assert len(result.value) == 2
-        assert all(isinstance(item, ImageUrlArtifact) for item in result.value)
-
-    def test_image_sequence_artifact_empty_list_returns_empty_list_artifact(self) -> None:
-        with patch("nuke_nodes.nuke_script_node.GriptapeNodes"):
-            result = _path_to_artifact("ImageSequenceArtifact", [])
-
-        from griptape.artifacts import ListArtifact
-
-        assert isinstance(result, ListArtifact)
-        assert len(result.value) == 0
-
-    def test_image_sequence_artifact_raises_type_error_for_str_path(self) -> None:
-        with pytest.raises(TypeError, match="ImageSequenceArtifact"):
-            _path_to_artifact("ImageSequenceArtifact", "/tmp/frame.%04d.png")
-
     def test_image_artifact_unchanged(self, tmp_path: Path) -> None:
         img_file = tmp_path / "out.png"
         img_file.write_bytes(b"\x89PNG")
@@ -254,6 +211,29 @@ class TestArtifactToPath:
         result = node._artifact_to_path(artifact)
         assert result == "/local/clip.mp4"
 
+    def test_sequence_constructs_hash_pattern_path(self) -> None:
+        try:
+            from griptape_nodes.common.sequences import MissingItemPolicy  # type: ignore  # noqa: PLC0415, I001
+            from griptape_nodes.common.sequences import Sequence as GtSequence  # type: ignore  # noqa: PLC0415, I001
+        except ImportError:
+            pytest.skip("griptape_nodes.common.sequences not available in this engine version")
+
+        seq = GtSequence(
+            entries=[],
+            first=1001,
+            last=1002,
+            discovered_first=1001,
+            discovered_last=1002,
+            padding=4,
+            pattern="frame_####.png",
+            directory="/out/frames",
+            policy=MissingItemPolicy.SPLIT,
+            present_numbers={1001, 1002},
+        )
+        node = _make_node()
+        result = node._artifact_to_path(seq)
+        assert result == "/out/frames/frame_####.png"
+
 
 class TestCoerceKnobValue:
     def test_integer_string(self) -> None:
@@ -342,6 +322,39 @@ class TestRefreshDynamicPorts:
         node._refresh_dynamic_ports(str(nk_fixture))
         # No dynamic ports should be registered
         assert node._dynamic_param_names == []
+
+    def test_image_sequence_output_port_is_sequence_type(self, tmp_path: Path) -> None:
+        from script_parser.annotation import GriptapeAnnotation
+
+        nk_file = tmp_path / "seq.nk"
+        nk_file.write_text("")
+        (tmp_path / "seq.gt.json").write_text("{}")
+        ann = GriptapeAnnotation(node_name="Write1", role="output", gt_name="frames", gt_type="ImageSequenceArtifact")
+
+        node = _make_node()
+        with patch("nuke_nodes.nuke_script_node.read_sidecar", return_value=([ann], [], False)):
+            node._refresh_dynamic_ports(str(nk_file))
+
+        created = {c.args[0].name: c.args[0] for c in node.add_parameter.call_args_list}
+        assert "frames" in created
+        assert created["frames"].type == "Sequence"
+        assert created["frames"].output_type == "Sequence"
+
+    def test_input_port_includes_sequence_in_input_types(self, tmp_path: Path) -> None:
+        from script_parser.annotation import GriptapeAnnotation
+
+        nk_file = tmp_path / "seq_in.nk"
+        nk_file.write_text("")
+        (tmp_path / "seq_in.gt.json").write_text("{}")
+        ann = GriptapeAnnotation(node_name="Read1", role="input", gt_name="src", gt_type="ImageArtifact")
+
+        node = _make_node()
+        with patch("nuke_nodes.nuke_script_node.read_sidecar", return_value=([ann], [], False)):
+            node._refresh_dynamic_ports(str(nk_file))
+
+        created = {c.args[0].name: c.args[0] for c in node.add_parameter.call_args_list}
+        assert "src" in created
+        assert "Sequence" in created["src"].input_types
 
 
 class TestEnsureAnnotations:
@@ -573,18 +586,19 @@ class TestProcess:
         assert "1" in call_kwargs["result_details"]
         node._handle_failure_exception.assert_called_once()
 
-    def test_sequence_output_produces_list_artifact(self, tmp_path: Path) -> None:
+    def test_sequence_output_produces_sequence_object(self, tmp_path: Path) -> None:
+        try:
+            from griptape_nodes.common.sequences import MissingItemPolicy  # type: ignore  # noqa: PLC0415, I001
+            from griptape_nodes.common.sequences import Sequence as GtSequence  # type: ignore  # noqa: PLC0415, I001
+            from griptape_nodes.retained_mode.events.os_events import ScanSequencesResultSuccess  # type: ignore  # noqa: PLC0415, I001
+        except (ImportError, AttributeError):
+            pytest.skip("Sequence API not available in this engine version")
+
         from execution.provider import JobResult, JobStatus
         from script_parser.annotation import GriptapeAnnotation
 
         nk_file = tmp_path / "test.nk"
         nk_file.write_text("")
-
-        # Create fake frame files
-        f1 = tmp_path / "frame.0001.png"
-        f2 = tmp_path / "frame.0002.png"
-        f1.write_bytes(b"\x89PNG")
-        f2.write_bytes(b"\x89PNG")
 
         node = _make_node()
         node._annotations = [
@@ -592,6 +606,7 @@ class TestProcess:
         ]
         node._expose_knobs = []
 
+        seq_path = str(tmp_path / "frame_####.png")
         node.get_parameter_value = MagicMock(
             side_effect=lambda name: {
                 "script_path": str(nk_file),
@@ -606,45 +621,46 @@ class TestProcess:
             status=JobStatus.SUCCEEDED,
             return_code=0,
             log=[],
-            outputs={"frames": [str(f1), str(f2)]},
+            outputs={"frames": seq_path},
         )
 
-        saved1, saved2 = MagicMock(), MagicMock()
-        saved1.location = "http://s/f1.png"
-        saved2.location = "http://s/f2.png"
-        # seq_dest: used by process() to resolve the sequence directory
+        fake_sequence = GtSequence(
+            entries=[],
+            first=1001,
+            last=1002,
+            discovered_first=1001,
+            discovered_last=1002,
+            padding=4,
+            pattern="frame_####.png",
+            directory=str(tmp_path),
+            policy=MissingItemPolicy.SPLIT,
+            present_numbers={1001, 1002},
+        )
+        scan_success = MagicMock(spec=ScanSequencesResultSuccess)
+        scan_success.sequences = [fake_sequence]
+
         seq_dest = MagicMock()
-        seq_dest.resolve.return_value = "/fake/temp/frames_frame.png"
-        dest1, dest2 = MagicMock(), MagicMock()
-        dest1.write_bytes.return_value = saved1
-        dest2.write_bytes.return_value = saved2
+        seq_dest.resolve.return_value = seq_path
         mock_dest_cls = MagicMock()
-        mock_dest_cls.from_situation.side_effect = [seq_dest, dest1, dest2]
-        mock_file = MagicMock()
-        mock_file.read_bytes.return_value = b"\x89PNG"
+        mock_dest_cls.from_situation.return_value = seq_dest
 
         with (
             patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
-            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
             patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
+            patch("nuke_nodes.nuke_script_node.os.makedirs"),
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
-            # final_file_path for the .empty sentinel — seq_dir is derived from its parent
-            write_result = MagicMock(spec=WriteFileResultSuccess)
-            write_result.final_file_path = "/fake/temp/.empty"
-            MockGT.handle_request.return_value = write_result
+            MockGT.handle_request.return_value = scan_success
             instance = MockProvider.return_value
             instance.submit.return_value = "handle-seq"
             instance.result.return_value = fake_result
 
             node.process()
 
-        from griptape.artifacts import ListArtifact
-
         output_val = node.parameter_output_values.__setitem__.call_args[0][1]
-        assert isinstance(output_val, ListArtifact)
-        assert len(output_val.value) == 2
+        assert isinstance(output_val, GtSequence)
+        assert output_val.pattern == "frame_####.png"
 
     def test_applies_zero_float_knob_override(self, tmp_path: Path) -> None:
         from execution.provider import JobResult, JobStatus

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -329,7 +329,7 @@ class TestRefreshDynamicPorts:
         nk_file = tmp_path / "seq.nk"
         nk_file.write_text("")
         (tmp_path / "seq.gt.json").write_text("{}")
-        ann = GriptapeAnnotation(node_name="Write1", role="output", gt_name="frames", gt_type="ImageSequenceArtifact")
+        ann = GriptapeAnnotation(node_name="Write1", role="output", gt_name="frames", gt_type="Sequence")
 
         node = _make_node()
         with patch("nuke_nodes.nuke_script_node.read_sidecar", return_value=([ann], [], False)):
@@ -607,7 +607,7 @@ class TestProcess:
 
         node = _make_node()
         node._annotations = [
-            GriptapeAnnotation(node_name="Write1", role="output", gt_name="frames", gt_type="ImageSequenceArtifact")
+            GriptapeAnnotation(node_name="Write1", role="output", gt_name="frames", gt_type="Sequence")
         ]
         node._expose_knobs = []
 

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -75,6 +75,45 @@ class TestPathToArtifact:
 
         assert isinstance(result, ImageUrlArtifact)
 
+    def test_three_d_artifact_glb_path_produces_artifact(self, tmp_path: Path) -> None:
+        glb_file = tmp_path / "model.glb"
+        glb_file.write_bytes(b"glTF")
+
+        mock_dest_cls = _mock_project_file_destination("http://static/model.glb")
+        mock_file = MagicMock()
+        mock_file.read_bytes.return_value = b"glTF"
+
+        with (
+            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
+        ):
+            result = _path_to_artifact("ThreeDUrlArtifact", str(glb_file))
+
+        assert result is not None
+
+    def test_three_d_artifact_gltf_path_produces_artifact(self, tmp_path: Path) -> None:
+        gltf_file = tmp_path / "model.gltf"
+        gltf_file.write_bytes(b"{}")
+
+        mock_dest_cls = _mock_project_file_destination("http://static/model.gltf")
+        mock_file = MagicMock()
+        mock_file.read_bytes.return_value = b"{}"
+
+        with (
+            patch("nuke_nodes.nuke_script_node.File", return_value=mock_file),
+            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
+        ):
+            result = _path_to_artifact("GLTFUrlArtifact", str(gltf_file))
+
+        assert result is not None
+
+    def test_three_d_artifact_non_glb_raises_value_error(self, tmp_path: Path) -> None:
+        obj_file = tmp_path / "model.obj"
+        obj_file.write_bytes(b"v 0 0 0")
+
+        with pytest.raises(ValueError, match=r"\.obj"):
+            _path_to_artifact("ThreeDUrlArtifact", str(obj_file))
+
 
 def _mock_artifact_to_path_dest(resolved_path: str = "/fake/temp/input.mp4") -> MagicMock:
     dest = MagicMock()

--- a/tests/unit/test_nuke_script_node.py
+++ b/tests/unit/test_nuke_script_node.py
@@ -594,6 +594,11 @@ class TestProcess:
         except (ImportError, AttributeError):
             pytest.skip("Sequence API not available in this engine version")
 
+        from griptape_nodes.retained_mode.events.project_events import (
+            GetPathForMacroRequest,
+            GetPathForMacroResultSuccess,
+        )
+
         from execution.provider import JobResult, JobStatus
         from script_parser.annotation import GriptapeAnnotation
 
@@ -606,7 +611,6 @@ class TestProcess:
         ]
         node._expose_knobs = []
 
-        seq_path = str(tmp_path / "frame_####.png")
         node.get_parameter_value = MagicMock(
             side_effect=lambda name: {
                 "script_path": str(nk_file),
@@ -615,6 +619,10 @@ class TestProcess:
                 "frame_end": 1002,
             }.get(name)
         )
+
+        macro_success = MagicMock(spec=GetPathForMacroResultSuccess)
+        macro_success.absolute_path = tmp_path / "NukeScriptNode1" / "frames" / "frame_####.png"
+        seq_path = str(macro_success.absolute_path).replace("\\", "/")
 
         fake_result = JobResult(
             handle="handle-seq",
@@ -639,19 +647,18 @@ class TestProcess:
         scan_success = MagicMock(spec=ScanSequencesResultSuccess)
         scan_success.sequences = [fake_sequence]
 
-        seq_dest = MagicMock()
-        seq_dest.resolve.return_value = seq_path
-        mock_dest_cls = MagicMock()
-        mock_dest_cls.from_situation.return_value = seq_dest
+        def _handle_request(req: object) -> object:
+            if isinstance(req, GetPathForMacroRequest):
+                return macro_success
+            return scan_success
 
         with (
             patch("nuke_nodes.nuke_script_node.DirectSubprocessProvider") as MockProvider,
             patch("nuke_nodes.nuke_script_node.GriptapeNodes") as MockGT,
-            patch("nuke_nodes.nuke_script_node.ProjectFileDestination", mock_dest_cls),
             patch("nuke_nodes.nuke_script_node.os.makedirs"),
         ):
             MockGT.ConfigManager.return_value.get_config_value.return_value = None
-            MockGT.handle_request.return_value = scan_success
+            MockGT.handle_request.side_effect = _handle_request
             instance = MockProvider.return_value
             instance.submit.return_value = "handle-seq"
             instance.result.return_value = fake_result

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -50,10 +50,10 @@ class TestExecuteTypes:
 
         assert "VideoUrlArtifact" in _EXECUTE_TYPES
 
-    def test_contains_image_sequence_artifact(self) -> None:
+    def test_contains_sequence(self) -> None:
         from nuke_runner.runner import _EXECUTE_TYPES
 
-        assert "ImageSequenceArtifact" in _EXECUTE_TYPES
+        assert "Sequence" in _EXECUTE_TYPES
 
     def test_contains_image_artifact(self) -> None:
         from nuke_runner.runner import _EXECUTE_TYPES
@@ -97,14 +97,14 @@ class TestNonExecutableArtifactSkipped:
         _nuke.execute.assert_not_called()
 
 
-class TestImageSequenceArtifactOutput:
+class TestSequenceOutput:
     def test_writes_pattern_path_for_sequence(self, tmp_path: Path) -> None:
         seq_dir = tmp_path / "seq"
         seq_dir.mkdir()
         pattern = str(seq_dir / "frame_####.png")
 
         manifest = _base_manifest(
-            outputs={"frames": {"path": pattern, "node": "Write1", "type": "ImageSequenceArtifact"}}
+            outputs={"frames": {"path": pattern, "node": "Write1", "type": "Sequence"}}
         )
 
         _nuke.scriptOpen = MagicMock()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -103,9 +103,7 @@ class TestSequenceOutput:
         seq_dir.mkdir()
         pattern = str(seq_dir / "frame_####.png")
 
-        manifest = _base_manifest(
-            outputs={"frames": {"path": pattern, "node": "Write1", "type": "Sequence"}}
-        )
+        manifest = _base_manifest(outputs={"frames": {"path": pattern, "node": "Write1", "type": "Sequence"}})
 
         _nuke.scriptOpen = MagicMock()
         _nuke.root.return_value = MagicMock()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -33,7 +33,7 @@ def _run_main(manifest: dict, tmp_path: Path) -> dict:
 
 def _base_manifest(outputs: dict | None = None) -> dict:
     return {
-        "schema": "griptape-nuke-runner/1.0",
+        "schema": "griptape-nuke-runner/1.1",
         "script": "/fake/comp.nk",
         "frame_range": [1001, 1001],
         "inputs": {},
@@ -98,14 +98,10 @@ class TestNonExecutableArtifactSkipped:
 
 
 class TestImageSequenceArtifactOutput:
-    def test_globs_rendered_frames_and_writes_list(self, tmp_path: Path) -> None:
+    def test_writes_pattern_path_for_sequence(self, tmp_path: Path) -> None:
         seq_dir = tmp_path / "seq"
         seq_dir.mkdir()
-        pattern = str(seq_dir / "frame.%04d.png")
-
-        # Create fake rendered frame files
-        (seq_dir / "frame.1001.png").write_bytes(b"\x89PNG")
-        (seq_dir / "frame.1002.png").write_bytes(b"\x89PNG")
+        pattern = str(seq_dir / "frame_####.png")
 
         manifest = _base_manifest(
             outputs={"frames": {"path": pattern, "node": "Write1", "type": "ImageSequenceArtifact"}}
@@ -118,27 +114,4 @@ class TestImageSequenceArtifactOutput:
         _nuke.execute = MagicMock()
 
         result = _run_main(manifest, tmp_path)
-        frames = result["outputs"]["frames"]
-        assert isinstance(frames, list)
-        assert len(frames) == 2
-        assert all("frame." in p for p in frames)
-
-    def test_empty_glob_writes_empty_list(self, tmp_path: Path) -> None:
-        seq_dir = tmp_path / "emptyseq"
-        seq_dir.mkdir()
-        pattern = str(seq_dir / "frame.%04d.png")
-
-        manifest = _base_manifest(
-            outputs={"frames": {"path": pattern, "node": "Write1", "type": "ImageSequenceArtifact"}}
-        )
-
-        _nuke.scriptOpen = MagicMock()
-        _nuke.root.return_value = MagicMock()
-        _nuke.root.return_value.__getitem__ = MagicMock(return_value=MagicMock())
-        _nuke.toNode.return_value = MagicMock()
-        _nuke.execute = MagicMock()
-
-        result = _run_main(manifest, tmp_path)
-        frames = result["outputs"]["frames"]
-        assert isinstance(frames, list)
-        assert frames == []
+        assert result["outputs"]["frames"] == pattern.replace("\\", "/")

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -52,12 +64,56 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
 name = "binaryornot"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/4755b85101f37707c71526a301c1203e413c715a0016ecb592de3d2dcfff/binaryornot-0.6.0.tar.gz", hash = "sha256:cc8d57cfa71d74ff8c28a7726734d53a851d02fad9e3a5581fb807f989f702f0", size = 478718, upload-time = "2026-03-08T16:26:28.804Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/0c/31cfaa6b56fe23488ecb993bc9fc526c0d84d89607decdf2a10776426c2e/binaryornot-0.6.0-py3-none-any.whl", hash = "sha256:900adfd5e1b821255ba7e63139b0396b14c88b9286e74e03b6f51e0200331337", size = 14185, upload-time = "2026-03-08T16:26:27.466Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -200,12 +256,46 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -225,12 +315,49 @@ wheels = [
 ]
 
 [[package]]
+name = "fastmcp-slim"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "starlette" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "fileseq"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/9f/211f4c1a07706dfd8ac92c64b17f2531891613019508bc5a59300a40ea56/fileseq-3.3.0.tar.gz", hash = "sha256:e4b2d44c218863fb913fbe8abd6adce5f7c3b88be42f016270b2c9525094bda0", size = 2176275, upload-time = "2026-07-05T03:35:33.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/18/b429fd820c432a65ab3ae176cd32ddc29d0de532dfa762e5a71563ef848c/fileseq-3.3.0-py3-none-any.whl", hash = "sha256:433e84b410381405e7fc06c559847e0cb05dd5f267fbc41ab06b491ecfddbdac", size = 205858, upload-time = "2026-07-05T03:35:31.752Z" },
 ]
 
 [[package]]
@@ -252,8 +379,30 @@ wheels = [
 ]
 
 [[package]]
+name = "genai-prices"
+version = "0.0.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/5072862613fba039da2b7c981a8649c6c6bbcb2863bd8bc81617c09ce5ee/genai_prices-0.0.71.tar.gz", hash = "sha256:de4db34ec38404f9ef383cb1ab29e204d16ccf27071af0b16d5747ee7affe36b", size = 82105, upload-time = "2026-07-10T00:38:30.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/98/c06c1318f6834a26268a2d4280e4183f60c5ea92152aea841feff29826ff/genai_prices-0.0.71-py3-none-any.whl", hash = "sha256:1d13111563af2b1ce43ccfacf77b7ac3216ad704c644408a56e11b181fe0d128", size = 84586, upload-time = "2026-07-10T00:38:29.252Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
 name = "griptape"
-version = "1.10.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -275,14 +424,32 @@ dependencies = [
     { name = "urllib3" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/ba/987550a6746c3678c0b9e194e8795ed504d9d157d9848e788f60f5120192/griptape-1.10.0.tar.gz", hash = "sha256:86ede22e958ba7bc3896114ba6eb58b91e2cd28cda605d916d47570384604bdc", size = 192727, upload-time = "2026-04-20T20:01:32.04Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/34/a8f35184cac59a423fe5bf095e35c28b55c9a6f9069581913f4c600d8c47/griptape-1.11.0.tar.gz", hash = "sha256:0c79907a1a612d58055214b0251328af4561cb9d4d98359c3b271a1d10b285a6", size = 195204, upload-time = "2026-07-14T19:27:40.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/26/ff303840c19d0f0c50313ee74a79a6e2736e7a919703cf440b2394930e41/griptape-1.10.0-py3-none-any.whl", hash = "sha256:3c4d40f80205497700311e38cdcf57cb81d4b8acf80971d4095eedd0a9df9f7d", size = 428096, upload-time = "2026-04-20T20:01:33.631Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9a/b53d09b3d6e1fda9a040c507439bfd4db38f9b1729ddc8a0864e1df9f2e6/griptape-1.11.0-py3-none-any.whl", hash = "sha256:aec75a567a77c99661f9c756d2cbb22e366becfd25f1446b8388968d64a95da8", size = 432148, upload-time = "2026-07-14T19:27:38.333Z" },
 ]
 
 [[package]]
 name = "griptape-nodes"
-version = "0.81.0"
+version = "0.93.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griptape-nodes-engine" },
+    { name = "websockets" },
+    { name = "xdg-base-dirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/4a/dc51722e591173c36f1558e194b8bb1c9943e84c2dc6704fb90e79f6435c/griptape_nodes-0.93.0.tar.gz", hash = "sha256:dddfca94bd477f72fcab853e3b19b828ae71f1d01a61558e2e9b3036359f3391", size = 505557, upload-time = "2026-07-17T00:08:55.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/4c/003b101f2f862d3ed8b37743fc81dcb142c34ad43d380fd593b94b8b37ed/griptape_nodes-0.93.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:171a8aa830abe6ff5999e882f6b065a1492c9dabb8aae2326a6f9a9e1f3917c9", size = 7289576, upload-time = "2026-07-17T00:08:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/98/64/6333d62a4f4cb9d9caac07b6f7c2769389ae59a9df39116ae07371be7ef7/griptape_nodes-0.93.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dc2dca6cda2d5af8754fad4543353a4421cdeb4c22c88a26295bdf308758112c", size = 7192720, upload-time = "2026-07-17T00:08:46.134Z" },
+    { url = "https://files.pythonhosted.org/packages/51/bc/36df8f6ddd8af5c39c0d06377e376b7e531b6695cf09f3dcf4bb22758506/griptape_nodes-0.93.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a2ddcb65742fd063f2394ffda0a800f25d98f77003568e717dc95271577201d5", size = 10592286, upload-time = "2026-07-17T00:08:48.59Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b1/7dca0873ebac99dba23d5572eb3d3a55e2ddb14b1789bb1e65010a60ab2c/griptape_nodes-0.93.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6a798c48eefe58775a9f70eb48e1f4f5dab65ec069bad70c3e02f286761bc91", size = 10115369, upload-time = "2026-07-17T00:08:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/6b/6421439512478066819df48d786135de629f7d08a7949d861422a48a2174/griptape_nodes-0.93.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f1538d1c8fc4389e14baa6c58a0b9170f9ffd4090b8a5a95ad7b1e4b65403c4", size = 6659671, upload-time = "2026-07-17T00:08:54.094Z" },
+]
+
+[[package]]
+name = "griptape-nodes-engine"
+version = "0.94.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -290,6 +457,7 @@ dependencies = [
     { name = "binaryornot" },
     { name = "cattrs" },
     { name = "fastapi" },
+    { name = "fileseq" },
     { name = "griptape" },
     { name = "httpx" },
     { name = "huggingface-hub" },
@@ -299,6 +467,8 @@ dependencies = [
     { name = "pillow" },
     { name = "portalocker" },
     { name = "pydantic" },
+    { name = "pydantic-ai-skills" },
+    { name = "pydantic-ai-slim", extra = ["mcp", "openai"] },
     { name = "pygit2" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -317,9 +487,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/41/0e8e2304b0ed2d99f4f1bb43670f41ee496e8ca7ff6a49ce48d2deaa6fda/griptape_nodes-0.81.0.tar.gz", hash = "sha256:ec205ea8188b71ac59c106fe18e8701bdc86cf313b06e566493ee349e18c0121", size = 732741, upload-time = "2026-04-22T19:21:39.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/91/21bcb987617682655c0b44a84b63040d451f2cce0d801213dd47c0205ab0/griptape_nodes_engine-0.94.3.tar.gz", hash = "sha256:32610d237c20998ff2042cf1eb502bee001a1df23fe3e7bd7eb3e9b98404c4f1", size = 1072023, upload-time = "2026-07-17T20:09:03.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/ba/f00616d61310da818d5731e7ef8fe1a644c60dfe373f1a10f4c6dcdd4759/griptape_nodes-0.81.0-py3-none-any.whl", hash = "sha256:0f3fda12b8b423083ec6d0a38854229605f6270550ba87a946c1c5f2d1062b31", size = 941245, upload-time = "2026-04-22T19:21:41.19Z" },
+    { url = "https://files.pythonhosted.org/packages/04/26/35cff620173985865a6f0930c816158d2b085e448be2e68ad34bf94ad5fb/griptape_nodes_engine-0.94.3-py3-none-any.whl", hash = "sha256:3e07942a7233865a519c6aa076b0ee8ca489b5dba9b95e7f7545dc9519a3b8b8", size = 1312262, upload-time = "2026-07-17T20:09:02.073Z" },
 ]
 
 [[package]]
@@ -339,7 +509,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "griptape-nodes", specifier = ">=0.81.0" }]
+requires-dist = [{ name = "griptape-nodes", specifier = ">=0.93.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -388,6 +558,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/34/18f1c596e677962f040284246f393b10a1f8ce440b3a7e69c637d0f1c7ad/httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924", size = 64300, upload-time = "2026-06-01T13:15:02.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl", hash = "sha256:477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415", size = 80024, upload-time = "2026-06-01T13:15:00.001Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +592,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/9a/cca0b9145f13d8ae34b885ae28d403a1469a433abc78e0f94f4ce94e650b/httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9", size = 81115, upload-time = "2026-06-01T13:15:04.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl", hash = "sha256:6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7", size = 74538, upload-time = "2026-06-01T13:15:01.566Z" },
 ]
 
 [[package]]
@@ -541,6 +739,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
+]
+
+[[package]]
 name = "json-repair"
 version = "0.58.6"
 source = { registry = "https://pypi.org/simple" }
@@ -603,6 +813,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "logfire-api"
+version = "4.38.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/1a/17af258260cf8378fabd10bacef0c585e19697eab1deea25f8e4f4fb6462/logfire_api-4.38.0.tar.gz", hash = "sha256:e773cd4a26edb48ef4ec6f88661d1c670bb68c303a71c7043a236d64a9699cd2", size = 90364, upload-time = "2026-07-20T12:15:34.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/22/598f988f293ce391e88baddeeaa1acaea625822653193935301e7149b5c6/logfire_api-4.38.0-py3-none-any.whl", hash = "sha256:6c0612d9200727b64b42eba6068d0d6afd45308f4b844ffd6290c2d33aa6a6f6", size = 140109, upload-time = "2026-07-20T12:15:31.973Z" },
 ]
 
 [[package]]
@@ -762,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.28.0"
+version = "2.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -774,9 +993,21 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/87/eb0abb4ef88ddb95b3c13149384c4c288f584f3be17d6a4f63f8c3e3c226/openai-2.28.0.tar.gz", hash = "sha256:bb7fdff384d2a787fa82e8822d1dd3c02e8cf901d60f1df523b7da03cbb6d48d", size = 670334, upload-time = "2026-03-13T19:56:27.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/5a/df122348638885526e53140e9c6b0d844af7312682b3bde9587eebc28b47/openai-2.28.0-py3-none-any.whl", hash = "sha256:79aa5c45dba7fef84085701c235cf13ba88485e1ef4f8dfcedc44fc2a698fc1d", size = 1141218, upload-time = "2026-03-13T19:56:25.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -817,6 +1048,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -847,6 +1087,31 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -868,6 +1133,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
+[[package]]
+name = "pydantic-ai-skills"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "pydantic-ai-slim" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/90/5f20728badc7d17ca0e81f24dc35a96c02f008323dce393d0e70a8465144/pydantic_ai_skills-1.2.0.tar.gz", hash = "sha256:e52f7e8243343dfa94206aae11cd142120edb8990fc392b1d8af32f99b6d351e", size = 9031839, upload-time = "2026-07-15T02:37:26.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/74/143ca60dd9bfa11ce0349ee58bbdd646798c8bdc031588d67a8bea96797d/pydantic_ai_skills-1.2.0-py3-none-any.whl", hash = "sha256:7ff4eb4b307deb6ef3bf31a6d9493c1e3a8e9b866a13b866a9ea4606bd914206", size = 63883, upload-time = "2026-07-15T02:37:24.117Z" },
+]
+
+[[package]]
+name = "pydantic-ai-slim"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-graph" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/cc/aeaef08962f86e4ad76f8f741138590fe9415b3e5085193dbcc621f76518/pydantic_ai_slim-2.13.0.tar.gz", hash = "sha256:3d5f4e5012dc0a4b0e9f76268ce8afd734191b48dbccbf221ac7d030d9e8fcae", size = 839266, upload-time = "2026-07-18T02:55:47.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/4e/24f932dfe7c29c23fc875c774acfae4330218362705faa9f590f43ef40da/pydantic_ai_slim-2.13.0-py3-none-any.whl", hash = "sha256:b56b4bf2d5bfcadc0f83a5da16c750b013a2d79cebc2170501ed82435acf39f1", size = 1019269, upload-time = "2026-07-18T02:55:40.017Z" },
+]
+
+[package.optional-dependencies]
+mcp = [
+    { name = "fastmcp-slim", extra = ["client"] },
+]
+openai = [
+    { name = "openai" },
+    { name = "tiktoken" },
 ]
 
 [[package]]
@@ -897,6 +1208,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
     { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
     { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+]
+
+[[package]]
+name = "pydantic-graph"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "logfire-api" },
+    { name = "pydantic" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/94/ff70ba2c05dddb4c503c6adae5e3f019b01b896e44805bda3b8f84feadfb/pydantic_graph-2.13.0.tar.gz", hash = "sha256:0b77975fef41c993744d06f6e56c49afdbfedb23e8984fe46b2f962dcf90f556", size = 43939, upload-time = "2026-07-18T02:55:49.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/87/c70957d6c519d1cb7375ffdcbe7bf28cf755a2efbf53863c9c4595c91e8e/pydantic_graph-2.13.0-py3-none-any.whl", hash = "sha256:65c51707c36fcc146d2d4130ed26c3186803419b126f72709b77181d0bb0e82e", size = 51656, upload-time = "2026-07-18T02:55:43.041Z" },
 ]
 
 [[package]]
@@ -1285,15 +1611,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Migrates image sequence output handling from the custom `ImageSequenceArtifact` type to the engine-native `Sequence` type introduced in griptape-nodes 0.93.0. The runner no longer globs frames itself — it writes the Nuke pattern path into the output manifest and the host uses `ScanSequencesRequest` to produce a `Sequence` object directly.
- Removes the `trimesh` dependency entirely. 3D outputs now require the Nuke Write node to export GLB/GLTF directly; a clear `ValueError` is raised if a non-GLB path is returned.
- Bumps the minimum engine version to 0.93.0 and the manifest schema to `1.1`.

## Changes

**Core migration (`ImageSequenceArtifact` → `Sequence`)**
- `nuke_script_node.py`: output paths for sequences are resolved via `GetPathForMacroRequest` (engine-managed location) and the directory is created with `MakeDirectoryRequest`. After the Nuke run, `ScanSequencesRequest` scans the pattern path and produces the `Sequence` object for the output port. Backward compat: sidecars annotated with `ImageSequenceArtifact` before engine 0.93 are accepted and produce `Sequence` ports.
- `nuke_runner/runner.py`: drops `glob`/`re`; just writes the pattern path through to the output manifest.
- `nuke_runner/manifest.py`: `ManifestOutput.path` simplified from `str | list[str]` to `str`; schema bumped to `1.1`.
- `nuke_plugin/griptape_annotator_panel.py`: `ImageSequenceArtifact` → `Sequence` in the output type list.
- `execution/provider.py`, `execution/direct.py`: output map simplified from `dict[str, str | list[str]]` to `dict[str, str]`.

**Dependency cleanup**
- `trimesh` removed from `pyproject.toml` and `griptape-nodes-library.json`.

## Test plan

- [ ] `uv run pytest tests/unit/` — all 196 unit tests pass
- [ ] `make check` — ruff, pyright, and JSON validation clean
- [ ] Integration: connect a `Sequence`-typed output from `NukeScriptNode` to a downstream node on the canvas and confirm the `Sequence` object flows through
- [ ] Integration: load a `.gt.json` sidecar annotated with `ImageSequenceArtifact` (pre-0.93) and confirm the port appears as `Sequence` type

Resolves #90 
