### PR TITLE
fix(gizmo): create per-machine venv + config instead of shared-drive

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import shutil
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -93,6 +95,12 @@ class NukeGizmoPublisher:
             # Package shared files (libraries, config, .env, pyproject.toml) into companion base.
             self._packager.package_to_folder(companion_base, workflow)
 
+            # Generate a uv.lock so the shared companion carries a pinned lockfile.
+            # At run time the gizmo sets UV_FROZEN, so uv never writes back to the
+            # (possibly read-only) shared drive.
+            self._packager.emit_progress(5.0, "Locking dependencies...")
+            self._write_lockfile(companion_base)
+
             # Override the bundled project.yml with Nuke-specific output conventions
             # so outputs land next to the .nk file, not inside the companion bundle.
             self._customize_project_yml(companion_base)
@@ -163,6 +171,36 @@ class NukeGizmoPublisher:
         except Exception as e:
             logger.exception("Failed to publish workflow '%s'", self._workflow_name)
             return PublishWorkflowResultFailure(result_details=f"Failed to publish workflow: {e}")
+
+    # -- Dependency locking --
+
+    @staticmethod
+    def _write_lockfile(companion_base: Path) -> None:
+        """Generate a uv.lock in the companion from its pyproject.toml.
+
+        Best-effort: a missing uv or a lock failure is logged and swallowed so
+        publishing still succeeds — the run button installs uv and resolves on
+        first run if no lock ships.
+        """
+        uv = shutil.which("uv")
+        if not uv:
+            logger.warning("uv not found on PATH; skipping uv.lock generation. Gizmo will resolve deps at run time.")
+            return
+        try:
+            result = subprocess.run(  # noqa: S603
+                [uv, "lock", "--project", str(companion_base)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as err:
+            logger.warning("uv lock failed (%s); gizmo will resolve deps at run time.", err)
+            return
+        if result.returncode != 0:
+            logger.warning(
+                "uv lock exited %d; gizmo will resolve deps at run time.\n%s", result.returncode, result.stderr
+            )
 
     # -- File copy helpers --
 

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -22,13 +22,18 @@ import os
 import sys
 from pathlib import Path
 
-# Redirect the engine's USER config into a throwaway dir inside the bundle so
-# per-run project paths (and any other engine writes) never pollute the user's
-# global ~/.config/griptape_nodes.  Must be set before any griptape_nodes import
-# because xdg_config_home() is evaluated once at config_manager import time.
-# The guard lets run_button.py's explicit env= take precedence when set by the parent.
+# Redirect the engine's USER config off the user's global ~/.config/griptape_nodes
+# so per-run project paths (and any other engine writes) never pollute it.  Must
+# be set before any griptape_nodes import because xdg_config_home() is evaluated
+# once at config_manager import time.  The guard lets run_button.py's explicit
+# env= take precedence — in normal gizmo runs the parent always sets this to a
+# per-machine dir.  This fallback only fires for standalone/debug invocations of
+# this script; it points at a per-machine path (never the possibly-shared bundle)
+# so a bundle on a read-only or shared drive can't break the run.
 if not os.environ.get("XDG_CONFIG_HOME"):
-    os.environ["XDG_CONFIG_HOME"] = str(Path(__file__).resolve().parent / ".gtn_config").replace("\\", "/")
+    _data_home = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    _config_home = Path(_data_home) / "griptape_nodes" / "gizmo_standalone_config"
+    os.environ["XDG_CONFIG_HOME"] = str(_config_home).replace("\\", "/")
 
 import argparse  # noqa: E402
 import importlib.util  # noqa: E402

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -56,6 +56,16 @@ except ImportError:
     _SENTINEL = ""
 
 
+def _venv_root() -> str:
+    """Return the per-machine base dir under which gizmo venvs/configs live.
+
+    Honors XDG_DATA_HOME so sites with roaming home directories can relocate the
+    venv root onto machine-local storage; falls back to ~/.local/share.
+    """
+    data_home = os.environ.get("XDG_DATA_HOME") or os.path.join(os.path.expanduser("~"), ".local", "share")
+    return os.path.join(data_home, "griptape_nodes", "venvs")
+
+
 def _gizmo_local_dir(companion: str, workflow_stem: str) -> str:
     """Return the per-machine base dir for this gizmo's venv and config.
 
@@ -63,29 +73,31 @@ def _gizmo_local_dir(companion: str, workflow_stem: str) -> str:
     venv/config must be created locally — a venv built for one artist's machine
     crashes on another's. Deriving a per-machine path keyed on the shared
     companion location keeps distinct gizmos separate and the same gizmo stable
-    across sessions on a given machine. companion must already be an absolute
-    forward-slashed path so the hash is stable regardless of the OS that stored
-    it. Returns an absolute forward-slashed path.
+    across sessions on a given machine. Returns an absolute forward-slashed path.
     """
     slug = re.sub(r"[^a-z0-9]+", "-", workflow_stem.lower()).strip("-") or "gizmo"
-    digest = hashlib.sha256(companion.encode("utf-8")).hexdigest()[:8]
-    base = os.path.join(os.path.expanduser("~"), ".local", "share", "griptape_nodes", "venvs")
-    return os.path.join(base, f"{slug}-{digest}").replace("\\", "/")
+    # normcase(realpath(...)) collapses case- and symlink-variant companion paths
+    # (e.g. C:/ vs c:/, relative vs absolute) so one gizmo keeps one venv.
+    normalized = os.path.normcase(os.path.realpath(companion))
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:8]
+    return os.path.join(_venv_root(), f"{slug}-{digest}").replace("\\", "/")
 
 
-def _build_child_env(companion: str, local_dir: str, base_env: dict) -> dict:
+def _build_child_env(local_dir: str, base_env: dict) -> dict:
     """Return a subprocess env pointing config and the uv venv at the local dir.
 
     XDG_CONFIG_HOME keeps engine config writes (e.g. projects_to_register) out of
-    the user's global ~/.config, and UV_PROJECT_ENVIRONMENT redirects uv's venv
-    away from <companion>/.venv (which would be shared-drive) to a per-machine
-    location. companion is still passed for signature stability; local_dir must
-    already be an absolute forward-slashed path.
+    the user's global ~/.config, UV_PROJECT_ENVIRONMENT redirects uv's venv away
+    from <companion>/.venv (which would be shared-drive) to a per-machine
+    location, and UV_FROZEN stops uv from writing uv.lock back to the (possibly
+    read-only) shared companion dir. local_dir must already be an absolute
+    forward-slashed path.
     """
     return {
         **base_env,
         "XDG_CONFIG_HOME": local_dir + "/.gtn_config",
         "UV_PROJECT_ENVIRONMENT": local_dir + "/.venv",
+        "UV_FROZEN": "1",
     }
 
 
@@ -308,7 +320,9 @@ node["_companion_dir"].setValue(companion)
 # and engine config must be created on THIS machine, not shared, or a venv built
 # for one artist crashes on another's. Keyed on the normalized companion path so
 # it is stable across sessions and unique per gizmo.
-_workflow_stem = os.path.splitext(_config.get("workflow_name", "") or _workflow_filename)[0]
+# workflow_name is already a stem (the publisher passes workflow_file_path.stem);
+# only the workflow_filename fallback carries an extension to strip.
+_workflow_stem = _config.get("workflow_name", "") or os.path.splitext(_workflow_filename)[0]
 _local_dir = _gizmo_local_dir(companion, _workflow_stem)
 os.makedirs(_local_dir, exist_ok=True)
 
@@ -316,7 +330,7 @@ os.makedirs(_local_dir, exist_ok=True)
 # user config writes (e.g. the projects_to_register list) out of the user's
 # global ~/.config, and UV_PROJECT_ENVIRONMENT redirects uv's venv off the
 # (possibly shared) companion dir onto this machine's local dir.
-_child_env = _build_child_env(companion, _local_dir, os.environ)
+_child_env = _build_child_env(_local_dir, os.environ)
 
 # -- Resolve workflow file from version subdir --
 

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -24,9 +24,11 @@ packages available). ``nuke`` is already in scope when exec'd from the gizmo.
 Qt (PySide2 or PySide6) is bundled with Nuke and available here.
 """
 
+import hashlib
 import json
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -54,14 +56,37 @@ except ImportError:
     _SENTINEL = ""
 
 
-def _build_child_env(companion: str, base_env: dict) -> dict:
-    """Return a subprocess env with XDG_CONFIG_HOME redirected into the bundle.
+def _gizmo_local_dir(companion: str, workflow_stem: str) -> str:
+    """Return the per-machine base dir for this gizmo's venv and config.
 
-    Keeps all engine config writes (e.g. projects_to_register) inside the
-    throwaway companion directory instead of the user's global ~/.config.
-    companion must already be an absolute forward-slashed path.
+    The gizmo (and its pyproject.toml) live on a shared drive, but each artist's
+    venv/config must be created locally — a venv built for one artist's machine
+    crashes on another's. Deriving a per-machine path keyed on the shared
+    companion location keeps distinct gizmos separate and the same gizmo stable
+    across sessions on a given machine. companion must already be an absolute
+    forward-slashed path so the hash is stable regardless of the OS that stored
+    it. Returns an absolute forward-slashed path.
     """
