### PR TITLE
Add Linked Expressions to Nuke Gizmos

### DIFF
--- a/publish_gizmo/constants.py
+++ b/publish_gizmo/constants.py
@@ -13,6 +13,11 @@ INIT_MARKER = "# griptape-plugin-path"
 # Filename of the run-button script copied into each companion directory
 RUN_BUTTON_FILENAME = "run_button.py"
 
+# Prefix for the hidden companion knob that stores a Link button's TCL expression
+# (the visible knob shows the evaluated value). Kept in sync with the local copy
+# in the bundled tcl_utils.py, which cannot import this module at runtime.
+GT_EXPR_PREFIX = "_gt_expr_"
+
 # Regex that extracts (workflow_stem, version_int) from a versioned gizmo filename
 VERSION_RE = re.compile(r"^(.+)_v(\d+)\.gizmo$")
 

--- a/publish_gizmo/gizmo_writer.py
+++ b/publish_gizmo/gizmo_writer.py
@@ -60,6 +60,14 @@ def _tcl_escape(code: str) -> str:
     return code
 
 
+def _tcl_escape_literal(text: str) -> str:
+    """Escape a literal knob value or tooltip so TCL stores it verbatim instead of evaluating it."""
+    text = text.replace("\\", "\\\\")
+    text = text.replace('"', '\\"')
+    text = text.replace("[", "\\[")
+    return text.replace("$", "\\$")
+
+
 class GizmoWriter:
     """Builds Nuke ``.gizmo`` file content line by line.
 
@@ -125,21 +133,27 @@ class GizmoWriter:
 
     # -- Value knobs --
 
-    def add_string_knob(self, knob_name: str, label: str, default: str | None = None, flags: str = "") -> None:
+    def add_string_knob(
+        self, knob_name: str, label: str, default: str | None = None, flags: str = "", tooltip: str | None = None
+    ) -> None:
         """Add a single-line string knob."""
         self._knobs.append((NukeKnobType.STRING, knob_name))
+        tooltip_part = f' t "{_tcl_escape_literal(tooltip)}"' if tooltip else ""
         flag_suffix = f" {flags}" if flags else ""
-        self._lines.append(f' addUserKnob {{{NukeKnobType.STRING} {knob_name} l "{label}"{flag_suffix}}}')
+        self._lines.append(f' addUserKnob {{{NukeKnobType.STRING} {knob_name} l "{label}"{tooltip_part}{flag_suffix}}}')
         if default is not None:
-            self._lines.append(f' {knob_name} "{default}"')
+            self._lines.append(f' {knob_name} "{_tcl_escape_literal(default)}"')
 
-    def add_file_knob(self, knob_name: str, label: str, default: str | None = None, flags: str = "") -> None:
+    def add_file_knob(
+        self, knob_name: str, label: str, default: str | None = None, flags: str = "", tooltip: str | None = None
+    ) -> None:
         """Add a file-browser knob."""
         self._knobs.append((NukeKnobType.FILE, knob_name))
+        tooltip_part = f' t "{_tcl_escape_literal(tooltip)}"' if tooltip else ""
         flag_suffix = f" {flags}" if flags else ""
-        self._lines.append(f' addUserKnob {{{NukeKnobType.FILE} {knob_name} l "{label}"{flag_suffix}}}')
+        self._lines.append(f' addUserKnob {{{NukeKnobType.FILE} {knob_name} l "{label}"{tooltip_part}{flag_suffix}}}')
         if default is not None:
-            self._lines.append(f' {knob_name} "{default}"')
+            self._lines.append(f' {knob_name} "{_tcl_escape_literal(default)}"')
 
     def add_bool_knob(self, knob_name: str, label: str, default: bool | None = None) -> None:
         """Add a checkbox (boolean) knob."""
@@ -163,14 +177,17 @@ class GizmoWriter:
             self._lines.append(f" {knob_name} {default}")
 
     def add_multiline_string_knob(
-        self, knob_name: str, label: str, default: str | None = None, flags: str = ""
+        self, knob_name: str, label: str, default: str | None = None, flags: str = "", tooltip: str | None = None
     ) -> None:
         """Add a multi-line text knob."""
         self._knobs.append((NukeKnobType.MULTILINE_STRING, knob_name))
+        tooltip_part = f' t "{_tcl_escape_literal(tooltip)}"' if tooltip else ""
         flag_suffix = f" {flags}" if flags else ""
-        self._lines.append(f' addUserKnob {{{NukeKnobType.MULTILINE_STRING} {knob_name} l "{label}"{flag_suffix}}}')
+        self._lines.append(
+            f' addUserKnob {{{NukeKnobType.MULTILINE_STRING} {knob_name} l "{label}"{tooltip_part}{flag_suffix}}}'
+        )
         if default is not None:
-            self._lines.append(f' {knob_name} "{default}"')
+            self._lines.append(f' {knob_name} "{_tcl_escape_literal(default)}"')
 
     def add_enumeration_knob(self, knob_name: str, label: str, choices: list, default_index: int | None = None) -> None:
         """Add a dropdown enumeration knob."""
@@ -180,16 +197,19 @@ class GizmoWriter:
         if default_index is not None:
             self._lines.append(f" {knob_name} {default_index}")
 
-    def add_pyscript_knob(self, knob_name: str, label: str, python_code: str, flags: str = "+STARTLINE") -> None:
+    def add_pyscript_knob(
+        self, knob_name: str, label: str, python_code: str, flags: str = "+STARTLINE", tooltip: str | None = None
+    ) -> None:
         """Add a PyScript button knob.
 
         ``python_code`` is plain Python; this method handles TCL escaping.
         """
         self._knobs.append((NukeKnobType.PYSCRIPT, knob_name))
         escaped = _tcl_escape(python_code)
+        tooltip_part = f' t "{_tcl_escape_literal(tooltip)}"' if tooltip else ""
         flag_suffix = f" {flags}" if flags else ""
         self._lines.append(
-            f' addUserKnob {{{NukeKnobType.PYSCRIPT} {knob_name} l "{label}" T "{escaped}"{flag_suffix}}}'
+            f' addUserKnob {{{NukeKnobType.PYSCRIPT} {knob_name} l "{label}"{tooltip_part} T "{escaped}"{flag_suffix}}}'
         )
 
     def add_invisible_string_knob(self, knob_name: str, value: str | None = None) -> None:

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -187,7 +187,7 @@ if _p.show():
 
 def _build_copy_link_button_code(knob_name: str) -> str:
     """Return Python for a per-output Copy Link button: puts [value <node>.<knob>] on the clipboard."""
-    return f'''\
+    return f"""\
 _n = nuke.thisNode()
 _expr = "[value " + _n.fullName() + ".{knob_name}]"
 try:
@@ -196,7 +196,7 @@ except ImportError:
     from PySide2.QtGui import QGuiApplication
 QGuiApplication.clipboard().setText(_expr)
 nuke.tprint("[Griptape] Copied to clipboard: " + _expr)
