### PR TITLE
feat(gizmo): make published gizmos authenticate to Griptape Cloud headlessly

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -93,6 +93,12 @@ class NukeGizmoPublisher:
             # Package shared files (libraries, config, .env, pyproject.toml) into companion base.
             self._packager.package_to_folder(companion_base, workflow)
 
+            # Ensure the Griptape Cloud credential reaches the bundle. The desktop
+            # app injects it into the engine's process env at spawn without writing
+            # it to any .env file, so the packager (which reads .env files only)
+            # misses it — a gizmo would then fail cloud auth headlessly.
+            self._backfill_cloud_credential(companion_base)
+
             # Override the bundled project.yml with Nuke-specific output conventions
             # so outputs land next to the .nk file, not inside the companion bundle.
             self._customize_project_yml(companion_base)
@@ -195,6 +201,56 @@ class NukeGizmoPublisher:
             details = f"Failed to move file from '{source_path}' to '{destination_path}'."
             logger.error(details)
             raise TypeError(details)
+
+    # -- Credential backfill --
+
+    # Griptape Cloud accepts either credential as a Bearer token; the License is
+    # preferred when both are present (mirrors the engine/std-lib resolvers).
+    _CLOUD_CREDENTIAL_NAMES = ("GRIPTAPE_NODES_LICENSE", "GT_CLOUD_API_KEY")
+
+    @classmethod
+    def _backfill_cloud_credential(cls, companion_base: Path) -> None:
+        """Write the Griptape Cloud credential into the bundle .env if it is missing.
+
+        ``SecretsManager.get_secret`` reads the process env first, so it surfaces
+        a desktop-injected credential (License or API key) that never landed in an
+        on-disk .env. A value already present in the bundle .env is left untouched.
+        """
+        env_path = companion_base / ".env"
+        read_result = GriptapeNodes.handle_request(
+            ReadFileRequest(file_path=str(env_path), workspace_only=False, encoding="utf-8")
+        )
+        existing = (
+            read_result.content
+            if isinstance(read_result, ReadFileResultSuccess) and isinstance(read_result.content, str)
+            else ""
+        )
+        existing_keys = {
+            line.split("=", 1)[0].strip() for line in existing.splitlines() if "=" in line and not line.startswith("#")
+        }
+
+        secrets_manager = GriptapeNodes.SecretsManager()
+        additions = []
+        for name in cls._CLOUD_CREDENTIAL_NAMES:
+            if name in existing_keys:
+                continue
+            value = secrets_manager.get_secret(name, should_error_on_not_found=False)
+            if value:
+                additions.append(f'{name}="{value}"')
+
+        if not additions:
+            return
+
+        updated = (
+            existing.rstrip("\n") + "\n" + "\n".join(additions) + "\n"
+            if existing.strip()
+            else "\n".join(additions) + "\n"
+        )
+        write_result = GriptapeNodes.handle_request(
+            WriteFileRequest(file_path=str(env_path), content=updated, encoding="utf-8")
+        )
+        if not isinstance(write_result, WriteFileResultSuccess):
+            logger.warning("Could not backfill Griptape Cloud credential into bundle .env at '%s'.", env_path)
 
     # -- Project template customisation --
 

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -60,6 +60,10 @@ def _bootstrap_environment(nk_script_dir: str | None = None) -> None:
     # override=False: the bundled .env only fills env vars the parent Nuke
     # process did not already set, so a pipeline/farm job can supply its own
     # credentials (e.g. per-job GT_CLOUD_API_KEY) without being clobbered.
+    # The Griptape Cloud credential — a GT_CLOUD_API_KEY or a GRIPTAPE_NODES_LICENSE
+    # (enterprise) — travels through this .env; the engine's SecretsManager reads
+    # whichever is present, so cloud nodes authenticate headlessly the same way
+    # they do in the desktop app.
     env_path = script_dir / ".env"
     if env_path.exists():
         load_dotenv(env_path, override=False)

