### PR TITLE
fix(gizmo): use versioned output filenames so Nuke detects new frames on re-run

### DIFF
--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -246,14 +246,12 @@ class NukeGizmoPublisher:
         * ``outputs`` directory is set to ``griptape_outputs`` (relative) so that
           outputs resolve next to the ``.nk`` file when a Nuke script directory
           is passed as the workspace at runtime.
-        * ``save_node_output`` uses a naming convention compatible with Nuke conventions.
-          The workflow name is hardcoded as a literal subdirectory (companion_base.name)
-          rather than using the ``{workflow_name}`` builtin variable, which resolves to
-          the workflow's full absolute path when the gizmo's companion directory is outside
-          the user's workspace (i.e. always, since outputs go next to the .nk file).
-          ``node_name`` is optional so that utility callers that omit it
-          (e.g. pillow_nodes_library, video_utils, audio_utils) do not cause errors:
-          ``{outputs}/<workflow_name>/{node_name?:_}{file_name_base}_v{_index?:04}.{file_extension}``
+        * ``save_node_output`` uses a versioned naming convention so each gizmo
+          run produces a new numbered file Nuke can detect and load:
+          ``{outputs}/{sub_dirs?:/}{file_name_base}_v{_index?:04}.{file_extension}``
+          ``{sub_dirs?:/}`` passes through any relative subdirectory; when absent
+          the whole token (including its separator) is dropped.
+          ``CREATE_NEW`` collision policy auto-increments the index on each run.
         """
         project_yml = companion_base / "project.yml"
         read_result = GriptapeNodes.handle_request(
@@ -287,9 +285,9 @@ class NukeGizmoPublisher:
             # so the result is "{outputs}/comp.exr" (single slash, no "//").
             # sub_dirs carries no trailing slash, so "{sub_dirs?}" alone would yield
             # "renderscomp.exr".
-            macro="{outputs}/{sub_dirs?:/}{file_name_base}.{file_extension}",
+            macro="{outputs}/{sub_dirs?:/}{file_name_base}_v{_index?:04}.{file_extension}",
             policy=SituationPolicy(
-                on_collision=SituationFilePolicy.OVERWRITE,
+                on_collision=SituationFilePolicy.CREATE_NEW,
                 create_dirs=True,
             ),
             fallback="save_file",

--- a/tests/unit/test_nuke_gizmo_publisher_output.py
+++ b/tests/unit/test_nuke_gizmo_publisher_output.py
@@ -1,0 +1,67 @@
+"""Tests for _customize_project_yml output filename macro and collision policy."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_PUBLISHER = Path(__file__).parent.parent.parent / "publish_gizmo" / "nuke_gizmo_publisher.py"
+
+
+def _get_customize_project_yml_source() -> ast.FunctionDef:
+    src = _PUBLISHER.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_customize_project_yml":
+            return node
+    msg = "_customize_project_yml not found in nuke_gizmo_publisher.py"
+    raise AssertionError(msg)
+
+
+def _find_situation_template_call(func: ast.FunctionDef) -> ast.Call:
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            func_node = node.func
+            if isinstance(func_node, ast.Name) and func_node.id == "SituationTemplate":
+                return node
+            if isinstance(func_node, ast.Attribute) and func_node.attr == "SituationTemplate":
+                return node
+    msg = "SituationTemplate() call not found in _customize_project_yml"
+    raise AssertionError(msg)
+
+
+def _get_keyword_value(call: ast.Call, name: str) -> ast.expr:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    msg = f"keyword '{name}' not found in SituationTemplate call"
+    raise AssertionError(msg)
+
+
+class TestCustomizeProjectYmlOutput:
+    def test_save_node_output_macro_is_versioned(self) -> None:
+        func = _get_customize_project_yml_source()
+        call = _find_situation_template_call(func)
+        macro_node = _get_keyword_value(call, "macro")
+        assert isinstance(macro_node, ast.Constant)
+        assert isinstance(macro_node.value, str)
+        assert "_v{_index?:04}" in macro_node.value, (
+            f"Expected versioned macro containing '_v{{_index?:04}}', got: {macro_node.value!r}"
+        )
+
+    def test_save_node_output_collision_policy_is_create_new(self) -> None:
+        func = _get_customize_project_yml_source()
+        call = _find_situation_template_call(func)
+        policy_node = _get_keyword_value(call, "policy")
+
+        # Find the SituationPolicy(...) call and its on_collision keyword
+        assert isinstance(policy_node, ast.Call)
+        on_collision_node = _get_keyword_value(policy_node, "on_collision")
+
+        # Must be SituationFilePolicy.CREATE_NEW
+        assert isinstance(on_collision_node, ast.Attribute), (
+            f"Expected an attribute access, got {ast.dump(on_collision_node)}"
+        )
+        assert on_collision_node.attr == "CREATE_NEW", (
+            f"Expected CREATE_NEW collision policy, got: {on_collision_node.attr!r}"
+        )


### PR DESCRIPTION
## Summary

- Fixed a bug where `save_node_output` overwrote the same output file (`file_name_base.file_extension`) on every gizmo run. Because Nuke's Read node caches by filename, re-running a gizmo with the same output name wouldn't refresh the frame in the Node Graph even though the file content changed.
- Changed the output macro to `{outputs}/{sub_dirs?:/}{file_name_base}_v{_index?:04}.{file_extension}` and switched the collision policy from `OVERWRITE` to `CREATE_NEW`, so each run auto-increments the version index and produces a new, uniquely-named file that Nuke reliably picks up.
- Updated the docstring to describe the new versioned naming convention and how `{sub_dirs?:/}` behaves when no subdirectory is present.

## Test plan

- [x] `tests/unit/test_nuke_gizmo_publisher_output.py` (new, 67 lines) covers the versioned macro/collision-policy behavior
- [ ] `make check`
- [ ] Manual: publish a gizmo, run it twice in Nuke, confirm two distinct versioned output files are created and the Read node shows the updated frame after the second run

Closes #99