-'''
+"""
 
 
 class NukeGizmoBuilder:

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 
-from publish_gizmo.constants import RUN_BUTTON_FILENAME, versioned_node_name
+from publish_gizmo.constants import GT_EXPR_PREFIX, RUN_BUTTON_FILENAME, versioned_node_name
 from publish_gizmo.gizmo_validator import validate_gizmo
 from publish_gizmo.gizmo_writer import GizmoWriter, NukeKnobType
 
@@ -92,10 +92,16 @@ _COPY_LINK_TOOLTIP = (
 
 
 def _output_tooltip(knob_name: str) -> str:
-    """Tooltip telling users how to reference this output from other nodes."""
+    """Tooltip telling users how to reference this output from other nodes.
+
+    ``knob_name`` already carries the ``_out`` suffix (e.g. ``caption_out``),
+    so the example expression uses that suffixed name even though the panel
+    labels the knob without it (e.g. "Caption"). This is intentional — the
+    suffixed name is exactly what the user must type in the expression.
+    """
     return (
         f"Workflow output. Reference it from any other node with a TCL expression, "
-        f"e.g. [value <this node's name>.{knob_name}]."
+        f"e.g. [value <this node's name>.{knob_name}] (note the '_out' suffix — that is the real knob name)."
     )
 
 
@@ -140,34 +146,33 @@ def _label(name: str) -> str:
     return name.replace("_", " ").title()
 
 
-def _build_knob_changed_code(has_multiple_media_outputs: bool) -> str:
+def _build_knob_changed_code() -> str:
     """Return Python code for the gizmo's knobChanged callback.
 
-    Always handles Link-expression upkeep: on rename, linked fields are
-    re-evaluated so they display the current value; manually editing a linked
-    field clears its stored expression (unlink). When the gizmo has multiple
-    media outputs, also flips the internal SwitchOutput when ``active_output``
-    changes.
+    Handles three cases: on ``active_output`` change, flip the internal
+    SwitchOutput (a no-op guarded by ``nuke.toNode`` when the gizmo has no
+    such node, e.g. a single-output gizmo); on rename, re-evaluate linked
+    fields so they display the current value; on a manual edit of a linked
+    field, clear its stored expression (unlink).
     """
-    active_output_block = """\
-if _gt_kn == "active_output":
-    _gt_n.begin()
-    try:
-        _gt_switch = nuke.toNode("SwitchOutput")
-        if _gt_switch:
-            _gt_switch["which"].setValue(int(_gt_n["active_output"].getValue()))
-    finally:
-        _gt_n.end()
-el"""
-    prefix = active_output_block if has_multiple_media_outputs else ""
+    prefix = GT_EXPR_PREFIX
+    prefix_len = len(GT_EXPR_PREFIX)
     return f"""\
 _gt_k = nuke.thisKnob()
 _gt_n = nuke.thisNode()
 _gt_kn = _gt_k.name()
-{prefix}if _gt_kn == "name":
+if _gt_kn == "active_output":
+    _gt_switch = nuke.toNode("SwitchOutput")
+    if _gt_switch:
+        _gt_n.begin()
+        try:
+            _gt_switch["which"].setValue(int(_gt_n["active_output"].getValue()))
+        finally:
+            _gt_n.end()
+elif _gt_kn == "name":
     for _gt_name in list(_gt_n.knobs()):
-        if _gt_name.startswith("_gt_expr_"):
-            _gt_target = _gt_name[9:]
+        if _gt_name.startswith("{prefix}"):
+            _gt_target = _gt_name[{prefix_len}:]
             if _gt_n[_gt_name].getText() and _gt_n.knob(_gt_target):
                 try:
                     _gt_v = _gt_n[_gt_name].evaluate()
@@ -175,8 +180,11 @@ _gt_kn = _gt_k.name()
                     _gt_v = None
                 if _gt_v:
                     _gt_n[_gt_target].setValue(_gt_v)
-elif not _gt_kn.startswith("_gt_") and _gt_n.knob("_gt_expr_" + _gt_kn):
-    _gt_ek = _gt_n["_gt_expr_" + _gt_kn]
+elif not _gt_kn.startswith("_gt_") and _gt_n.knob("{prefix}" + _gt_kn):
+    # Unlink: a manual edit clears the stored expression. Note the value-comparison
+    # tradeoff — if the user types text identical to the current evaluated value,
+    # the link is NOT cleared (values are equal). Accepted; not a bug.
+    _gt_ek = _gt_n["{prefix}" + _gt_kn]
     if _gt_ek.getText():
         try:
             _gt_cur = _gt_ek.evaluate()
@@ -209,7 +217,7 @@ if _p.show():
         if _t:
             _expr = "[value " + _t + "]"
     if _expr:
-        _ek = _n["_gt_expr_{knob_name}"]
+        _ek = _n["{GT_EXPR_PREFIX}{knob_name}"]
         _ek.setValue(_expr)
         try:
             _v = _ek.evaluate()
@@ -335,8 +343,9 @@ class NukeGizmoBuilder:
             self._write_output_knob(w, name, info)
 
         # Always present: refreshes linked fields on rename and unlinks a field
-        # the user manually edits; also drives SwitchOutput for multi-output gizmos.
-        w.set_knob_changed(_build_knob_changed_code(has_multiple_media_outputs=len(media_output_names) > 1))
+        # the user manually edits; also drives SwitchOutput for multi-output gizmos
+        # (a no-op, guarded by nuke.toNode, when there is no SwitchOutput node).
+        w.set_knob_changed(_build_knob_changed_code())
 
         w.end_gizmo_header()
 
@@ -464,7 +473,7 @@ class NukeGizmoBuilder:
             flags="-STARTLINE",
             tooltip=_LINK_BUTTON_TOOLTIP,
         )
-        w.add_invisible_string_knob(f"_gt_expr_{knob_name}")
+        w.add_invisible_string_knob(f"{GT_EXPR_PREFIX}{knob_name}")
 
     def _write_output_knob(self, w: GizmoWriter, name: str, info: dict) -> None:
         """Write a read-only knob for a workflow output parameter."""

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -82,11 +82,12 @@ _OUTPUT_DIR_TOOLTIP = (
     "Directory for workflow outputs. Supports TCL expressions, e.g. [file dirname [value root.name]]/griptape."
 )
 _LINK_BUTTON_TOOLTIP = (
-    "Set this field to a live expression: gizmo name, script folder, script name, frame, or any node.knob."
+    "Link this field to the gizmo name, script folder, script name, frame, or any node.knob. "
+    "The field shows the linked value; editing it by hand removes the link."
 )
 _COPY_LINK_TOOLTIP = (
     "Copy a [value ...] expression for this output to the clipboard. "
-    "Paste it into any text field (e.g. a Text node's message) to link it."
+    "Select another node first to expression-link one of its knobs to this output directly."
 )
 
 
@@ -139,23 +140,50 @@ def _label(name: str) -> str:
     return name.replace("_", " ").title()
 
 
-def _build_active_output_knob_changed() -> str:
+def _build_knob_changed_code(has_multiple_media_outputs: bool) -> str:
     """Return Python code for the gizmo's knobChanged callback.
 
-    When the user changes the ``active_output`` selector, this code updates
-    the internal SwitchOutput node's ``which`` knob so the correct Read node
-    flows to the gizmo's output pipe immediately — no re-run needed.
+    Always handles Link-expression upkeep: on rename, linked fields are
+    re-evaluated so they display the current value; manually editing a linked
+    field clears its stored expression (unlink). When the gizmo has multiple
+    media outputs, also flips the internal SwitchOutput when ``active_output``
+    changes.
     """
-    return """\
-if nuke.thisKnob().name() == "active_output":
-    n = nuke.thisNode()
-    n.begin()
+    active_output_block = """\
+if _gt_kn == "active_output":
+    _gt_n.begin()
     try:
-        switch = nuke.toNode("SwitchOutput")
-        if switch:
-            switch["which"].setValue(int(n["active_output"].getValue()))
+        _gt_switch = nuke.toNode("SwitchOutput")
+        if _gt_switch:
+            _gt_switch["which"].setValue(int(_gt_n["active_output"].getValue()))
     finally:
-        n.end()
+        _gt_n.end()
+el"""
+    prefix = active_output_block if has_multiple_media_outputs else ""
+    return f"""\
+_gt_k = nuke.thisKnob()
+_gt_n = nuke.thisNode()
+_gt_kn = _gt_k.name()
+{prefix}if _gt_kn == "name":
+    for _gt_name in list(_gt_n.knobs()):
+        if _gt_name.startswith("_gt_expr_"):
+            _gt_target = _gt_name[9:]
+            if _gt_n[_gt_name].getText() and _gt_n.knob(_gt_target):
+                try:
+                    _gt_v = _gt_n[_gt_name].evaluate()
+                except Exception:
+                    _gt_v = None
+                if _gt_v:
+                    _gt_n[_gt_target].setValue(_gt_v)
+elif not _gt_kn.startswith("_gt_") and _gt_n.knob("_gt_expr_" + _gt_kn):
+    _gt_ek = _gt_n["_gt_expr_" + _gt_kn]
+    if _gt_ek.getText():
+        try:
+            _gt_cur = _gt_ek.evaluate()
+        except Exception:
+            _gt_cur = None
+        if _gt_k.getText() != _gt_cur:
+            _gt_ek.setValue("")
 """
 
 
@@ -181,12 +209,22 @@ if _p.show():
         if _t:
             _expr = "[value " + _t + "]"
     if _expr:
-        _n["{knob_name}"].setValue(_expr)
+        _ek = _n["_gt_expr_{knob_name}"]
+        _ek.setValue(_expr)
+        try:
+            _v = _ek.evaluate()
+        except Exception:
+            _v = None
+        if _v:
+            _n["{knob_name}"].setValue(_v)
+        else:
+            _ek.setValue("")
+            _n["{knob_name}"].setValue(_expr)
 '''
 
 
 def _build_copy_link_button_code(knob_name: str) -> str:
