### PR TITLE
chore: add CI/CD workflows and harden Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -34,3 +36,28 @@ jobs:
 
       - name: Run checks
         run: make check
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: make install/dev
+
+      - name: Run unit tests
+        run: make test/unit

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,47 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: make test/unit
+
+      - name: Delete existing nightly release
+        run: gh release delete nightly --yes || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Move nightly tag
+        run: |
+          git tag -f nightly
+          git push -f origin nightly
+
+      - name: Create nightly release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: nightly
+          name: nightly
+          generate_release_notes: true
+          make_latest: false
+          prerelease: true

--- a/.github/workflows/version-bump-minor.yml
+++ b/.github/workflows/version-bump-minor.yml
@@ -8,20 +8,42 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Create bump branch
+        run: git checkout -b bump-tmp
+
       - name: Bump minor version
         run: make version/minor
 
-      - name: Push changes
-        run: git push
+      - name: Push bump branch
+        run: |
+          VERSION=$(make version/get)
+          git push origin "bump-tmp:chore/bump-v${VERSION}"
+
+      - name: Open PR with auto-merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          VERSION=$(make version/get)
+          BRANCH="chore/bump-v${VERSION}"
+          if ! gh pr view "${BRANCH}" --json number -q .number 2>/dev/null; then
+            gh pr create \
+              --title "chore: bump v${VERSION}" \
+              --body "Automated version bump to v${VERSION}." \
+              --base main \
+              --head "${BRANCH}"
+          fi
+          gh pr merge "${BRANCH}" --auto --squash

--- a/.github/workflows/version-bump-patch.yml
+++ b/.github/workflows/version-bump-patch.yml
@@ -8,20 +8,42 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Create bump branch
+        run: git checkout -b bump-tmp
+
       - name: Bump patch version
         run: make version/patch
 
-      - name: Push changes
-        run: git push
+      - name: Push bump branch
+        run: |
+          VERSION=$(make version/get)
+          git push origin "bump-tmp:chore/bump-v${VERSION}"
+
+      - name: Open PR with auto-merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          VERSION=$(make version/get)
+          BRANCH="chore/bump-v${VERSION}"
+          if ! gh pr view "${BRANCH}" --json number -q .number 2>/dev/null; then
+            gh pr create \
+              --title "chore: bump v${VERSION}" \
+              --body "Automated version bump to v${VERSION}." \
+              --base main \
+              --head "${BRANCH}"
+          fi
+          gh pr merge "${BRANCH}" --auto --squash

--- a/.github/workflows/version-publish.yml
+++ b/.github/workflows/version-publish.yml
@@ -15,11 +15,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Get current version
         id: version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+MAKEFLAGS += --no-print-directory
 
 LIBRARY_JSON := griptape-nodes-library.json
 
@@ -10,42 +11,42 @@ version/get: ## Get version.
 version/set: ## Set version. Usage: make version/set v=1.2.3
 	@jq --arg v "$(v)" '.metadata.library_version = $$v' $(LIBRARY_JSON) > $(LIBRARY_JSON).tmp
 	@mv $(LIBRARY_JSON).tmp $(LIBRARY_JSON)
-	@make version/commit
+	@$(MAKE) version/commit
 
 .PHONY: version/patch
 version/patch: ## Bump patch version.
-	@CURRENT=$$(make version/get); \
+	@CURRENT=$$($(MAKE) version/get); \
 	IFS='.' read -r major minor patch <<< "$$CURRENT"; \
 	NEW_VERSION="$${major}.$${minor}.$$((patch + 1))"; \
 	jq --arg v "$$NEW_VERSION" '.metadata.library_version = $$v' $(LIBRARY_JSON) > $(LIBRARY_JSON).tmp; \
 	mv $(LIBRARY_JSON).tmp $(LIBRARY_JSON); \
 	echo "Bumped to $$NEW_VERSION"
-	@make version/commit
+	@$(MAKE) version/commit
 
 .PHONY: version/minor
 version/minor: ## Bump minor version.
-	@CURRENT=$$(make version/get); \
+	@CURRENT=$$($(MAKE) version/get); \
 	IFS='.' read -r major minor patch <<< "$$CURRENT"; \
 	NEW_VERSION="$${major}.$$((minor + 1)).0"; \
 	jq --arg v "$$NEW_VERSION" '.metadata.library_version = $$v' $(LIBRARY_JSON) > $(LIBRARY_JSON).tmp; \
 	mv $(LIBRARY_JSON).tmp $(LIBRARY_JSON); \
 	echo "Bumped to $$NEW_VERSION"
-	@make version/commit
+	@$(MAKE) version/commit
 
 .PHONY: version/major
 version/major: ## Bump major version.
-	@CURRENT=$$(make version/get); \
+	@CURRENT=$$($(MAKE) version/get); \
 	IFS='.' read -r major minor patch <<< "$$CURRENT"; \
 	NEW_VERSION="$$((major + 1)).0.0"; \
 	jq --arg v "$$NEW_VERSION" '.metadata.library_version = $$v' $(LIBRARY_JSON) > $(LIBRARY_JSON).tmp; \
 	mv $(LIBRARY_JSON).tmp $(LIBRARY_JSON); \
 	echo "Bumped to $$NEW_VERSION"
-	@make version/commit
+	@$(MAKE) version/commit
 
 .PHONY: version/commit
 version/commit: ## Commit version.
 	@git add $(LIBRARY_JSON)
-	@git commit -m "chore: bump v$$(make version/get)"
+	@git commit -m "chore: bump v$$($(MAKE) version/get)"
 
 .PHONY: version/publish
 version/publish: ## Create and push git tags.
@@ -68,7 +69,7 @@ print(f'Synced {len(deps)} dependencies to $(LIBRARY_JSON)')"
 
 .PHONY: install
 install: ## Install all dependencies.
-	@make install/all
+	@$(MAKE) install/all
 
 .PHONY: install/core
 install/core: deps/sync ## Install core dependencies.
@@ -92,8 +93,16 @@ format: ## Format project.
 
 .PHONY: fix
 fix: ## Fix project.
-	@make format
+	@$(MAKE) format
 	@uv run ruff check --fix --unsafe-fixes
+
+.PHONY: test
+test: ## Run tests.
+	@uv run pytest
+
+.PHONY: test/unit
+test/unit: ## Run unit tests.
+	@uv run pytest tests/unit
 
 .PHONY: check
 check: check/format check/lint check/types check/json ## Run all checks.


### PR DESCRIPTION
## Summary

- **Split CI** into separate `check` and `test` jobs; add `permissions: contents: read` to both
- **Add `nightly-release.yml`**: daily prerelease at 02:00 UTC, gated on `make test/unit`
- **Harden version-bump workflows**: PR-based auto-merge flow via `RELEASE_PAT` instead of pushing directly to `main`
- **`version-publish.yml`**: remove unnecessary `Configure Git` step
- **Makefile**: add `MAKEFLAGS += --no-print-directory`, replace bare `make` with `$(MAKE)` in recursive calls, add `test` and `test/unit` targets

Mirrors the machinery added to `griptape-nodes-library-opencolorio` in commit `ea33404`.

## Prerequisites

`RELEASE_PAT` must be added as a GitHub Actions secret (with `contents: write` and `pull-requests: write` scope) before the version-bump workflows can open and auto-merge PRs.

## Test plan

- [x] `make check` passes locally
- [x] `make test/unit` passes locally (193 tests)
- [ ] CI runs green on this PR
- [ ] Nightly workflow fires at 02:00 UTC and produces a prerelease