-    return {**base_env, "XDG_CONFIG_HOME": companion + "/.gtn_config"}
+    slug = re.sub(r"[^a-z0-9]+", "-", workflow_stem.lower()).strip("-") or "gizmo"
+    digest = hashlib.sha256(companion.encode("utf-8")).hexdigest()[:8]
+    base = os.path.join(os.path.expanduser("~"), ".local", "share", "griptape_nodes", "venvs")
+    return os.path.join(base, f"{slug}-{digest}").replace("\\", "/")
+
+
+def _build_child_env(companion: str, local_dir: str, base_env: dict) -> dict:
+    """Return a subprocess env pointing config and the uv venv at the local dir.
+
+    XDG_CONFIG_HOME keeps engine config writes (e.g. projects_to_register) out of
+    the user's global ~/.config, and UV_PROJECT_ENVIRONMENT redirects uv's venv
+    away from <companion>/.venv (which would be shared-drive) to a per-machine
+    location. companion is still passed for signature stability; local_dir must
+    already be an absolute forward-slashed path.
+    """
+    return {
+        **base_env,
+        "XDG_CONFIG_HOME": local_dir + "/.gtn_config",
+        "UV_PROJECT_ENVIRONMENT": local_dir + "/.venv",
+    }
 
 
 # Qt is bundled with Nuke. Try PySide6 first (Nuke 16+), fall back to PySide2 (Nuke 13–15).