-    """Return Python for a per-output Copy Link button: puts [value <node>.<knob>] on the clipboard."""
+    """Return Python for a per-output Copy Link button: clipboard copy, plus a live expression link when one node is selected."""
     return f"""\
 _n = nuke.thisNode()
 _expr = "[value " + _n.fullName() + ".{knob_name}]"
@@ -196,6 +234,25 @@ except ImportError:
     from PySide2.QtGui import QGuiApplication
 QGuiApplication.clipboard().setText(_expr)
 nuke.tprint("[Griptape] Copied to clipboard: " + _expr)
+_sel = [_s for _s in nuke.selectedNodes() if _s.fullName() != _n.fullName()]
+if len(_sel) == 1:
+    _target = _sel[0]
+    _kn = nuke.getInput("Expression-link a knob on " + _target.name() + " to this output (blank = clipboard only)", "")
+    if _kn:
+        if _target.knob(_kn):
+            _tk = _target[_kn]
+            _linked = False
+            try:
+                _linked = bool(_tk.setExpression(_expr))
+            except Exception:
+                _linked = False
+            if not _linked or not _tk.hasExpression():
+                _tk.setValue(_expr)
+                nuke.tprint("[Griptape] Set " + _target.name() + "." + _kn + " to live expression text: " + _expr)
+            else:
+                nuke.tprint("[Griptape] Expression-linked " + _target.name() + "." + _kn + " -> " + _expr)
+        else:
+            nuke.message("No knob named '" + _kn + "' on " + _target.name())
 """
 
 
@@ -240,13 +297,7 @@ class NukeGizmoBuilder:
         # --- Run tab (leftmost) ---
         w.add_tab("run_tab", label="Run")
         w.add_string_knob("output_dir", label="Output Directory", tooltip=_OUTPUT_DIR_TOOLTIP)
-        w.add_pyscript_knob(
-            "_link_output_dir",
-            label="Link...",
-            python_code=_build_link_button_code("output_dir"),
-            flags="-STARTLINE",
-            tooltip=_LINK_BUTTON_TOOLTIP,
-        )
+        self._write_link_button(w, "output_dir")
         run_code = self._build_run_button_bootstrap(
             input_params,
             list(output_params.keys()),
@@ -280,9 +331,12 @@ class NukeGizmoBuilder:
                 if name in media_output_names
             ]
             w.add_enumeration_knob("active_output", "Active Output", choices)
-            w.set_knob_changed(_build_active_output_knob_changed())
         for name, info in output_params.items():
             self._write_output_knob(w, name, info)
+
+        # Always present: refreshes linked fields on rename and unlinks a field
+        # the user manually edits; also drives SwitchOutput for multi-output gizmos.
+        w.set_knob_changed(_build_knob_changed_code(has_multiple_media_outputs=len(media_output_names) > 1))
 
         w.end_gizmo_header()
 
@@ -397,7 +451,12 @@ class NukeGizmoBuilder:
 
     @staticmethod
     def _write_link_button(w: GizmoWriter, knob_name: str) -> None:
-        """Write a same-line Link button that fills the knob with a preset TCL expression."""
+        """Write a same-line Link button plus the hidden knob that stores the link's expression.
+
+        The visible knob always displays the evaluated value; the expression
+        lives in ``_gt_expr_<knob>`` and is re-evaluated by the gizmo's
+        knobChanged callback (e.g. on rename).
+        """
         w.add_pyscript_knob(
             f"_link_{knob_name}",
             label="Link...",
@@ -405,6 +464,7 @@ class NukeGizmoBuilder:
             flags="-STARTLINE",
             tooltip=_LINK_BUTTON_TOOLTIP,
         )
+        w.add_invisible_string_knob(f"_gt_expr_{knob_name}")
 
     def _write_output_knob(self, w: GizmoWriter, name: str, info: dict) -> None:
         """Write a read-only knob for a workflow output parameter."""

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -72,6 +72,31 @@ _INPUT_NODE_PREFIX = "Input"
 _OUTPUT_NODE_PREFIX = "Output"
 _TEMP_FILE_PREFIX = "gt_input"
 
+# Tooltips advertising Nuke TCL expression support (string knobs have no
+# right-click "Add expression" menu, so hover hints are the discovery path)
+_TCL_HINT_TOOLTIP = (
+    "Supports Nuke TCL expressions in [brackets], e.g. [value this.name] or [frame]. "
+    "Expressions are evaluated when the workflow runs."
+)
+_OUTPUT_DIR_TOOLTIP = (
+    "Directory for workflow outputs. Supports TCL expressions, e.g. [file dirname [value root.name]]/griptape."
+)
+_LINK_BUTTON_TOOLTIP = (
+    "Set this field to a live expression: gizmo name, script folder, script name, frame, or any node.knob."
+)
+_COPY_LINK_TOOLTIP = (
+    "Copy a [value ...] expression for this output to the clipboard. "
+    "Paste it into any text field (e.g. a Text node's message) to link it."
+)
+
+
+def _output_tooltip(knob_name: str) -> str:
+    """Tooltip telling users how to reference this output from other nodes."""
+    return (
+        f"Workflow output. Reference it from any other node with a TCL expression, "
+        f"e.g. [value <this node's name>.{knob_name}]."
+    )
+
 
 def _read_node_name(param_name: str) -> str:
     """Return the internal Read node name for a given media output parameter."""
@@ -134,6 +159,46 @@ if nuke.thisKnob().name() == "active_output":
 """
 
 
+def _build_link_button_code(knob_name: str) -> str:
+    """Return Python for a per-input Link button: preset chooser that writes a TCL expression into the knob."""
+    return f'''\
+_n = nuke.thisNode()
+_p = nuke.Panel("Link {knob_name}")
+_p.addEnumerationPulldown("Link to", "{{This gizmo's name}} {{Nuke script folder}} {{Nuke script name}} {{Current frame}} {{Custom node.knob}}")
+if _p.show():
+    _c = _p.value("Link to")
+    _expr = None
+    if _c == "This gizmo's name":
+        _expr = "[value this.name]"
+    elif _c == "Nuke script folder":
+        _expr = "[file dirname [value root.name]]"
+    elif _c == "Nuke script name":
+        _expr = "[file rootname [file tail [value root.name]]]"
+    elif _c == "Current frame":
+        _expr = "[frame]"
+    else:
+        _t = nuke.getInput("Node.knob to link to (e.g. Text1.message)", "")
+        if _t:
+            _expr = "[value " + _t + "]"
+    if _expr:
+        _n["{knob_name}"].setValue(_expr)
+'''
+
+
+def _build_copy_link_button_code(knob_name: str) -> str:
+    """Return Python for a per-output Copy Link button: puts [value <node>.<knob>] on the clipboard."""
+    return f'''\
+_n = nuke.thisNode()
+_expr = "[value " + _n.fullName() + ".{knob_name}]"
+try:
+    from PySide6.QtGui import QGuiApplication
+except ImportError:
+    from PySide2.QtGui import QGuiApplication
+QGuiApplication.clipboard().setText(_expr)
+nuke.tprint("[Griptape] Copied to clipboard: " + _expr)
+'''
+
+
 class NukeGizmoBuilder:
     """Generates a Nuke .gizmo text file from a Griptape workflow shape.
 
@@ -174,7 +239,14 @@ class NukeGizmoBuilder:
 
         # --- Run tab (leftmost) ---
         w.add_tab("run_tab", label="Run")
