### PR TITLE
fix(gizmo): resolve a relative Output Directory to an absolute path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ publish_gizmo/           Gizmo publisher — packages workflows as versioned .gi
   nuke_discovery.py        Nuke installation auto-discovery (macOS/Windows/Linux)
   nuke_gizmo_builder.py    Generates .gizmo TCL from a workflow shape
   run_button.py            Executes inside Nuke's Python; PySide6/PySide2 progress dialog
+  output_paths.py          Output Directory resolution + macro/artifact → Nuke-openable paths
 nuke_runner/             Headless runner — scripts that run inside nuke -t (stdlib only)
   runner.py                Entry point; reads manifest, runs Write nodes, collects outputs
   introspect.py            Knob schema introspection; writes JSON to temp file

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -79,7 +79,8 @@ _TCL_HINT_TOOLTIP = (
     "Expressions are evaluated when the workflow runs."
 )
 _OUTPUT_DIR_TOOLTIP = (
-    "Directory for workflow outputs. Supports TCL expressions, e.g. [file dirname [value root.name]]/griptape."
+    "Directory for workflow outputs. A relative path is resolved against the folder containing this .nk script. "
+    "Supports TCL expressions, e.g. [file dirname [value root.name]]/griptape."
 )
 _LINK_BUTTON_TOOLTIP = (
     "Link this field to the gizmo name, script folder, script name, frame, or any node.knob. "

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -80,6 +80,7 @@ _TCL_HINT_TOOLTIP = (
 )
 _OUTPUT_DIR_TOOLTIP = (
     f"Directory for workflow outputs. Leave blank to save to a '{OUTPUTS_DIR_NAME}' folder next to the .nk script. "
+    "A relative path is resolved against the folder containing this .nk script. "
     "Supports TCL expressions, e.g. [file dirname [value root.name]]/griptape."
 )
 # Static Run-tab text under the Output Directory field. The blank-field default is

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -137,6 +137,9 @@ class NukeGizmoPublisher:
                 Path(__file__).parent / "output_protocol.py", companion_base / "output_protocol.py", overwrite=True
             )
             self._copy_file(Path(__file__).parent / "tcl_utils.py", companion_base / "tcl_utils.py", overwrite=True)