@@ -278,11 +303,20 @@ if not companion or not os.path.isdir(companion):
 companion = companion.replace("\\", "/")
 node["_companion_dir"].setValue(companion)
 
-# Build the child-process environment once.  Redirecting XDG_CONFIG_HOME into a
-# bundle-local subdir ensures the engine's user config writes (e.g. the
-# projects_to_register list) stay inside the throwaway bundle directory and never
-# pollute the user's global ~/.config/griptape_nodes.
-_child_env = _build_child_env(companion, os.environ)
+# -- Resolve the per-machine local dir (venv + config) --
+# The companion (and its pyproject.toml) may live on a shared drive; the venv
+# and engine config must be created on THIS machine, not shared, or a venv built
+# for one artist crashes on another's. Keyed on the normalized companion path so
+# it is stable across sessions and unique per gizmo.
+_workflow_stem = os.path.splitext(_config.get("workflow_name", "") or _workflow_filename)[0]
+_local_dir = _gizmo_local_dir(companion, _workflow_stem)
+os.makedirs(_local_dir, exist_ok=True)
+
+# Build the child-process environment once.  XDG_CONFIG_HOME keeps the engine's
+# user config writes (e.g. the projects_to_register list) out of the user's
+# global ~/.config, and UV_PROJECT_ENVIRONMENT redirects uv's venv off the
+# (possibly shared) companion dir onto this machine's local dir.
+_child_env = _build_child_env(companion, _local_dir, os.environ)
 
 # -- Resolve workflow file from version subdir --
 
@@ -417,7 +451,7 @@ else:
                     uv = _p
                     break
 