-        w.add_string_knob("output_dir", label="Output Directory")
+        w.add_string_knob("output_dir", label="Output Directory", tooltip=_OUTPUT_DIR_TOOLTIP)
+        w.add_pyscript_knob(
+            "_link_output_dir",
+            label="Link...",
+            python_code=_build_link_button_code("output_dir"),
+            flags="-STARTLINE",
+            tooltip=_LINK_BUTTON_TOOLTIP,
+        )
         run_code = self._build_run_button_bootstrap(
             input_params,
             list(output_params.keys()),
@@ -308,7 +380,8 @@ class NukeGizmoBuilder:
             default_index = choices.index(default) if default and default in choices else None
             w.add_enumeration_knob(knob_name, label, choices, default_index=default_index)
         elif param_type in _FILE_PATH_TYPES:
-            w.add_file_knob(knob_name, label, default=default or None)
+            w.add_file_knob(knob_name, label, default=default or None, tooltip=_TCL_HINT_TOOLTIP)
+            self._write_link_button(w, knob_name)
         elif param_type == "bool":
             w.add_bool_knob(knob_name, label, default=default if type(default) is bool else None)
         elif param_type == "float":
@@ -316,9 +389,22 @@ class NukeGizmoBuilder:
         elif param_type == "int":
             w.add_int_knob(knob_name, label, default=default if type(default) is int else None)
         elif param_type in _MULTILINE_TYPES:
-            w.add_multiline_string_knob(knob_name, label, default=default or None)
+            w.add_multiline_string_knob(knob_name, label, default=default or None, tooltip=_TCL_HINT_TOOLTIP)
+            self._write_link_button(w, knob_name)
         else:
-            w.add_string_knob(knob_name, label, default=default or None)
+            w.add_string_knob(knob_name, label, default=default or None, tooltip=_TCL_HINT_TOOLTIP)
+            self._write_link_button(w, knob_name)
+
+    @staticmethod
+    def _write_link_button(w: GizmoWriter, knob_name: str) -> None:
+        """Write a same-line Link button that fills the knob with a preset TCL expression."""
+        w.add_pyscript_knob(
+            f"_link_{knob_name}",
+            label="Link...",
+            python_code=_build_link_button_code(knob_name),
+            flags="-STARTLINE",
+            tooltip=_LINK_BUTTON_TOOLTIP,
+        )
 
     def _write_output_knob(self, w: GizmoWriter, name: str, info: dict) -> None:
         """Write a read-only knob for a workflow output parameter."""
@@ -327,11 +413,18 @@ class NukeGizmoBuilder:
         param_type = info.get("type", "str")
 
         if param_type in _FILE_PATH_TYPES:
-            w.add_file_knob(knob_name, label, flags="+DISABLED")
+            w.add_file_knob(knob_name, label, flags="+DISABLED", tooltip=_output_tooltip(knob_name))
         elif param_type in _MULTILINE_TYPES:
-            w.add_multiline_string_knob(knob_name, label, flags="+DISABLED")
+            w.add_multiline_string_knob(knob_name, label, flags="+DISABLED", tooltip=_output_tooltip(knob_name))
         else:
-            w.add_string_knob(knob_name, label, flags="+DISABLED")
+            w.add_string_knob(knob_name, label, flags="+DISABLED", tooltip=_output_tooltip(knob_name))
+        w.add_pyscript_knob(
+            f"_copy_{knob_name}",
+            label="Copy Link",
+            python_code=_build_copy_link_button_code(knob_name),
+            flags="-STARTLINE",
+            tooltip=_COPY_LINK_TOOLTIP,
+        )
 
     def _build_run_button_bootstrap(
         self,

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -126,6 +126,7 @@ class NukeGizmoPublisher:
             self._copy_file(
                 Path(__file__).parent / "output_protocol.py", companion_base / "output_protocol.py", overwrite=True
             )
+            self._copy_file(Path(__file__).parent / "tcl_utils.py", companion_base / "tcl_utils.py", overwrite=True)
 
             available_versions = self._collect_versions(companion_base)
 

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -65,13 +65,24 @@ def _build_child_env(companion: str, base_env: dict) -> dict:
 
 
 def _expand_tcl(n, knob_name: str, raw):
-    """Expand TCL bracket expressions in a string knob value, falling back to the raw text.
+    """Resolve a knob's runtime value, preferring its stored Link expression.
 
-    Plain String_Knobs never evaluate [bracket] expressions themselves, so we ask
-    TCL's ``value`` command to read the knob — it evaluates in the knob's own node
-    context, making ``this`` resolve to the gizmo instance. Values that aren't
+    A knob linked via the gizmo's Link button stores its TCL expression in a
+    hidden ``_gt_expr_<knob>`` companion knob while the visible field shows the
+    evaluated value; re-evaluating the expression here keeps time-dependent
+    links (e.g. [frame]) fresh. Hand-typed [bracket] text in the visible field
+    is expanded via TCL's ``value`` command, which evaluates in the knob's own
+    node context so ``this`` resolves to the gizmo instance. Values that aren't
     valid TCL (e.g. JSON arrays) raise and fall back to the raw text.
     """
+    expr_knob = n.knob("_gt_expr_" + knob_name)
+    if expr_knob is not None and expr_knob.getText():
+        try:
+            expanded = expr_knob.evaluate()
+        except Exception:  # noqa: BLE001
+            expanded = None
+        if expanded:
+            return expanded
     if not isinstance(raw, str) or "[" not in raw:
         return raw
     try:

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -64,6 +64,23 @@ def _build_child_env(companion: str, base_env: dict) -> dict:
     return {**base_env, "XDG_CONFIG_HOME": companion + "/.gtn_config"}
 
 
+def _expand_tcl(n, knob_name: str, raw):
+    """Expand TCL bracket expressions in a string knob value, falling back to the raw text.
+
+    Plain String_Knobs never evaluate [bracket] expressions themselves, so we ask
+    TCL's ``value`` command to read the knob — it evaluates in the knob's own node
+    context, making ``this`` resolve to the gizmo instance. Values that aren't
+    valid TCL (e.g. JSON arrays) raise and fall back to the raw text.
+    """
+    if not isinstance(raw, str) or "[" not in raw:
+        return raw
+    try:
+        expanded = nuke.tcl("value", n.fullName() + "." + knob_name)  # noqa: F821
+    except Exception:  # noqa: BLE001
+        return raw
+    return expanded if expanded else raw
+
+
 # Qt is bundled with Nuke. Try PySide6 first (Nuke 16+), fall back to PySide2 (Nuke 13–15).
 try:
     from PySide6.QtCore import Qt
@@ -302,7 +319,7 @@ _nk_script_dir = nuke.script_directory()  # noqa: F821
 if _nk_script_dir:
     _nk_script_dir = _nk_script_dir.replace("\\", "/")
 
-output_dir = node["output_dir"].value()
+output_dir = _expand_tcl(node, "output_dir", node["output_dir"].value())
 if output_dir:
     output_dir = output_dir.replace("\\", "/")
 
@@ -316,7 +333,7 @@ else:
     inputs: dict = {}
     for _k in _param_names:
         if node.knob(_k):
-            inputs[_k] = node[_k].value()
+            inputs[_k] = _expand_tcl(node, _k, node[_k].value())
             print(f"[Griptape] knob '{_k}' -> type={type(inputs[_k]).__name__!r} value={inputs[_k]!r}")
         else:
             print(f"[Griptape] knob '{_k}' -> NOT FOUND on node")

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -53,6 +53,11 @@ except ImportError:
 
     _SENTINEL = ""
 
+# _expand_tcl lives in a sibling module so the unit tests can import it directly
+# rather than source-parsing this exec'd script. tcl_utils.py is copied into the
+# companion bundle at publish time (see NukeGizmoPublisher).
+from tcl_utils import _expand_tcl  # noqa: E402
+
 
 def _build_child_env(companion: str, base_env: dict) -> dict:
     """Return a subprocess env with XDG_CONFIG_HOME redirected into the bundle.
@@ -62,34 +67,6 @@ def _build_child_env(companion: str, base_env: dict) -> dict:
     companion must already be an absolute forward-slashed path.
     """
     return {**base_env, "XDG_CONFIG_HOME": companion + "/.gtn_config"}
-
-
-def _expand_tcl(n, knob_name: str, raw):
-    """Resolve a knob's runtime value, preferring its stored Link expression.
-
-    A knob linked via the gizmo's Link button stores its TCL expression in a
-    hidden ``_gt_expr_<knob>`` companion knob while the visible field shows the
-    evaluated value; re-evaluating the expression here keeps time-dependent
-    links (e.g. [frame]) fresh. Hand-typed [bracket] text in the visible field
-    is expanded via TCL's ``value`` command, which evaluates in the knob's own
-    node context so ``this`` resolves to the gizmo instance. Values that aren't
-    valid TCL (e.g. JSON arrays) raise and fall back to the raw text.
-    """
-    expr_knob = n.knob("_gt_expr_" + knob_name)
-    if expr_knob is not None and expr_knob.getText():
-        try:
-            expanded = expr_knob.evaluate()
-        except Exception:  # noqa: BLE001
-            expanded = None
-        if expanded:
-            return expanded
-    if not isinstance(raw, str) or "[" not in raw:
-        return raw
-    try:
-        expanded = nuke.tcl("value", n.fullName() + "." + knob_name)  # noqa: F821
-    except Exception:  # noqa: BLE001
-        return raw
-    return expanded if expanded else raw
 
 
 # Qt is bundled with Nuke. Try PySide6 first (Nuke 16+), fall back to PySide2 (Nuke 13–15).

--- a/publish_gizmo/tcl_utils.py
+++ b/publish_gizmo/tcl_utils.py
@@ -1,0 +1,55 @@
+"""TCL-expression resolution for gizmo knobs, shared by the bundled run_button.
+
+This module is copied into the gizmo companion directory at publish time and
+imported by ``run_button.py`` (which is exec'd, not imported). Keeping the logic
+here — rather than inline in the exec'd script — lets the unit tests import it
+normally instead of source-parsing ``run_button.py``.
+
+Runtime dependency: ``nuke`` is provided by the Nuke interpreter. Tests inject a
+fake ``nuke`` via the module namespace.
+"""
+
+from __future__ import annotations
+
+try:
+    import nuke  # type: ignore[import-not-found]
+except ImportError:  # unit tests / non-Nuke environments inject their own
+    nuke = None  # type: ignore[assignment]
+
+# Prefix for the hidden companion knob that stores a Link button's TCL expression.
+# Must stay in sync with GT_EXPR_PREFIX in constants.py (which is not copied into
+# the bundle, so it cannot be imported here at runtime).
+GT_EXPR_PREFIX = "_gt_expr_"
+
+
+def _expand_tcl(n, knob_name: str, raw):
+    """Resolve a knob's runtime value, preferring its stored Link expression.
+
+    A knob linked via the gizmo's Link button stores its TCL expression in a
+    hidden ``_gt_expr_<knob>`` companion knob while the visible field shows the
+    evaluated value; re-evaluating the expression here keeps time-dependent
+    links (e.g. [frame]) fresh. Hand-typed [bracket] text in the visible field
+    is expanded via TCL's ``value`` command, which evaluates in the knob's own
+    node context so ``this`` resolves to the gizmo instance. Values that aren't
+    valid TCL (e.g. JSON arrays) raise and fall back to the raw text.
+
+    An expression that legitimately evaluates to an empty string returns ``""``
+    (not the stale display text): only an evaluation *error* falls back to raw.
+    """
+    expr_knob = n.knob(GT_EXPR_PREFIX + knob_name)
+    if expr_knob is not None and expr_knob.getText():
+        try:
+            expanded = expr_knob.evaluate()
+        except Exception:  # noqa: BLE001
+            expanded = None
+        if expanded is not None:
+            return expanded
+    if not isinstance(raw, str) or "[" not in raw:
+        return raw
+    try:
+        # nuke is always present at runtime (this branch only runs inside Nuke);
+        # the module-level fallback to None exists solely for unit-test injection.
+        expanded = nuke.tcl("value", n.fullName() + "." + knob_name)  # type: ignore[union-attr]
+    except Exception:  # noqa: BLE001
+        return raw
+    return expanded if expanded is not None else raw

--- a/tests/unit/test_gizmo_writer.py
+++ b/tests/unit/test_gizmo_writer.py
@@ -1,0 +1,31 @@
+"""Tests for gizmo_writer TCL literal escaping."""
+
+from __future__ import annotations
+
+from publish_gizmo.gizmo_writer import _tcl_escape_literal
+
+
+class TestTclEscapeLiteral:
+    def test_plain_text_is_noop(self) -> None:
+        assert _tcl_escape_literal("hello world") == "hello world"
+
+    def test_open_bracket_escaped(self) -> None:
+        assert _tcl_escape_literal("[value this.name]") == r"\[value this.name]"
+
+    def test_close_bracket_not_escaped(self) -> None:
+        assert _tcl_escape_literal("a]b") == "a]b"
+
+    def test_quote_escaped(self) -> None:
+        assert _tcl_escape_literal('say "hi"') == r"say \"hi\""
+
+    def test_backslash_doubled(self) -> None:
+        assert _tcl_escape_literal("C:\\path") == "C:\\\\path"
+
+    def test_dollar_escaped(self) -> None:
+        assert _tcl_escape_literal("$var") == r"\$var"
+
+    def test_backslash_before_bracket_escapes_both(self) -> None:
+        assert _tcl_escape_literal(r"\[x]") == r"\\\[x]"
+
+    def test_newline_preserved(self) -> None:
+        assert _tcl_escape_literal("line1\nline2") == "line1\nline2"

--- a/tests/unit/test_nuke_gizmo_builder.py
+++ b/tests/unit/test_nuke_gizmo_builder.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import ast
+
 import pytest
 
-from publish_gizmo.nuke_gizmo_builder import NukeGizmoBuilder
+from publish_gizmo.nuke_gizmo_builder import NukeGizmoBuilder, _build_knob_changed_code
 
 
 def _minimal_shape(input_params: dict[str, dict]) -> dict:
@@ -261,12 +263,29 @@ class TestTclHintTooltips:
     def test_tooltips_never_contain_unescaped_brackets(self) -> None:
         gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
         for line in gizmo.splitlines():
-            # PyScript button lines carry raw Python in T "..." where brackets are
-            # brace-quoted and safe; only value-knob tooltips need escaping.
-            if ' t "' in line and "addUserKnob {22" not in line:
-                assert "[value" not in line.replace(r"\[value", "")
-                assert "[file" not in line.replace(r"\[file", "")
-                assert "[frame" not in line.replace(r"\[frame", "")
+            # Check the tooltip attribute (t "...") on EVERY knob, including {22}
+            # PyScript buttons — their _COPY_LINK_TOOLTIP / _LINK_BUTTON_TOOLTIP
+            # contain [value ...] and must be escaped. Only the tooltip substring
+            # is checked so the T "..." script body (where brackets have no TCL
+            # significance, since Nuke does not substitute inside a script attr)
+            # does not produce false positives.
+            if ' t "' not in line:
+                continue
+            tooltip = line.split(' t "', 1)[1].split('"', 1)[0]
+            assert "[value" not in tooltip.replace(r"\[value", "")
+            assert "[file" not in tooltip.replace(r"\[file", "")
+            assert "[frame" not in tooltip.replace(r"\[frame", "")
+
+    def test_copy_link_tooltip_escapes_brackets(self) -> None:
+        """The Copy Link button's tooltip contains [value ...] and must be escaped."""
+        gizmo = _generate_gizmo_with_output(
+            {"caption": {"type": "str", "default_value": "", "mode_allowed_output": True, "ui_options": {}}}
+        )
+        button_line = next(line for line in gizmo.splitlines() if "addUserKnob {22 _copy_caption_out" in line)
+        assert ' t "' in button_line
+        tooltip = button_line.split(' t "', 1)[1].split('"', 1)[0]
+        assert r"\[value" in tooltip
+        assert "[value" not in tooltip.replace(r"\[value", "")
 
     def test_output_dir_knob_has_expression_tooltip(self) -> None:
         gizmo = _generate_gizmo({})
@@ -311,18 +330,28 @@ class TestExpressionLinkButtons:
         gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
         assert 'addUserKnob {1 _gt_expr_folder_path l "" +INVISIBLE}' in gizmo
 
+    def test_knob_changed_code_is_valid_python(self) -> None:
+        """The generated callback must parse as Python — guards against string-concat
+        traps (e.g. an 'el' fragment relying on the next literal to form 'elif')."""
+        ast.parse(_build_knob_changed_code())
+
     def test_knob_changed_refreshes_links_on_rename(self) -> None:
         gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
         knob_changed_line = next(line for line in gizmo.splitlines() if line.startswith(" knobChanged"))
         assert "_gt_expr_" in knob_changed_line
         assert '\\"name\\"' in knob_changed_line
 
-    def test_knob_changed_handles_active_output_only_with_multiple_media_outputs(self) -> None:
+    def test_knob_changed_always_present_and_guards_switch_output(self) -> None:
+        """The callback is emitted unconditionally; the SwitchOutput branch is
+        guarded by nuke.toNode so it is a safe no-op on single-output gizmos."""
         single = _generate_gizmo_with_output(
             {"image": {"type": "ImageUrlArtifact", "default_value": "", "mode_allowed_output": True, "ui_options": {}}}
         )
         single_kc = next(line for line in single.splitlines() if line.startswith(" knobChanged"))
-        assert "active_output" not in single_kc
+        # active_output handling is always present, but guarded by a SwitchOutput lookup.
+        assert "active_output" in single_kc
+        assert "SwitchOutput" in single_kc
+        assert "_gt_expr_" in single_kc
 
         multi = _generate_gizmo_with_output(
             {

--- a/tests/unit/test_nuke_gizmo_builder.py
+++ b/tests/unit/test_nuke_gizmo_builder.py
@@ -300,6 +300,49 @@ class TestExpressionLinkButtons:
         assert "-STARTLINE" in button_line
         assert "value this.name" in button_line
         assert "setValue" in button_line
+        assert "evaluate" in button_line
+        # setExpression returns False on string-family knobs (verified in Nuke 17);
+        # the input link button must not attempt it.
+        assert "setExpression" not in button_line
+        # The expression is stored in the hidden companion knob, not the visible field.
+        assert "_gt_expr_folder_path" in button_line
+
+    def test_link_button_has_hidden_expression_knob(self) -> None:
+        gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
+        assert 'addUserKnob {1 _gt_expr_folder_path l "" +INVISIBLE}' in gizmo
+
+    def test_knob_changed_refreshes_links_on_rename(self) -> None:
+        gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
+        knob_changed_line = next(line for line in gizmo.splitlines() if line.startswith(" knobChanged"))
+        assert "_gt_expr_" in knob_changed_line
+        assert '\\"name\\"' in knob_changed_line
+
+    def test_knob_changed_handles_active_output_only_with_multiple_media_outputs(self) -> None:
+        single = _generate_gizmo_with_output(
+            {"image": {"type": "ImageUrlArtifact", "default_value": "", "mode_allowed_output": True, "ui_options": {}}}
+        )
+        single_kc = next(line for line in single.splitlines() if line.startswith(" knobChanged"))
+        assert "active_output" not in single_kc
+
+        multi = _generate_gizmo_with_output(
+            {
+                "alpha": {
+                    "type": "ImageUrlArtifact",
+                    "default_value": "",
+                    "mode_allowed_output": True,
+                    "ui_options": {},
+                },
+                "beauty": {
+                    "type": "ImageUrlArtifact",
+                    "default_value": "",
+                    "mode_allowed_output": True,
+                    "ui_options": {},
+                },
+            }
+        )
+        multi_kc = next(line for line in multi.splitlines() if line.startswith(" knobChanged"))
+        assert "active_output" in multi_kc
+        assert "SwitchOutput" in multi_kc
 
     def test_link_button_immediately_follows_its_knob(self) -> None:
         gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
@@ -331,6 +374,8 @@ class TestExpressionLinkButtons:
         assert "-STARTLINE" in button_line
         assert "fullName()" in button_line
         assert "clipboard" in button_line
+        assert "selectedNodes" in button_line
+        assert "setExpression" in button_line
 
     def test_multiline_input_gets_link_button(self) -> None:
         gizmo = _generate_gizmo({"config": {"type": "JsonArtifact", "default_value": ""}})

--- a/tests/unit/test_nuke_gizmo_builder.py
+++ b/tests/unit/test_nuke_gizmo_builder.py
@@ -225,4 +225,117 @@ class TestReadNodeExpressionLink:
             }
         )
         assert "GEN_READ" not in gizmo
-        assert r"\[value" not in gizmo
+        assert r'file "\[value' not in gizmo
+
+
+class TestTclExpressionDefaultsEscaped:
+    """Defaults containing TCL brackets must be escaped so they survive gizmo parse as literal text."""
+
+    def test_str_default_with_expression_is_escaped(self) -> None:
+        gizmo = _generate_gizmo({"prompt": {"type": "str", "default_value": "[value this.name]"}})
+        assert r' prompt "\[value this.name]"' in gizmo
+        assert ' prompt "[value this.name]"' not in gizmo
+
+    def test_str_default_with_quote_is_escaped(self) -> None:
+        gizmo = _generate_gizmo({"prompt": {"type": "str", "default_value": 'say "hi"'}})
+        assert r' prompt "say \"hi\""' in gizmo
+
+    def test_file_default_with_expression_is_escaped(self) -> None:
+        gizmo = _generate_gizmo({"image": {"type": "ImageUrlArtifact", "default_value": "[frame].jpg"}})
+        assert r' image "\[frame].jpg"' in gizmo
+
+    def test_plain_default_unchanged(self) -> None:
+        gizmo = _generate_gizmo({"prompt": {"type": "str", "default_value": "hello world"}})
+        assert ' prompt "hello world"' in gizmo
+
+
+class TestTclHintTooltips:
+    """String-family input knobs and output knobs must carry TCL-expression tooltips."""
+
+    def test_str_input_knob_has_expression_tooltip(self) -> None:
+        gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
+        knob_line = next(line for line in gizmo.splitlines() if "addUserKnob {1 folder_path" in line)
+        assert ' t "' in knob_line
+        assert r"\[value this.name]" in knob_line
+
+    def test_tooltips_never_contain_unescaped_brackets(self) -> None:
+        gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
+        for line in gizmo.splitlines():
+            # PyScript button lines carry raw Python in T "..." where brackets are
+            # brace-quoted and safe; only value-knob tooltips need escaping.
+            if ' t "' in line and "addUserKnob {22" not in line:
+                assert "[value" not in line.replace(r"\[value", "")
+                assert "[file" not in line.replace(r"\[file", "")
+                assert "[frame" not in line.replace(r"\[frame", "")
+
+    def test_output_dir_knob_has_expression_tooltip(self) -> None:
+        gizmo = _generate_gizmo({})
+        knob_line = next(line for line in gizmo.splitlines() if "addUserKnob {1 output_dir" in line)
+        assert ' t "' in knob_line
+        assert r"\[file dirname" in knob_line
+
+    def test_output_knob_has_reference_tooltip(self) -> None:
+        gizmo = _generate_gizmo_with_output(
+            {"caption": {"type": "str", "default_value": "", "mode_allowed_output": True, "ui_options": {}}}
+        )
+        knob_line = next(line for line in gizmo.splitlines() if "addUserKnob {1 caption_out" in line)
+        assert "+DISABLED" in knob_line
+        assert ' t "' in knob_line
+        assert r"\[value" in knob_line
+        assert "caption_out" in knob_line
+
+    def test_numeric_knobs_have_no_tooltip(self) -> None:
+        gizmo = _generate_gizmo({"count": {"type": "int", "default_value": 1}})
+        knob_line = next(line for line in gizmo.splitlines() if "addUserKnob {3 count" in line)
+        assert ' t "' not in knob_line
+
+
+class TestExpressionLinkButtons:
+    """String-family knobs get same-line Link/Copy Link PyScript buttons; other types do not."""
+
+    def test_str_input_gets_link_button(self) -> None:
+        gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
+        button_line = next(line for line in gizmo.splitlines() if "addUserKnob {22 _link_folder_path" in line)
+        assert 'l "Link..."' in button_line
+        assert "-STARTLINE" in button_line
+        assert "value this.name" in button_line
+        assert "setValue" in button_line
+
+    def test_link_button_immediately_follows_its_knob(self) -> None:
+        gizmo = _generate_gizmo({"folder_path": {"type": "str", "default_value": ""}})
+        lines = gizmo.splitlines()
+        knob_idx = next(i for i, line in enumerate(lines) if "addUserKnob {1 folder_path" in line)
+        button_idx = next(i for i, line in enumerate(lines) if "addUserKnob {22 _link_folder_path" in line)
+        assert button_idx == knob_idx + 1
+
+    def test_int_input_gets_no_link_button(self) -> None:
+        gizmo = _generate_gizmo({"count": {"type": "int", "default_value": 1}})
+        assert "_link_count" not in gizmo
+
+    def test_dropdown_input_gets_no_link_button(self) -> None:
+        gizmo = _generate_gizmo(
+            {"mode": {"type": "str", "default_value": "a", "ui_options": {"simple_dropdown": ["a", "b"]}}}
+        )
+        assert "_link_mode" not in gizmo
+
+    def test_output_dir_gets_link_button(self) -> None:
+        gizmo = _generate_gizmo({})
+        assert "addUserKnob {22 _link_output_dir" in gizmo
+
+    def test_output_knob_gets_copy_link_button(self) -> None:
+        gizmo = _generate_gizmo_with_output(
+            {"caption": {"type": "str", "default_value": "", "mode_allowed_output": True, "ui_options": {}}}
+        )
+        button_line = next(line for line in gizmo.splitlines() if "addUserKnob {22 _copy_caption_out" in line)
+        assert 'l "Copy Link"' in button_line
+        assert "-STARTLINE" in button_line
+        assert "fullName()" in button_line
+        assert "clipboard" in button_line
+
+    def test_multiline_input_gets_link_button(self) -> None:
+        gizmo = _generate_gizmo({"config": {"type": "JsonArtifact", "default_value": ""}})
+        assert "addUserKnob {22 _link_config" in gizmo
+
+    def test_file_input_gets_link_button(self) -> None:
+        gizmo = _generate_gizmo({"image": {"type": "ImageUrlArtifact", "default_value": ""}})
+        assert "addUserKnob {22 _link_image" in gizmo

--- a/tests/unit/test_run_button_expand_tcl.py
+++ b/tests/unit/test_run_button_expand_tcl.py
@@ -20,12 +20,31 @@ class _FakeNuke:
         return self.result
 
 
+class _FakeExprKnob:
+    def __init__(self, text: str, evaluated: str | None = None, error: Exception | None = None) -> None:
+        self._text = text
+        self._evaluated = evaluated
+        self._error = error
+
+    def getText(self) -> str:  # noqa: N802
+        return self._text
+
+    def evaluate(self) -> str | None:
+        if self._error is not None:
+            raise self._error
+        return self._evaluated
+
+
 class _FakeNode:
-    def __init__(self, full_name: str) -> None:
+    def __init__(self, full_name: str, expr_knobs: dict | None = None) -> None:
         self._full_name = full_name
+        self._expr_knobs = expr_knobs or {}
 
     def fullName(self) -> str:  # noqa: N802
         return self._full_name
+
+    def knob(self, name: str):
+        return self._expr_knobs.get(name)
 
 
 def _load_expand_tcl(fake_nuke: _FakeNuke):
@@ -79,3 +98,22 @@ class TestExpandTcl:
         expand = _load_expand_tcl(fake)
         expand(_FakeNode("Group1.wf_v01"), "output_dir", "[file dirname [value root.name]]")
         assert fake.calls == [("value", "Group1.wf_v01.output_dir")]
+
+    def test_stored_link_expression_takes_precedence(self) -> None:
+        fake = _FakeNuke(result="should-not-be-used")
+        expand = _load_expand_tcl(fake)
+        node = _FakeNode("Gizmo1", {"_gt_expr_prompt": _FakeExprKnob("[value this.name]", evaluated="Gizmo1")})
+        assert expand(node, "prompt", "stale display text") == "Gizmo1"
+        assert fake.calls == []
+
+    def test_empty_stored_expression_falls_through_to_raw(self) -> None:
+        fake = _FakeNuke()
+        expand = _load_expand_tcl(fake)
+        node = _FakeNode("Gizmo1", {"_gt_expr_prompt": _FakeExprKnob("")})
+        assert expand(node, "prompt", "typed text") == "typed text"
+
+    def test_failing_stored_expression_falls_through(self) -> None:
+        fake = _FakeNuke()
+        expand = _load_expand_tcl(fake)
+        node = _FakeNode("Gizmo1", {"_gt_expr_prompt": _FakeExprKnob("[bad", error=RuntimeError("bad expression"))})
+        assert expand(node, "prompt", "typed text") == "typed text"

--- a/tests/unit/test_run_button_expand_tcl.py
+++ b/tests/unit/test_run_button_expand_tcl.py
@@ -1,0 +1,81 @@
+"""Tests for run_button._expand_tcl — TCL bracket-expression expansion for knob values."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_RUN_BUTTON = Path(__file__).parent.parent.parent / "publish_gizmo" / "run_button.py"
+
+
+class _FakeNuke:
+    def __init__(self, result: str | None = None, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[tuple] = []
+
+    def tcl(self, *args):
+        self.calls.append(args)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _FakeNode:
+    def __init__(self, full_name: str) -> None:
+        self._full_name = full_name
+
+    def fullName(self) -> str:  # noqa: N802
+        return self._full_name
+
+
+def _load_expand_tcl(fake_nuke: _FakeNuke):
+    """Extract _expand_tcl from run_button.py without running its top-level Nuke code."""
+    source = _RUN_BUTTON.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("def _expand_tcl("))
+    body_lines = []
+    for line in lines[start:]:
+        if body_lines and line and not line[0].isspace() and not line.startswith("def _expand_tcl"):
+            break
+        body_lines.append(line)
+    ns: dict = {"nuke": fake_nuke}
+    exec("\n".join(body_lines), ns)  # noqa: S102
+    return ns["_expand_tcl"]
+
+
+class TestExpandTcl:
+    def test_non_str_value_returned_unchanged(self) -> None:
+        fake = _FakeNuke()
+        expand = _load_expand_tcl(fake)
+        assert expand(_FakeNode("Gizmo1"), "count", 5) == 5
+        assert expand(_FakeNode("Gizmo1"), "flag", None) is None
+        assert fake.calls == []
+
+    def test_str_without_bracket_returned_unchanged(self) -> None:
+        fake = _FakeNuke()
+        expand = _load_expand_tcl(fake)
+        assert expand(_FakeNode("Gizmo1"), "prompt", "hello") == "hello"
+        assert fake.calls == []
+
+    def test_str_with_bracket_expanded_via_tcl_value(self) -> None:
+        fake = _FakeNuke(result="Gizmo1")
+        expand = _load_expand_tcl(fake)
+        assert expand(_FakeNode("Gizmo1"), "prompt", "[value this.name]") == "Gizmo1"
+        assert fake.calls == [("value", "Gizmo1.prompt")]
+
+    def test_tcl_error_falls_back_to_raw(self) -> None:
+        fake = _FakeNuke(error=RuntimeError("bad expression"))
+        expand = _load_expand_tcl(fake)
+        raw = '[{"a": 1}, {"b": 2}]'
+        assert expand(_FakeNode("Gizmo1"), "config", raw) == raw
+
+    def test_empty_expansion_falls_back_to_raw(self) -> None:
+        fake = _FakeNuke(result="")
+        expand = _load_expand_tcl(fake)
+        assert expand(_FakeNode("Gizmo1"), "prompt", "[value this.missing]") == "[value this.missing]"
+
+    def test_nested_node_path_used_in_tcl_call(self) -> None:
+        fake = _FakeNuke(result="/out")
+        expand = _load_expand_tcl(fake)
+        expand(_FakeNode("Group1.wf_v01"), "output_dir", "[file dirname [value root.name]]")
+        assert fake.calls == [("value", "Group1.wf_v01.output_dir")]

--- a/tests/unit/test_run_button_expand_tcl.py
+++ b/tests/unit/test_run_button_expand_tcl.py
@@ -1,10 +1,11 @@
-"""Tests for run_button._expand_tcl — TCL bracket-expression expansion for knob values."""
+"""Tests for tcl_utils._expand_tcl — TCL bracket-expression expansion for knob values."""
 
 from __future__ import annotations
 
-from pathlib import Path
+import pytest
 
-_RUN_BUTTON = Path(__file__).parent.parent.parent / "publish_gizmo" / "run_button.py"
+from publish_gizmo import tcl_utils
+from publish_gizmo.tcl_utils import _expand_tcl
 
 
 class _FakeNuke:
@@ -47,73 +48,61 @@ class _FakeNode:
         return self._expr_knobs.get(name)
 
 
-def _load_expand_tcl(fake_nuke: _FakeNuke):
-    """Extract _expand_tcl from run_button.py without running its top-level Nuke code."""
-    source = _RUN_BUTTON.read_text(encoding="utf-8")
-    lines = source.splitlines()
-    start = next(i for i, line in enumerate(lines) if line.startswith("def _expand_tcl("))
-    body_lines = []
-    for line in lines[start:]:
-        if body_lines and line and not line[0].isspace() and not line.startswith("def _expand_tcl"):
-            break
-        body_lines.append(line)
-    ns: dict = {"nuke": fake_nuke}
-    exec("\n".join(body_lines), ns)  # noqa: S102
-    return ns["_expand_tcl"]
+@pytest.fixture
+def fake_nuke(monkeypatch: pytest.MonkeyPatch) -> _FakeNuke:
+    """Install a fake ``nuke`` on the tcl_utils module for the duration of a test."""
+    fake = _FakeNuke()
+    monkeypatch.setattr(tcl_utils, "nuke", fake)
+    return fake
 
 
 class TestExpandTcl:
-    def test_non_str_value_returned_unchanged(self) -> None:
-        fake = _FakeNuke()
-        expand = _load_expand_tcl(fake)
-        assert expand(_FakeNode("Gizmo1"), "count", 5) == 5
-        assert expand(_FakeNode("Gizmo1"), "flag", None) is None
-        assert fake.calls == []
+    def test_non_str_value_returned_unchanged(self, fake_nuke: _FakeNuke) -> None:
+        assert _expand_tcl(_FakeNode("Gizmo1"), "count", 5) == 5
+        assert _expand_tcl(_FakeNode("Gizmo1"), "flag", None) is None
+        assert fake_nuke.calls == []
 
-    def test_str_without_bracket_returned_unchanged(self) -> None:
-        fake = _FakeNuke()
-        expand = _load_expand_tcl(fake)
-        assert expand(_FakeNode("Gizmo1"), "prompt", "hello") == "hello"
-        assert fake.calls == []
+    def test_str_without_bracket_returned_unchanged(self, fake_nuke: _FakeNuke) -> None:
+        assert _expand_tcl(_FakeNode("Gizmo1"), "prompt", "hello") == "hello"
+        assert fake_nuke.calls == []
 
-    def test_str_with_bracket_expanded_via_tcl_value(self) -> None:
-        fake = _FakeNuke(result="Gizmo1")
-        expand = _load_expand_tcl(fake)
-        assert expand(_FakeNode("Gizmo1"), "prompt", "[value this.name]") == "Gizmo1"
-        assert fake.calls == [("value", "Gizmo1.prompt")]
+    def test_str_with_bracket_expanded_via_tcl_value(self, fake_nuke: _FakeNuke) -> None:
+        fake_nuke.result = "Gizmo1"
+        assert _expand_tcl(_FakeNode("Gizmo1"), "prompt", "[value this.name]") == "Gizmo1"
+        assert fake_nuke.calls == [("value", "Gizmo1.prompt")]
 
-    def test_tcl_error_falls_back_to_raw(self) -> None:
-        fake = _FakeNuke(error=RuntimeError("bad expression"))
-        expand = _load_expand_tcl(fake)
+    def test_tcl_error_falls_back_to_raw(self, fake_nuke: _FakeNuke) -> None:
+        fake_nuke.error = RuntimeError("bad expression")
         raw = '[{"a": 1}, {"b": 2}]'
-        assert expand(_FakeNode("Gizmo1"), "config", raw) == raw
+        assert _expand_tcl(_FakeNode("Gizmo1"), "config", raw) == raw
 
-    def test_empty_expansion_falls_back_to_raw(self) -> None:
-        fake = _FakeNuke(result="")
-        expand = _load_expand_tcl(fake)
-        assert expand(_FakeNode("Gizmo1"), "prompt", "[value this.missing]") == "[value this.missing]"
+    def test_empty_tcl_expansion_passes_through(self, fake_nuke: _FakeNuke) -> None:
+        """A hand-typed expression evaluating to "" returns "" (not the raw text)."""
+        fake_nuke.result = ""
+        assert _expand_tcl(_FakeNode("Gizmo1"), "prompt", "[value this.missing]") == ""
 
-    def test_nested_node_path_used_in_tcl_call(self) -> None:
-        fake = _FakeNuke(result="/out")
-        expand = _load_expand_tcl(fake)
-        expand(_FakeNode("Group1.wf_v01"), "output_dir", "[file dirname [value root.name]]")
-        assert fake.calls == [("value", "Group1.wf_v01.output_dir")]
+    def test_nested_node_path_used_in_tcl_call(self, fake_nuke: _FakeNuke) -> None:
+        fake_nuke.result = "/out"
+        _expand_tcl(_FakeNode("Group1.wf_v01"), "output_dir", "[file dirname [value root.name]]")
+        assert fake_nuke.calls == [("value", "Group1.wf_v01.output_dir")]
 
-    def test_stored_link_expression_takes_precedence(self) -> None:
-        fake = _FakeNuke(result="should-not-be-used")
-        expand = _load_expand_tcl(fake)
+    def test_stored_link_expression_takes_precedence(self, fake_nuke: _FakeNuke) -> None:
+        fake_nuke.result = "should-not-be-used"
         node = _FakeNode("Gizmo1", {"_gt_expr_prompt": _FakeExprKnob("[value this.name]", evaluated="Gizmo1")})
-        assert expand(node, "prompt", "stale display text") == "Gizmo1"
-        assert fake.calls == []
+        assert _expand_tcl(node, "prompt", "stale display text") == "Gizmo1"
+        assert fake_nuke.calls == []
 
-    def test_empty_stored_expression_falls_through_to_raw(self) -> None:
-        fake = _FakeNuke()
-        expand = _load_expand_tcl(fake)
+    def test_empty_stored_expression_returns_empty(self, fake_nuke: _FakeNuke) -> None:
+        """A stored link that evaluates to "" returns "" — not the stale display text."""
+        node = _FakeNode("Gizmo1", {"_gt_expr_prompt": _FakeExprKnob("[value root.name]", evaluated="")})
+        assert _expand_tcl(node, "prompt", "stale display text") == ""
+        assert fake_nuke.calls == []
+
+    def test_blank_stored_expression_falls_through_to_raw(self, fake_nuke: _FakeNuke) -> None:
+        """No stored expression text at all -> fall through to the raw value."""
         node = _FakeNode("Gizmo1", {"_gt_expr_prompt": _FakeExprKnob("")})
-        assert expand(node, "prompt", "typed text") == "typed text"
+        assert _expand_tcl(node, "prompt", "typed text") == "typed text"
 
-    def test_failing_stored_expression_falls_through(self) -> None:
-        fake = _FakeNuke()
-        expand = _load_expand_tcl(fake)
+    def test_failing_stored_expression_falls_through(self, fake_nuke: _FakeNuke) -> None:
         node = _FakeNode("Gizmo1", {"_gt_expr_prompt": _FakeExprKnob("[bad", error=RuntimeError("bad expression"))})
-        assert expand(node, "prompt", "typed text") == "typed text"
+        assert _expand_tcl(node, "prompt", "typed text") == "typed text"


### PR DESCRIPTION
Updating to allow for expression linking.
Adds `Link` buttons to the nuke nodes, which can expression link to string inputs.
<img width="1194" height="538" alt="image" src="https://github.com/user-attachments/assets/bb528e93-7720-42db-876c-538a9599612d" />
<img width="598" height="265" alt="Screenshot 2026-07-28 at 2 37 22 PM" src="https://github.com/user-attachments/assets/7da0455e-15f3-4d39-a79e-8e2d4aef834d" />
<img width="606" height="268" alt="Screenshot 2026-07-28 at 2 37 38 PM" src="https://github.com/user-attachments/assets/af261e24-2f9c-4825-a553-c985cabf5c44" />
<img width="381" height="320" alt="Screenshot 2026-07-28 at 2 37 53 PM" src="https://github.com/user-attachments/assets/16ebfba1-4c30-4164-8558-97ee689b8194" />