+            self._copy_file(
+                Path(__file__).parent / "output_paths.py", companion_base / "output_paths.py", overwrite=True
+            )
 
             available_versions = self._collect_versions(companion_base)
 

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -108,7 +108,11 @@ def main() -> None:
     parser.add_argument(
         "--output-dir",
         default=None,
-        help="Override for the {outputs} directory macro (absolute path at runtime)",
+        help=(
+            "Override for the {outputs} directory macro. An absolute path is used as-is; a relative path is "
+            "anchored to --nk-script-dir (the companion bundle when the script is unsaved); project directory "
+            "macros such as {inputs} are resolved against the bundle's project.yml"
+        ),
     )
     parser.add_argument(
         "--nk-script-dir",
@@ -141,7 +145,13 @@ def main() -> None:
     # save path and the path reported back to Nuke are derived from this single
     # absolute value, so a relative knob value can't be resolved two different
     # ways (which left Nuke's Read node unable to open a file that was written).
-    output_dir = resolve_output_dir(args.output_dir, args.nk_script_dir, str(Path(__file__).parent))
+    # The macro map is built from the bundle's project.yml before any override is
+    # installed, so a {outputs}-relative knob value resolves against the authored
+    # directory instead of becoming a self-reference the engine reads as a cycle.
+    script_dir = Path(__file__).parent
+    workspace_dir = Path(args.nk_script_dir) if args.nk_script_dir else None
+    macro_map = build_macro_map(script_dir, workspace_dir=workspace_dir)
+    output_dir = resolve_output_dir(args.output_dir, args.nk_script_dir, str(script_dir), macro_map)
     if output_dir:
         logger.info("Output directory: %s", output_dir)
 
@@ -186,7 +196,6 @@ def main() -> None:
         emit_payload({"error": "Workflow module has no execute_workflow() function"})
         sys.exit(1)
 
-    script_dir = Path(__file__).parent
     bundle_project_file = script_dir / "project.yml"
 
     # When an output directory is specified, build a per-run temp project.yml that
@@ -231,8 +240,6 @@ def main() -> None:
             except OSError:
                 pass
 
-    workspace_dir = Path(args.nk_script_dir) if args.nk_script_dir else None
-    macro_map = build_macro_map(script_dir, workspace_dir=workspace_dir)
     if output_dir:
         macro_map["outputs"] = output_dir
     result = serialize_output(output, macro_map)

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -39,15 +39,15 @@ import argparse  # noqa: E402
 import importlib.util  # noqa: E402
 import json  # noqa: E402
 import logging  # noqa: E402
-import re  # noqa: E402
 import subprocess  # noqa: E402
 import tempfile  # noqa: E402
 
 from dotenv import load_dotenv
-from griptape_nodes.common.project_templates import load_project_template_from_yaml
 from griptape_nodes.common.project_templates.directory import DirectoryDefinition
-from griptape_nodes.common.project_templates.validation import ProjectValidationInfo, ProjectValidationStatus
+from output_paths import build_macro_map, load_project_template, resolve_output_dir, serialize_output
 from output_protocol import emit_payload
+
+logger = logging.getLogger(__name__)
 
 
 def _bootstrap_environment(nk_script_dir: str | None = None) -> None:
@@ -99,100 +99,6 @@ def _load_workflow_module(workflow_file: str):
     return module
 
 
-def _build_macro_map(script_dir: Path, workspace_dir: Path | None = None) -> dict[str, str]:
-    """Build a map of macro names to absolute paths from the project.yml.
-
-    The project system stores output values in macro form (e.g. {outputs}/file.jpg).
-    This map lets us resolve those macros to real paths that Nuke can open.
-
-    Args:
-        script_dir: The companion bundle directory (where project.yml lives).
-        workspace_dir: If provided, relative directory macros are resolved
-            against this directory instead of *script_dir*.  This is used when
-            the Nuke script directory was passed as the workspace so that
-            ``{outputs}`` etc. point next to the ``.nk`` file.
-    """
-    project_yml = script_dir / "project.yml"
-    if not project_yml.exists():
-        return {}
-
-    validation_info = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
-    template = load_project_template_from_yaml(project_yml.read_text(encoding="utf-8"), validation_info)
-    if template is None:
-        return {}
-
-    base_dir = workspace_dir if workspace_dir is not None else script_dir
-
-    # Resolve relative macros against base_dir so the companion bundle is portable.
-    # Absolute path_macros (e.g. from a legacy publish) are kept as-is.
-    result = {}
-    for dir_def in template.directories.values():
-        raw = dir_def.path_macro
-        value: str | None = raw if isinstance(raw, str) else raw.select() if hasattr(raw, "select") else None
-        if not value:
-            continue
-        if not Path(value).is_absolute():
-            value = str(base_dir / value)
-        # Normalize to forward slashes: Nuke/TCL treats backslashes as escape
-        # characters when saving .nk files, which silently mangles Windows paths.
-        result[dir_def.name] = value.replace("\\", "/")
-    return result
-
-
-def _resolve_macro_path(value: str, macro_map: dict[str, str]) -> str:
-    """Replace {outputs}, {inputs}, etc. in a path string with their resolved values."""
-    if "{" not in value:
-        return value
-
-    def _replace(match: re.Match[str]) -> str:
-        value = macro_map.get(match.group(1))
-        return value if value is not None else match.group(0)
-
-    return re.sub(r"\{([\w-]+)\}", _replace, value)
-
-
-def _serialize_output(output: dict | None, macro_map: dict[str, str]) -> dict[str, str]:
-    """Flatten and serialize the workflow output dict for JSON printing.
-
-    The executor returns a nested dict: {node_name: {param_name: value}}.
-    We flatten it to {param_name: str(value)} for the gizmo to consume.
-    Image artifacts expose a .url or .value attribute that contains the path.
-    Macro paths like {outputs}/file.jpg are resolved to absolute paths.
-    """
-    if not output:
-        return {}
-
-    result: dict[str, str] = {}
-    for _node_name, params in output.items():
-        if not isinstance(params, dict):
-            continue
-        for param_name, value in params.items():
-            if value is None:
-                result[param_name] = ""
-            elif hasattr(value, "url"):
-                # ImageUrlArtifact — convert file:// URI to a plain path for Nuke.
-                # file:///C:/path (Windows) and file:///unix/path both have three
-                # slashes; stripping only "file://" leaves "/C:/path" on Windows
-                # which is invalid.  Strip the third slash only when followed by a
-                # drive letter (e.g. /C:/) so Unix absolute paths are unchanged.
-                url = str(value.url)
-                if url.startswith("file://"):
-                    url = url[7:]  # -> /C:/... on Windows, /unix/... on Unix
-                    if len(url) >= 3 and url[0] == "/" and url[1].isalpha() and url[2] == ":":
-                        url = url[1:]  # -> C:/... on Windows
-                result[param_name] = _resolve_macro_path(url, macro_map)
-            elif hasattr(value, "value") and isinstance(value.value, (str, bytes)):
-                raw = value.value
-                if isinstance(raw, bytes):
-                    result[param_name] = f"<binary {len(raw)} bytes>"
-                else:
-                    result[param_name] = _resolve_macro_path(raw, macro_map)
-            else:
-                result[param_name] = _resolve_macro_path(str(value), macro_map)
-
-    return result
-
-
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
@@ -230,6 +136,14 @@ def main() -> None:
 
     # Bootstrap environment before loading workflow (needs .env for API keys etc.)
     _bootstrap_environment(nk_script_dir=args.nk_script_dir)
+
+    # Resolve the requested output directory once, up front.  Both the engine's
+    # save path and the path reported back to Nuke are derived from this single
+    # absolute value, so a relative knob value can't be resolved two different
+    # ways (which left Nuke's Read node unable to open a file that was written).
+    output_dir = resolve_output_dir(args.output_dir, args.nk_script_dir, str(Path(__file__).parent))
+    if output_dir:
+        logger.info("Output directory: %s", output_dir)
 
     # Eagerly register the bundled libraries before the workflow module loads.
     # The workflow uses name-based RegisterLibraryFromFileRequest, which only
@@ -283,13 +197,12 @@ def main() -> None:
     temp_project_file = None
     project_file_path: str | None = str(bundle_project_file) if bundle_project_file.exists() else None
 
-    if args.output_dir and bundle_project_file.exists():
-        validation_info = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
-        template = load_project_template_from_yaml(bundle_project_file.read_text(encoding="utf-8"), validation_info)
+    if output_dir:
+        template = load_project_template(bundle_project_file)
         if template is not None:
             template.directories["outputs"] = DirectoryDefinition(
                 name="outputs",
-                path_macro=args.output_dir,
+                path_macro=output_dir,
             )
             tmp = tempfile.NamedTemporaryFile(
                 mode="w",
@@ -319,10 +232,10 @@ def main() -> None:
                 pass
 
     workspace_dir = Path(args.nk_script_dir) if args.nk_script_dir else None
-    macro_map = _build_macro_map(Path(__file__).parent, workspace_dir=workspace_dir)
-    if args.output_dir:
-        macro_map["outputs"] = args.output_dir
-    result = _serialize_output(output, macro_map)
+    macro_map = build_macro_map(script_dir, workspace_dir=workspace_dir)
+    if output_dir:
+        macro_map["outputs"] = output_dir
+    result = serialize_output(output, macro_map)
     emit_payload(result)
 
 

--- a/publish_gizmo/output_paths.py
+++ b/publish_gizmo/output_paths.py
@@ -12,6 +12,7 @@ and callers can't drift apart on how a relative path is anchored.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from pathlib import Path
@@ -22,6 +23,8 @@ from griptape_nodes.common.project_templates.validation import ProjectValidation
 
 if TYPE_CHECKING:
     from griptape_nodes.common.project_templates.project import ProjectTemplate
+
+logger = logging.getLogger(__name__)
 
 
 def load_project_template(project_yml: Path) -> ProjectTemplate | None:
@@ -45,7 +48,12 @@ def absolutize(value: str, base_dir: str) -> str:
     return os.path.normpath(expanded).replace("\\", "/")
 
 
-def resolve_output_dir(raw: str | None, nk_script_dir: str | None, companion_dir: str) -> str | None:
+def resolve_output_dir(
+    raw: str | None,
+    nk_script_dir: str | None,
+    companion_dir: str,
+    macro_map: dict[str, str] | None = None,
+) -> str | None:
     """Resolve the gizmo's Output Directory knob value to an absolute path.
 
     A relative value is anchored to the Nuke script's directory — the engine
@@ -54,16 +62,31 @@ def resolve_output_dir(raw: str | None, nk_script_dir: str | None, companion_dir
     here, rather than letting the engine and Nuke each resolve the same relative
     string against their own working directory, is what keeps the path reported
     back to Nuke openable by the gizmo's internal Read node.
+
+    Project directory macros are expanded against *macro_map* for the same
+    reason: left raw, ``{outputs}/renders`` reaches the engine as a
+    self-referential ``outputs`` definition, and any macro reaches Nuke as an
+    unresolved ``{...}`` literal.
     """
     if not raw:
         return None
 
-    # Engine path macros ({outputs}, {workflow_name}, ...) must keep their
-    # engine-level meaning; joining them onto a base dir would break them.
-    if "{" in raw:
-        return raw
+    base_dir = nk_script_dir or companion_dir
 
-    return absolutize(raw, nk_script_dir or companion_dir)
+    if "{" in raw:
+        expanded = resolve_macro_path(raw, macro_map or {})
+        # Builtins ({workflow_name}, ...) and env-var macros aren't in the map;
+        # only the engine can resolve those, so hand it the value untouched.
+        if "{" in expanded:
+            logger.warning(
+                "Output directory %r contains macros this runner cannot resolve; "
+                "the path reported back to Nuke may not be openable.",
+                raw,
+            )
+            return raw
+        return absolutize(expanded, base_dir)
+
+    return absolutize(raw, base_dir)
 
 
 def build_macro_map(script_dir: Path, workspace_dir: Path | None = None) -> dict[str, str]:

--- a/publish_gizmo/output_paths.py
+++ b/publish_gizmo/output_paths.py
@@ -1,0 +1,157 @@
+"""Output-path resolution shared by the bundled gizmo runner.
+
+This module is copied into the gizmo companion directory at publish time and
+imported by ``run_workflow.py``. Keeping the logic here — rather than inline in
+the runner, which mutates ``XDG_CONFIG_HOME`` at import time before importing
+the engine — lets the unit tests import it normally.
+
+Everything that turns a project directory macro or an engine artifact into a
+path Nuke can open lives here, so the runner has exactly one place to consult
+and callers can't drift apart on how a relative path is anchored.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from griptape_nodes.common.project_templates import load_project_template_from_yaml
+from griptape_nodes.common.project_templates.validation import ProjectValidationInfo, ProjectValidationStatus
+
+if TYPE_CHECKING:
+    from griptape_nodes.common.project_templates.project import ProjectTemplate
+
+
+def load_project_template(project_yml: Path) -> ProjectTemplate | None:
+    """Load a project.yml into a template, or None if it is missing or invalid."""
+    if not project_yml.exists():
+        return None
+    validation_info = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
+    return load_project_template_from_yaml(project_yml.read_text(encoding="utf-8"), validation_info)
+
+
+def absolutize(value: str, base_dir: str) -> str:
+    """Anchor *value* to *base_dir* if relative and normalize to forward slashes.
+
+    Nuke/TCL treats backslashes as escape characters when saving .nk files, which
+    silently mangles Windows paths, so every path leaving this module is
+    forward-slashed.
+    """
+    expanded = os.path.expanduser(value)
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(base_dir, expanded)
+    return os.path.normpath(expanded).replace("\\", "/")
+
+
+def resolve_output_dir(raw: str | None, nk_script_dir: str | None, companion_dir: str) -> str | None:
+    """Resolve the gizmo's Output Directory knob value to an absolute path.
+
+    A relative value is anchored to the Nuke script's directory — the engine
+    workspace, and the same base the blank-field case already uses — falling
+    back to the companion bundle when the script is unsaved. Anchoring once
+    here, rather than letting the engine and Nuke each resolve the same relative
+    string against their own working directory, is what keeps the path reported
+    back to Nuke openable by the gizmo's internal Read node.
+    """
+    if not raw:
+        return None
+
+    # Engine path macros ({outputs}, {workflow_name}, ...) must keep their
+    # engine-level meaning; joining them onto a base dir would break them.
+    if "{" in raw:
+        return raw
+
+    return absolutize(raw, nk_script_dir or companion_dir)
+
+
+def build_macro_map(script_dir: Path, workspace_dir: Path | None = None) -> dict[str, str]:
+    """Build a map of macro names to absolute paths from the project.yml.
+
+    The project system stores output values in macro form (e.g. {outputs}/file.jpg).
+    This map lets us resolve those macros to real paths that Nuke can open.
+
+    Args:
+        script_dir: The companion bundle directory (where project.yml lives).
+        workspace_dir: If provided, relative directory macros are resolved
+            against this directory instead of *script_dir*.  This is used when
+            the Nuke script directory was passed as the workspace so that
+            ``{outputs}`` etc. point next to the ``.nk`` file.
+    """
+    template = load_project_template(script_dir / "project.yml")
+    if template is None:
+        return {}
+
+    base_dir = str(workspace_dir) if workspace_dir is not None else str(script_dir)
+
+    # Resolve relative macros against base_dir so the companion bundle is portable.
+    # Absolute path_macros (e.g. from a legacy publish) keep their location.
+    result = {}
+    for dir_def in template.directories.values():
+        raw = dir_def.path_macro
+        value: str | None = raw if isinstance(raw, str) else raw.select() if hasattr(raw, "select") else None
+        if not value:
+            continue
+        result[dir_def.name] = absolutize(value, base_dir)
+    return result
+
+
+def resolve_macro_path(value: str, macro_map: dict[str, str]) -> str:
+    """Replace {outputs}, {inputs}, etc. in a path string with their resolved values."""
+    if "{" not in value:
+        return value
+
+    def _replace(match: re.Match[str]) -> str:
+        resolved = macro_map.get(match.group(1))
+        return resolved if resolved is not None else match.group(0)
+
+    return re.sub(r"\{([\w-]+)\}", _replace, value)
+
+
+def serialize_output(output: dict | None, macro_map: dict[str, str]) -> dict[str, str]:
+    """Flatten and serialize the workflow output dict for JSON printing.
+
+    The executor returns a nested dict: {node_name: {param_name: value}}.
+    We flatten it to {param_name: str(value)} for the gizmo to consume.
+    Image artifacts expose a .url or .value attribute that contains the path.
+    Macro paths like {outputs}/file.jpg are resolved to absolute paths.
+    """
+    if not output:
+        return {}
+
+    result: dict[str, str] = {}
+    for _node_name, params in output.items():
+        if not isinstance(params, dict):
+            continue
+        for param_name, value in params.items():
+            if value is None:
+                result[param_name] = ""
+            elif hasattr(value, "url"):
+                result[param_name] = resolve_macro_path(_path_from_file_url(str(value.url)), macro_map)
+            elif hasattr(value, "value") and isinstance(value.value, (str, bytes)):
+                raw = value.value
+                if isinstance(raw, bytes):
+                    result[param_name] = f"<binary {len(raw)} bytes>"
+                else:
+                    result[param_name] = resolve_macro_path(raw, macro_map)
+            else:
+                result[param_name] = resolve_macro_path(str(value), macro_map)
+
+    return result
+
+
+def _path_from_file_url(url: str) -> str:
+    """Convert a file:// URI to a plain path Nuke can open.
+
+    file:///C:/path (Windows) and file:///unix/path both have three slashes;
+    stripping only "file://" leaves "/C:/path" on Windows, which is invalid.
+    Strip the third slash only when followed by a drive letter (e.g. /C:/) so
+    Unix absolute paths are unchanged.
+    """
+    if not url.startswith("file://"):
+        return url
+    url = url[7:]  # -> /C:/... on Windows, /unix/... on Unix
+    if len(url) >= 3 and url[0] == "/" and url[1].isalpha() and url[2] == ":":
+        url = url[1:]  # -> C:/... on Windows
+    return url

--- a/tests/unit/test_nuke_gizmo_builder.py
+++ b/tests/unit/test_nuke_gizmo_builder.py
@@ -293,6 +293,11 @@ class TestTclHintTooltips:
         assert ' t "' in knob_line
         assert r"\[file dirname" in knob_line
 
+    def test_output_dir_tooltip_documents_relative_resolution(self) -> None:
+        gizmo = _generate_gizmo({})
+        knob_line = next(line for line in gizmo.splitlines() if "addUserKnob {1 output_dir" in line)
+        assert "relative path is resolved against the folder containing this .nk script" in knob_line
+
     def test_output_knob_has_reference_tooltip(self) -> None:
         gizmo = _generate_gizmo_with_output(
             {"caption": {"type": "str", "default_value": "", "mode_allowed_output": True, "ui_options": {}}}

--- a/tests/unit/test_output_paths.py
+++ b/tests/unit/test_output_paths.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
+import pytest
 from griptape_nodes.common.project_templates.directory import DirectoryDefinition
 from griptape_nodes.common.project_templates.project import ProjectTemplate
 
@@ -49,11 +51,32 @@ class TestResolveOutputDir:
         expected = str(Path.home() / "renders").replace("\\", "/")
         assert resolve_output_dir("~/renders", _NK_DIR, _COMPANION) == expected
 
-    def test_engine_macro_value_is_passed_through_unchanged(self) -> None:
-        assert resolve_output_dir("{outputs}/renders", _NK_DIR, _COMPANION) == "{outputs}/renders"
-
     def test_dot_relative_dir_resolves_against_nk_script_dir(self) -> None:
         assert resolve_output_dir("./renders", _NK_DIR, _COMPANION) == f"{_NK_DIR}/renders"
+
+    def test_directory_macro_is_resolved_and_absolutized(self) -> None:
+        macro_map = {"inputs": f"{_NK_DIR}/griptape_inputs"}
+        resolved = resolve_output_dir("{inputs}/renders", _NK_DIR, _COMPANION, macro_map)
+        assert resolved == f"{_NK_DIR}/griptape_inputs/renders"
+
+    def test_self_referential_outputs_macro_resolves_to_bundle_outputs(self) -> None:
+        macro_map = {"outputs": f"{_NK_DIR}/griptape_outputs"}
+        resolved = resolve_output_dir("{outputs}/renders", _NK_DIR, _COMPANION, macro_map)
+        assert resolved == f"{_NK_DIR}/griptape_outputs/renders"
+
+    def test_relative_macro_result_is_anchored_to_nk_script_dir(self) -> None:
+        macro_map = {"outputs": "griptape_outputs"}
+        resolved = resolve_output_dir("{outputs}/renders", _NK_DIR, _COMPANION, macro_map)
+        assert resolved == f"{_NK_DIR}/griptape_outputs/renders"
+
+    def test_unresolvable_macro_is_passed_through_for_the_engine(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            resolved = resolve_output_dir("{workflow_name}/out", _NK_DIR, _COMPANION, {})
+        assert resolved == "{workflow_name}/out"
+        assert "cannot resolve" in caplog.text
+
+    def test_macro_value_without_macro_map_is_passed_through(self) -> None:
+        assert resolve_output_dir("{outputs}/renders", _NK_DIR, _COMPANION) == "{outputs}/renders"
 
 
 class TestBuildMacroMap:

--- a/tests/unit/test_output_paths.py
+++ b/tests/unit/test_output_paths.py
@@ -1,0 +1,130 @@
+"""Tests for output_paths — Output Directory resolution and macro-path serialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from griptape_nodes.common.project_templates.directory import DirectoryDefinition
+from griptape_nodes.common.project_templates.project import ProjectTemplate
+
+from publish_gizmo.output_paths import (
+    build_macro_map,
+    resolve_macro_path,
+    resolve_output_dir,
+    serialize_output,
+)
+
+_NK_DIR = "/projects/shot_010/comp"
+_COMPANION = "/library/griptape/my_workflow"
+
+
+class _FakeUrlArtifact:
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+
+class _FakeValueArtifact:
+    def __init__(self, value: str | bytes) -> None:
+        self.value = value
+
+
+class TestResolveOutputDir:
+    def test_blank_dir_returns_none(self) -> None:
+        assert resolve_output_dir(None, _NK_DIR, _COMPANION) is None
+        assert resolve_output_dir("", _NK_DIR, _COMPANION) is None
+
+    def test_relative_dir_resolves_against_nk_script_dir(self) -> None:
+        assert resolve_output_dir("flibbidy", _NK_DIR, _COMPANION) == f"{_NK_DIR}/flibbidy"
+
+    def test_relative_dir_falls_back_to_companion_when_script_unsaved(self) -> None:
+        assert resolve_output_dir("flibbidy", None, _COMPANION) == f"{_COMPANION}/flibbidy"
+
+    def test_absolute_dir_is_returned_normalized(self) -> None:
+        assert resolve_output_dir("/renders/./out/", _NK_DIR, _COMPANION) == "/renders/out"
+
+    def test_windows_backslashes_become_forward_slashes(self) -> None:
+        assert resolve_output_dir("renders\\v001", _NK_DIR, _COMPANION) == f"{_NK_DIR}/renders/v001"
+
+    def test_tilde_is_expanded_to_home(self) -> None:
+        expected = str(Path.home() / "renders").replace("\\", "/")
+        assert resolve_output_dir("~/renders", _NK_DIR, _COMPANION) == expected
+
+    def test_engine_macro_value_is_passed_through_unchanged(self) -> None:
+        assert resolve_output_dir("{outputs}/renders", _NK_DIR, _COMPANION) == "{outputs}/renders"
+
+    def test_dot_relative_dir_resolves_against_nk_script_dir(self) -> None:
+        assert resolve_output_dir("./renders", _NK_DIR, _COMPANION) == f"{_NK_DIR}/renders"
+
+
+class TestBuildMacroMap:
+    def test_missing_project_yml_yields_empty_map(self, tmp_path: Path) -> None:
+        assert build_macro_map(tmp_path) == {}
+
+    def test_relative_directory_macro_resolves_against_workspace_dir(self, tmp_path: Path) -> None:
+        _write_project_yml(tmp_path, "griptape_outputs")
+        workspace = tmp_path / "comp"
+        macro_map = build_macro_map(tmp_path, workspace_dir=workspace)
+        assert macro_map["outputs"] == f"{workspace.as_posix()}/griptape_outputs"
+
+    def test_relative_directory_macro_resolves_against_bundle_when_no_workspace(self, tmp_path: Path) -> None:
+        _write_project_yml(tmp_path, "griptape_outputs")
+        macro_map = build_macro_map(tmp_path)
+        assert macro_map["outputs"] == f"{tmp_path.as_posix()}/griptape_outputs"
+
+    def test_absolute_directory_macro_is_kept(self, tmp_path: Path) -> None:
+        _write_project_yml(tmp_path, "/renders/shot_010")
+        macro_map = build_macro_map(tmp_path, workspace_dir=tmp_path / "comp")
+        assert macro_map["outputs"] == "/renders/shot_010"
+
+
+class TestResolveMacroPath:
+    def test_plain_path_is_unchanged(self) -> None:
+        assert resolve_macro_path("/renders/out.png", {"outputs": "/x"}) == "/renders/out.png"
+
+    def test_known_macro_is_substituted(self) -> None:
+        assert resolve_macro_path("{outputs}/out.png", {"outputs": "/renders"}) == "/renders/out.png"
+
+    def test_unknown_macro_is_left_in_place(self) -> None:
+        assert resolve_macro_path("{nope}/out.png", {"outputs": "/renders"}) == "{nope}/out.png"
+
+
+class TestSerializeOutput:
+    def test_empty_output_yields_empty_dict(self) -> None:
+        assert serialize_output(None, {}) == {}
+        assert serialize_output({}, {}) == {}
+
+    def test_none_parameter_value_becomes_empty_string(self) -> None:
+        assert serialize_output({"Node": {"caption": None}}, {}) == {"caption": ""}
+
+    def test_url_artifact_macro_is_resolved_to_absolute_path(self) -> None:
+        output = {"Node": {"image": _FakeUrlArtifact("{outputs}/gen.png")}}
+        assert serialize_output(output, {"outputs": "/renders"}) == {"image": "/renders/gen.png"}
+
+    def test_unix_file_uri_keeps_leading_slash(self) -> None:
+        output = {"Node": {"image": _FakeUrlArtifact("file:///renders/gen.png")}}
+        assert serialize_output(output, {}) == {"image": "/renders/gen.png"}
+
+    def test_windows_file_uri_drops_slash_before_drive_letter(self) -> None:
+        output = {"Node": {"image": _FakeUrlArtifact("file:///C:/renders/gen.png")}}
+        assert serialize_output(output, {}) == {"image": "C:/renders/gen.png"}
+
+    def test_binary_artifact_value_is_summarized(self) -> None:
+        output = {"Node": {"blob": _FakeValueArtifact(b"1234")}}
+        assert serialize_output(output, {}) == {"blob": "<binary 4 bytes>"}
+
+    def test_plain_value_is_stringified_and_macro_resolved(self) -> None:
+        output = {"Node": {"path": "{outputs}/out.exr", "count": 3}}
+        assert serialize_output(output, {"outputs": "/renders"}) == {"path": "/renders/out.exr", "count": "3"}
+
+    def test_non_dict_node_entry_is_skipped(self) -> None:
+        assert serialize_output({"Node": "not a dict"}, {}) == {}
+
+
+def _write_project_yml(bundle_dir: Path, outputs_path_macro: str) -> None:
+    template = ProjectTemplate(
+        project_template_schema_version=ProjectTemplate.LATEST_SCHEMA_VERSION,
+        name="test_project",
+        situations={},
+        directories={"outputs": DirectoryDefinition(name="outputs", path_macro=outputs_path_macro)},
+    )
+    (bundle_dir / "project.yml").write_text(template.to_yaml(), encoding="utf-8")

--- a/tests/unit/test_workflow_runner_output.py
+++ b/tests/unit/test_workflow_runner_output.py
@@ -46,21 +46,6 @@ def test_extract_payload_round_trips_emit():
     assert extract_payload(buf.getvalue()) == payload
 
 
-def test_serialize_output_empty():
-    """_serialize_output returns {} for None or empty input — not a crash."""
-    import importlib.util
-    from pathlib import Path
-
-    spec = importlib.util.spec_from_file_location(
-        "_nuke_workflow_runner",
-        Path(__file__).parent.parent.parent / "publish_gizmo" / "nuke_workflow_runner.py",
-    )
-    # We can't exec the full module (it imports third-party libs), so just test
-    # the pure helper in isolation by re-implementing the logic inline here.
-    # This is a smoke-test that the contract hasn't drifted.
-    assert spec is not None  # the file exists
-
-
 def test_extract_payload_with_simulated_rich_pollution():
     """Simulate the actual Agent-run stdout: ANSI art before the JSON sentinel."""
     ansi_art = "\x1b[1m\x1b[0m╭── Griptape Nodes ──╮\n│ libraries loaded   │\n╰────────────────────╯\n"


### PR DESCRIPTION
**Fixes #100**

**The bug:** typing a relative path like `flibbidy` into a gizmo's `Output Directory` wrote the file to the right place, but the gizmo's internal Read node failed with `No such file or directory`.

**Why:** the runner handed the same relative string to two different consumers. The engine resolved it against its workspace (the `.nk` script's folder, so the file landed at `<nk dir>/flibbidy/`), while the path reported back to Nuke stayed relative — and Nuke resolves relative paths against something else entirely. The blank-field case worked because that path already got absolutised; the `--output-dir` branch overwrote the absolutised value verbatim.

**The fix:** resolve `--output-dir` once, up front. A relative value is anchored to the `.nk` script's directory (the same base the blank case uses; the companion bundle when the script is unsaved), `~` is expanded, and the result is normalized to forward slashes. That one absolute value now feeds both the per-run `project.yml` `path_macro` and the macro map used to report paths back to Nuke, so they can't disagree. Nothing moves on disk — only the reported path changes.

Also moved the output-path helpers (`build_macro_map`, `resolve_macro_path`, `serialize_output`) out of the runner into `publish_gizmo/output_paths.py` so the anchoring rule lives in one shared `absolutize()` and the logic is unit-testable — the runner mutates `XDG_CONFIG_HOME` at import time, which is why `serialize_output` had no real coverage before. The knob tooltip now states the relative-path rule.

## Testing

- 23 new unit tests in `tests/unit/test_output_paths.py`; full unit suite (275) and `make check` pass.
- Verified in Nuke by the reporter's repro: relative `Output Directory` now writes and reads back with no Read error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)