--- a/tests/unit/test_nuke_gizmo_publisher_credential.py
+++ b/tests/unit/test_nuke_gizmo_publisher_credential.py
@@ -1,0 +1,84 @@
+"""Tests for NukeGizmoPublisher._backfill_cloud_credential.
+
+The desktop injects the Griptape Cloud credential into the engine process env
+without writing it to any .env, so the packager misses it. The publisher must
+backfill it into the bundle .env from SecretsManager (which reads process env).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from griptape_nodes.retained_mode.events.os_events import ReadFileResultSuccess, WriteFileResultSuccess
+
+from publish_gizmo.nuke_gizmo_publisher import NukeGizmoPublisher
+
+_MODULE = "publish_gizmo.nuke_gizmo_publisher.GriptapeNodes"
+
+
+def _run_backfill(existing_env: str, secrets: dict[str, str | None]) -> str | None:
+    """Invoke _backfill_cloud_credential with a mocked bundle .env and SecretsManager.
+
+    Returns the content written to the bundle .env, or None if no write happened.
+    """
+    written: dict[str, str] = {}
+
+    def _handle_request(request):
+        req_type = type(request).__name__
+        if req_type == "ReadFileRequest":
+            result = MagicMock(spec=ReadFileResultSuccess)
+            result.content = existing_env
+            return result
+        if req_type == "WriteFileRequest":
+            written["content"] = request.content
+            return MagicMock(spec=WriteFileResultSuccess)
+        msg = f"unexpected request {req_type}"
+        raise AssertionError(msg)
+
+    secrets_manager = MagicMock()
+    secrets_manager.get_secret.side_effect = lambda name, **_: secrets.get(name)
+
+    with patch(_MODULE) as gtn:
+        gtn.handle_request.side_effect = _handle_request
+        gtn.SecretsManager.return_value = secrets_manager
+        NukeGizmoPublisher._backfill_cloud_credential(Path("/tmp/companion"))
+
+    return written.get("content")
+
+
+class TestBackfillCloudCredential:
+    def test_backfills_api_key_when_missing(self) -> None:
+        content = _run_backfill(existing_env="OTHER=1\n", secrets={"GT_CLOUD_API_KEY": "minted-key"})
+        assert content is not None
+        assert 'GT_CLOUD_API_KEY="minted-key"' in content
+        assert "OTHER=1" in content
+
+    def test_backfills_license_when_missing(self) -> None:
+        content = _run_backfill(
+            existing_env="",
+            secrets={"GRIPTAPE_NODES_LICENSE": "the-license", "GT_CLOUD_API_KEY": None},
+        )
+        assert content is not None
+        assert 'GRIPTAPE_NODES_LICENSE="the-license"' in content
+
+    def test_does_not_overwrite_existing_key(self) -> None:
+        content = _run_backfill(
+            existing_env='GT_CLOUD_API_KEY="on-disk-key"\n',
+            secrets={"GT_CLOUD_API_KEY": "process-env-key"},
+        )
+        # No write should occur because the key already exists in the bundle .env.
+        assert content is None
+
+    def test_no_credential_anywhere_writes_nothing(self) -> None:
+        content = _run_backfill(existing_env="OTHER=1\n", secrets={})
+        assert content is None
+
+    def test_backfills_both_when_both_present_and_missing(self) -> None:
+        content = _run_backfill(
+            existing_env="",
+            secrets={"GRIPTAPE_NODES_LICENSE": "the-license", "GT_CLOUD_API_KEY": "minted-key"},
+        )
+        assert content is not None
+        assert 'GRIPTAPE_NODES_LICENSE="the-license"' in content
+        assert 'GT_CLOUD_API_KEY="minted-key"' in content


### PR DESCRIPTION
## Problem
The desktop app injects the Griptape Cloud credential — `GT_CLOUD_API_KEY` (OAuth login) or `GRIPTAPE_NODES_LICENSE` (enterprise) — into the engine's process env at spawn, and never writes it to an on-disk `.env`. `WorkflowPackager` builds the bundle `.env` from `.env` files only, so a purely desktop-authenticated user published a gizmo whose `.env` silently lacked the credential. Cloud nodes then failed when the gizmo ran headlessly in Nuke, even though they worked in the app.

## Fix
`NukeGizmoPublisher._backfill_cloud_credential` runs right after packaging: it reads the bundle `.env` and, for any missing cloud credential, pulls it from `SecretsManager` (which reads the process env first) and appends it. A value already on disk wins. License is preferred over API key, matching the std-lib proxy resolver.

## Why no engine changes
The legacy engine cloud drivers (`api_client/client.py`, cloud storage, `build_griptape_cloud_model`) are not reached in the headless gizmo path (`LocalWorkflowExecutor`, LOCAL storage). Common cloud nodes authenticate via the std-lib `resolve_proxy_api_key`, which is already license-aware. So the fix lives entirely in the Nuke publisher.

## Related
A companion change to `GriptapeCloudPrompt` in griptape-nodes-library-standard (use `resolve_proxy_api_key`) is tracked separately.

## Tests
`tests/unit/test_nuke_gizmo_publisher_credential.py` — 5 cases (backfill API key / license / both, on-disk wins, nothing-to-capture). `make check` + full unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)