-    if not os.path.isdir(os.path.join(companion, ".venv")):
+    if not os.path.isdir(os.path.join(_local_dir, ".venv")):
         _pre_dialog_logs.append(
             "Building your gizmo python environment...\n"
             "This will take a few minutes the first gizmo run, but will be faster on subsequent gizmo runs."

--- a/tests/unit/test_nuke_gizmo_publisher_lock.py
+++ b/tests/unit/test_nuke_gizmo_publisher_lock.py
@@ -1,0 +1,64 @@
+"""Tests for the publisher's uv.lock generation step (best-effort, never fatal)."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+_PUBLISHER = Path(__file__).parent.parent.parent / "publish_gizmo" / "nuke_gizmo_publisher.py"
+
+
+def _load_write_lockfile(shutil_mod, subprocess_mod, logger):
+    """Extract _write_lockfile from the publisher without importing griptape_nodes."""
+    src = _PUBLISHER.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_write_lockfile":
+            func_src = textwrap.dedent(ast.get_source_segment(src, node) or "")
+            ns: dict = {"shutil": shutil_mod, "subprocess": subprocess_mod, "logger": logger, "Path": Path}
+            exec(func_src, ns)  # noqa: S102
+            return ns["_write_lockfile"]
+    msg = "_write_lockfile not found in nuke_gizmo_publisher.py"
+    raise AssertionError(msg)
+
+
+class TestWriteLockfile:
+    def test_runs_uv_lock_with_project(self, tmp_path) -> None:
+        run = mock.Mock(return_value=SimpleNamespace(returncode=0, stderr=""))
+        subprocess_mod = SimpleNamespace(run=run, SubprocessError=subprocess.SubprocessError)
+        fn = _load_write_lockfile(SimpleNamespace(which=lambda _: "/usr/bin/uv"), subprocess_mod, mock.Mock())
+        fn(tmp_path)
+        cmd = run.call_args[0][0]
+        assert cmd[:3] == ["/usr/bin/uv", "lock", "--project"]
+        assert cmd[3] == str(tmp_path)
+
+    def test_skips_when_uv_absent(self, tmp_path) -> None:
+        run = mock.Mock()
+        subprocess_mod = SimpleNamespace(run=run, SubprocessError=subprocess.SubprocessError)
+        logger = mock.Mock()
+        fn = _load_write_lockfile(SimpleNamespace(which=lambda _: None), subprocess_mod, logger)
+        fn(tmp_path)
+        run.assert_not_called()
+        logger.warning.assert_called_once()
+
+    def test_swallows_nonzero_exit(self, tmp_path) -> None:
+        run = mock.Mock(return_value=SimpleNamespace(returncode=1, stderr="boom"))
+        subprocess_mod = SimpleNamespace(run=run, SubprocessError=subprocess.SubprocessError)
+        logger = mock.Mock()
+        fn = _load_write_lockfile(SimpleNamespace(which=lambda _: "/usr/bin/uv"), subprocess_mod, logger)
+        fn(tmp_path)  # must not raise
+        logger.warning.assert_called_once()
+
+    def test_swallows_subprocess_error(self, tmp_path) -> None:
+        def _raise(*_a, **_k):
+            raise OSError("no exec")
+
+        subprocess_mod = SimpleNamespace(run=_raise, SubprocessError=subprocess.SubprocessError)
+        logger = mock.Mock()
+        fn = _load_write_lockfile(SimpleNamespace(which=lambda _: "/usr/bin/uv"), subprocess_mod, logger)
+        fn(tmp_path)  # must not raise
+        logger.warning.assert_called_once()

--- a/tests/unit/test_run_button_env.py
+++ b/tests/unit/test_run_button_env.py
@@ -1,61 +1,107 @@
-"""Tests for run_button._build_child_env — the bundle config isolation helper."""
+"""Tests for run_button's per-machine local-dir + config isolation helpers."""
 
 from __future__ import annotations
 
+import hashlib
+import os
+import re
 from pathlib import Path
 
 # run_button.py is exec'd in Nuke's interpreter and references nuke/Qt at module
-# scope, so it can't be imported normally.  Import only the pure helper by
-# inserting the source dir and importing the function via exec into a namespace.
+# scope, so it can't be imported normally.  Import only the pure helpers by
+# slicing their source out and exec'ing into a namespace seeded with the stdlib
+# modules those helpers reference.
 _RUN_BUTTON = Path(__file__).parent.parent.parent / "publish_gizmo" / "run_button.py"
 
 
-def _load_build_child_env():
-    """Extract _build_child_env from run_button.py without running its top-level Nuke code."""
+def _load_func(func_name: str):
+    """Extract a top-level function from run_button.py without running its Nuke code."""
     source = _RUN_BUTTON.read_text(encoding="utf-8")
-    # Isolate just the function definition.
     lines = source.splitlines()
-    start = next(i for i, line in enumerate(lines) if line.startswith("def _build_child_env("))
-    # Collect lines until the next top-level definition or blank-then-non-blank pair.
-    body_lines = []
-    for line in lines[start:]:
-        if body_lines and line and not line[0].isspace() and not line.startswith("def _build_child_env"):
+    start = next(i for i, line in enumerate(lines) if line.startswith(f"def {func_name}("))
+    # Collect lines until the next top-level statement (dedent to column 0).
+    body_lines = [lines[start]]
+    for line in lines[start + 1 :]:
+        if line and not line[0].isspace():
             break
         body_lines.append(line)
-    ns: dict = {}
+    ns: dict = {"os": os, "re": re, "hashlib": hashlib}
     exec("\n".join(body_lines), ns)  # noqa: S102
-    return ns["_build_child_env"]
+    return ns[func_name]
 
 
-_build_child_env = _load_build_child_env()
+_build_child_env = _load_func("_build_child_env")
+_gizmo_local_dir = _load_func("_gizmo_local_dir")
+
+
+class TestGizmoLocalDir:
+    """The per-machine venv/config base dir derivation."""
+
+    def test_under_griptape_nodes_venvs(self) -> None:
+        d = _gizmo_local_dir("/mnt/share/griptape/my_workflow", "my_workflow")
+        assert "/.local/share/griptape_nodes/venvs/" in d
+
+    def test_is_absolute_and_forward_slashed(self) -> None:
+        d = _gizmo_local_dir("C:/share/griptape/my_workflow", "my_workflow")
+        assert "\\" not in d
+        assert Path(d).is_absolute() or d.startswith(str(Path.home()).replace("\\", "/"))
+
+    def test_name_is_slug_dash_hash8(self) -> None:
+        d = _gizmo_local_dir("/mnt/share/griptape/My Workflow!", "My Workflow!")
+        name = d.rsplit("/", 1)[-1]
+        assert re.fullmatch(r"my-workflow-[0-9a-f]{8}", name), name
+
+    def test_stable_for_same_inputs(self) -> None:
+        a = _gizmo_local_dir("/mnt/share/griptape/wf", "wf")
+        b = _gizmo_local_dir("/mnt/share/griptape/wf", "wf")
+        assert a == b
+
+    def test_distinct_companion_paths_yield_distinct_dirs(self) -> None:
+        a = _gizmo_local_dir("/mnt/share/griptape/wf", "wf")
+        b = _gizmo_local_dir("/other/share/griptape/wf", "wf")
+        assert a != b
+
+    def test_empty_stem_falls_back_to_gizmo_slug(self) -> None:
+        d = _gizmo_local_dir("/mnt/share/griptape/wf", "")
+        name = d.rsplit("/", 1)[-1]
+        assert name.startswith("gizmo-")
 
 
 class TestBuildChildEnv:
-    def test_sets_xdg_config_home_inside_bundle(self) -> None:
-        """XDG_CONFIG_HOME must point at <companion>/.gtn_config."""
-        env = _build_child_env("/some/bundle", {})
-        assert env["XDG_CONFIG_HOME"] == "/some/bundle/.gtn_config"
+    _LOCAL = "/home/user/.local/share/griptape_nodes/venvs/wf-abcd1234"
 
-    def test_xdg_config_home_is_absolute(self) -> None:
-        env = _build_child_env("/abs/path/bundle", {})
-        assert Path(env["XDG_CONFIG_HOME"]).is_absolute()
+    def test_sets_xdg_config_home_under_local_dir(self) -> None:
+        """XDG_CONFIG_HOME must point at <local_dir>/.gtn_config, not the companion."""
+        env = _build_child_env("/some/bundle", self._LOCAL, {})
+        assert env["XDG_CONFIG_HOME"] == self._LOCAL + "/.gtn_config"
 
-    def test_xdg_config_home_uses_forward_slashes(self) -> None:
+    def test_sets_uv_project_environment_under_local_dir(self) -> None:
+        """UV_PROJECT_ENVIRONMENT redirects uv's venv off the shared companion dir."""
+        env = _build_child_env("/some/bundle", self._LOCAL, {})
+        assert env["UV_PROJECT_ENVIRONMENT"] == self._LOCAL + "/.venv"
+
+    def test_config_and_venv_not_in_companion(self) -> None:
+        env = _build_child_env("/mnt/share/griptape/wf", self._LOCAL, {})
+        assert "/mnt/share/" not in env["XDG_CONFIG_HOME"]
+        assert "/mnt/share/" not in env["UV_PROJECT_ENVIRONMENT"]
+
+    def test_paths_are_forward_slashed(self) -> None:
         """Forward slashes required — Nuke/TCL treats backslashes as escapes."""
-        env = _build_child_env("C:/Users/jadan/.nuke/griptape/myWorkflow", {})
+        env = _build_child_env("C:/Users/jadan/.nuke/griptape/myWorkflow", self._LOCAL, {})
         assert "\\" not in env["XDG_CONFIG_HOME"]
+        assert "\\" not in env["UV_PROJECT_ENVIRONMENT"]
 
     def test_preserves_all_base_env_keys(self) -> None:
         """All existing env keys must be present in the child env."""
         base = {"PATH": "/usr/bin", "HOME": "/home/user", "CUSTOM_VAR": "value"}
-        env = _build_child_env("/bundle", base)
+        env = _build_child_env("/bundle", self._LOCAL, base)
         for key, value in base.items():
             assert env[key] == value
 
     def test_does_not_mutate_base_env(self) -> None:
         base = {"PATH": "/usr/bin"}
         original_base = dict(base)
-        _build_child_env("/bundle", base)
+        _build_child_env("/bundle", self._LOCAL, base)
         assert base == original_base
 
 

--- a/tests/unit/test_run_button_env.py
+++ b/tests/unit/test_run_button_env.py
@@ -14,24 +14,28 @@ from pathlib import Path
 _RUN_BUTTON = Path(__file__).parent.parent.parent / "publish_gizmo" / "run_button.py"
 
 
-def _load_func(func_name: str):
-    """Extract a top-level function from run_button.py without running its Nuke code."""
+def _func_source(func_name: str) -> str:
+    """Return the source lines of a top-level function from run_button.py."""
     source = _RUN_BUTTON.read_text(encoding="utf-8")
     lines = source.splitlines()
     start = next(i for i, line in enumerate(lines) if line.startswith(f"def {func_name}("))
-    # Collect lines until the next top-level statement (dedent to column 0).
     body_lines = [lines[start]]
     for line in lines[start + 1 :]:
         if line and not line[0].isspace():
             break
         body_lines.append(line)
-    ns: dict = {"os": os, "re": re, "hashlib": hashlib}
-    exec("\n".join(body_lines), ns)  # noqa: S102
-    return ns[func_name]
+    return "\n".join(body_lines)
 
 
-_build_child_env = _load_func("_build_child_env")
-_gizmo_local_dir = _load_func("_gizmo_local_dir")
+# Load the pure helpers into one shared namespace so _gizmo_local_dir can call
+# _venv_root, without running run_button.py's module-scope Nuke/Qt code.
+_NS: dict = {"os": os, "re": re, "hashlib": hashlib}
+for _name in ("_venv_root", "_gizmo_local_dir", "_build_child_env"):
+    exec(_func_source(_name), _NS)  # noqa: S102
+
+_venv_root = _NS["_venv_root"]
+_build_child_env = _NS["_build_child_env"]
+_gizmo_local_dir = _NS["_gizmo_local_dir"]
 
 
 class TestGizmoLocalDir:
@@ -66,42 +70,73 @@ class TestGizmoLocalDir:
         name = d.rsplit("/", 1)[-1]
         assert name.startswith("gizmo-")
 
+    def test_hash_is_case_and_realpath_normalized(self, tmp_path) -> None:
+        """Case-variant companion paths for the same dir map to one venv."""
+        real = tmp_path / "griptape" / "wf"
+        real.mkdir(parents=True)
+        a = _gizmo_local_dir(str(real), "wf")
+        b = _gizmo_local_dir(os.path.normcase(str(real)), "wf")
+        assert a == b
+
+    def test_honors_xdg_data_home(self, monkeypatch) -> None:
+        """XDG_DATA_HOME relocates the venv root off a (possibly roaming) home."""
+        monkeypatch.setenv("XDG_DATA_HOME", "/scratch/local")
+        d = _gizmo_local_dir("/mnt/share/griptape/wf", "wf")
+        assert d.startswith("/scratch/local/griptape_nodes/venvs/")
+
+
+class TestVenvRoot:
+    def test_defaults_under_local_share(self, monkeypatch) -> None:
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        root = _venv_root()
+        assert root.endswith(os.path.join("griptape_nodes", "venvs"))
+        assert ".local" in root and "share" in root
+
+    def test_honors_xdg_data_home(self, monkeypatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", "/scratch/local")
+        assert _venv_root() == os.path.join("/scratch/local", "griptape_nodes", "venvs")
+
 
 class TestBuildChildEnv:
     _LOCAL = "/home/user/.local/share/griptape_nodes/venvs/wf-abcd1234"
 
     def test_sets_xdg_config_home_under_local_dir(self) -> None:
         """XDG_CONFIG_HOME must point at <local_dir>/.gtn_config, not the companion."""
-        env = _build_child_env("/some/bundle", self._LOCAL, {})
+        env = _build_child_env(self._LOCAL, {})
         assert env["XDG_CONFIG_HOME"] == self._LOCAL + "/.gtn_config"
 
     def test_sets_uv_project_environment_under_local_dir(self) -> None:
         """UV_PROJECT_ENVIRONMENT redirects uv's venv off the shared companion dir."""
-        env = _build_child_env("/some/bundle", self._LOCAL, {})
+        env = _build_child_env(self._LOCAL, {})
         assert env["UV_PROJECT_ENVIRONMENT"] == self._LOCAL + "/.venv"
 
+    def test_sets_uv_frozen(self) -> None:
+        """UV_FROZEN stops uv writing uv.lock back to the shared companion dir."""
+        env = _build_child_env(self._LOCAL, {})
+        assert env["UV_FROZEN"] == "1"
+
     def test_config_and_venv_not_in_companion(self) -> None:
-        env = _build_child_env("/mnt/share/griptape/wf", self._LOCAL, {})
+        env = _build_child_env(self._LOCAL, {})
         assert "/mnt/share/" not in env["XDG_CONFIG_HOME"]
         assert "/mnt/share/" not in env["UV_PROJECT_ENVIRONMENT"]
 
     def test_paths_are_forward_slashed(self) -> None:
         """Forward slashes required — Nuke/TCL treats backslashes as escapes."""
-        env = _build_child_env("C:/Users/jadan/.nuke/griptape/myWorkflow", self._LOCAL, {})
+        env = _build_child_env(self._LOCAL, {})
         assert "\\" not in env["XDG_CONFIG_HOME"]
         assert "\\" not in env["UV_PROJECT_ENVIRONMENT"]
 
     def test_preserves_all_base_env_keys(self) -> None:
         """All existing env keys must be present in the child env."""
         base = {"PATH": "/usr/bin", "HOME": "/home/user", "CUSTOM_VAR": "value"}
-        env = _build_child_env("/bundle", self._LOCAL, base)
+        env = _build_child_env(self._LOCAL, base)
         for key, value in base.items():
             assert env[key] == value
 
     def test_does_not_mutate_base_env(self) -> None:
         base = {"PATH": "/usr/bin"}
         original_base = dict(base)
-        _build_child_env("/bundle", self._LOCAL, base)
+        _build_child_env(self._LOCAL, base)
         assert base == original_base
 
 


### PR DESCRIPTION
closes #92 
## Problem

When a Griptape workflow is published as a Nuke gizmo to a **shared drive**, the gizmo's Python virtualenv gets created *inside the shared companion directory*. The run button launches `uv run --project <companion>`, and uv materializes the venv at `<companion>/.venv` — on the shared drive. The first artist to run the gizmo builds a `.venv` tailored to their machine (absolute interpreter paths, platform binaries); every other artist inherits it and crashes.

The same collision affected engine config: `XDG_CONFIG_HOME` was redirected to `<companion>/.gtn_config`, so per-user engine state was also written to the shared drive.

## Fix

Redirect both the venv and the config onto a **per-machine** path under `~/.local/share/griptape_nodes/venvs/<slug>-<hash8>/`, via `UV_PROJECT_ENVIRONMENT` and `XDG_CONFIG_HOME` in the gizmo's child-process env. The `--project <companion>` flag stays, so the gizmo + workflow + `pyproject.toml` remain shareable — only the venv/config move local.

The path is a deterministic sha256 of the **normalized** companion location, so:
- the same gizmo reuses its local venv across sessions (first run builds it, later runs reuse),
- distinct gizmos never collide,
- all versions of one gizmo correctly share one venv.

## Notes

- **Only re-published gizmos get the fix** — `run_button.py` is bundled into each companion at publish time. Existing gizmos need a re-publish.
- The stale `.venv` left on the shared drive by old gizmos is safe to delete after re-publish (the new code ignores it via `UV_PROJECT_ENVIRONMENT`).

## Testing

- `uv run pytest tests/unit/` → **240 passed** (new `TestGizmoLocalDir` + updated `TestBuildChildEnv`).
- `make check` → ruff format + lint + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)