### PR TITLE
Simplify gizmo publish dialog: drop Nuke-executable auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Griptape Nodes library for building workflows that run inside [Foundry Nuke](h
 - **NukeScriptNode** – runs a `.nk` script headlessly via `nuke -t`, surfaces annotated Read/Write nodes as typed input/output ports on the canvas, and supports per-knob value overrides. Inputs accept images, video, and raw file paths; outputs can be images, image sequences, video, or 3D geometry.
 - **Griptape Annotator** – a dockable panel that runs inside the Nuke GUI for tagging I/O nodes and promoting knobs to the Griptape interface.
 - **Gizmo publisher** (`publish_gizmo/`): packages a workflow into a versioned `.gizmo` alongside a runner script and installs it into a Nuke plugin directory (default: `~/.nuke`).
-- **Auto-discovery** of Nuke installations on macOS, Windows, and Linux, plus `NUKE_PATH` segment detection for picking an install target.
+- **`NUKE_PATH` detection**: extra plugin directories from `NUKE_PATH` are surfaced as gizmo install targets in the publish dialog, alongside the default `~/.nuke`.
 - **Griptape menu integration**: publishing writes a `menu.py` that adds a `Griptape` submenu to Nuke's Nodes toolbar and a `Refresh Griptape Gizmos` command on the main menu bar. Multiple published versions of the same workflow are grouped under a per-workflow submenu.
 - **Nuke-aware output paths**: the bundled `project.yml` is rewritten so workflow outputs land next to the `.nk` file (under `griptape_outputs/<workflow_name>/...`).
 
@@ -135,8 +135,7 @@ Set `foundry_LICENSE` in the Griptape Secrets panel. It is injected into the Nuk
 
 1. Build a workflow whose top-level flow starts with a `NukeStartFlow` node and ends with a `NukeEndFlow` node.
 2. Trigger *Publish Workflow*. In the dialog, pick:
-   - A **Nuke install** (auto-detected) to resolve plugin path candidates.
-   - A **gizmo install path** – either `~/.nuke`, a path from `NUKE_PATH`, a Nuke-install plugins directory, or a custom path.
+   - A **gizmo install path** – either `~/.nuke`, a path from `NUKE_PATH`, or a custom path.
    - An **update mode** to pick between creating a new version and overwriting the current one.
 3. The publisher writes, under the chosen install directory:
 

--- a/publish_gizmo/nuke_discovery.py
+++ b/publish_gizmo/nuke_discovery.py
@@ -22,42 +22,6 @@ def normalize_path_str(path_str: str) -> str:
         return str(p)
 
 
-def install_root_for_nuke_executable(exe: Path) -> Path:
-    """Return the version folder to show in the UI (e.g. /Applications/Nuke16.0v7)."""
-    try:
-        exe_r = exe.resolve()
-    except OSError:
-        exe_r = exe
-    if sys.platform == "darwin":
-        macos = exe_r.parent
-        if macos.name == "MacOS":
-            contents = macos.parent
-            inner = contents.parent
-            if inner.suffix == ".app":
-                outer = inner.parent
-                if outer == Path("/Applications"):
-                    return inner
-                return outer
-            return inner
-        return exe_r.parent
-    return exe_r.parent
-
-
-def pick_preferred_executable_for_root(root: Path, candidates: list[Path]) -> Path:
-    """Prefer e.g. Nuke16.0v7.app when root is folder Nuke16.0v7."""
-    root_name = root.name
-    sorted_cands = sorted(candidates, key=lambda p: str(p))
-    for c in sorted_cands:
-        try:
-            if c.parent.name == "MacOS":
-                bundle = c.parent.parent.parent
-                if bundle.suffix == ".app" and bundle.stem == root_name:
-                    return c
-        except (IndexError, OSError):
-            continue
-    return sorted_cands[0]
-
-
 def discover_nuke_executables() -> list[str]:
     """Return sorted unique paths to Nuke executables found on this machine."""
     paths: list[str] = []
@@ -136,27 +100,6 @@ def discover_nuke_executables() -> list[str]:
     return paths
 
 
-def discover_nuke_install_roots_and_map() -> tuple[list[str], dict[str, str]]:
-    """Return (sorted install root paths, root -> executable path map)."""
-    exes = discover_nuke_executables()
-    root_to_candidates: dict[str, list[Path]] = {}
-    for exe_str in exes:
-        exe = Path(exe_str)
-        root = install_root_for_nuke_executable(exe)
-        rk = normalize_path_str(str(root))
-        root_to_candidates.setdefault(rk, []).append(exe)
-
-    root_to_exe: dict[str, str] = {}
-    for rk, cands in root_to_candidates.items():
-        picked = pick_preferred_executable_for_root(Path(rk), cands)
-        try:
-            root_to_exe[rk] = str(picked.resolve())
-        except OSError:
-            root_to_exe[rk] = str(picked)
-
-    return sorted(root_to_exe.keys()), root_to_exe
-
-
 def nuke_path_env_segments() -> list[str]:
     """Return normalized paths from the NUKE_PATH environment variable."""
     raw = os.environ.get("NUKE_PATH", "").strip()
@@ -175,39 +118,7 @@ def nuke_path_env_segments() -> list[str]:
     return out
 
 
-def versioned_gizmo_paths_for_exe(nuke_exe: str) -> list[str]:
-    """Return OS-specific plugin paths relative to the selected Nuke install."""
-    exe_path = Path(nuke_exe)
-    try:
-        exe = exe_path.resolve()
-    except OSError:
-        exe = exe_path
-
-    paths: list[str] = []
-    if sys.platform == "darwin":
-        macos = exe.parent
-        if macos.name == "MacOS":
-            paths.append(str(macos / "plugins"))
-            contents = macos.parent
-            bundle_or_install = contents.parent
-            if bundle_or_install.suffix == ".app":
-                outer = bundle_or_install.parent
-                paths.append(str(outer / "plugins" / "nukescripts"))
-            else:
-                paths.append(str(bundle_or_install / "plugins" / "nukescripts"))
-        else:
-            root = exe.parent
-            paths.extend([str(root / "plugins" / "nukescripts"), str(root / "plugins")])
-    elif sys.platform == "win32":
-        root = exe.parent
-        paths.extend([str(root / "plugins" / "nukescripts"), str(root / "plugins")])
-    else:
-        root = exe.parent
-        paths.extend([str(root / "plugins" / "nukescripts"), str(root / "plugins")])
-    return paths
-
-
-def compute_gizmo_install_path_choices(selected_nuke: str | None, root_to_exe: dict[str, str]) -> list[str]:
+def compute_gizmo_install_path_choices() -> list[str]:
     """Return candidate gizmo install directories (excluding 'Custom path…').
 
     ``~/.nuke`` is always listed first as it is the most common install target.
@@ -228,13 +139,6 @@ def compute_gizmo_install_path_choices(selected_nuke: str | None, root_to_exe: d
 
     for seg in nuke_path_env_segments():
         add_path(seg)
-
-    if selected_nuke:
-        norm = normalize_path_str(selected_nuke)
-        exe = root_to_exe.get(norm)
-        if exe and Path(exe).is_file():
-            for p in versioned_gizmo_paths_for_exe(exe):
-                add_path(p)
 
     return candidates
 

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -369,7 +369,6 @@ class NukeGizmoPublisher:
         if start_flow is None:
             return
         start_flow.metadata["publish_config"] = {
-            "nuke": self._metadata.get("nuke"),
             "gizmo_install_path": self._metadata.get("gizmo_install_path"),
             "custom_gizmo_path": self._metadata.get("custom_gizmo_path"),
             "gizmo_path": str(gizmo_path),

--- a/publish_gizmo/nuke_publish_options.py
+++ b/publish_gizmo/nuke_publish_options.py
@@ -23,7 +23,6 @@ from publish_gizmo.nuke_discovery import (
     GIZMO_INSTALL_CUSTOM,
     compute_gizmo_install_path_choices,
     default_gizmo_path,
-    discover_nuke_install_roots_and_map,
     normalize_path_str,
 )
 
@@ -55,19 +54,7 @@ def get_nuke_publish_options(request: GetPublishOptionsRequest) -> GetPublishOpt
             if saved and isinstance(saved, dict):
                 current = saved
 
-    nuke_roots, root_to_exe = discover_nuke_install_roots_and_map()
-
-    # Resolve the currently selected nuke installation
-    saved_nuke = current.get("nuke")
-    if saved_nuke and normalize_path_str(saved_nuke) in nuke_roots:
-        selected_nuke: str | None = normalize_path_str(saved_nuke)
-    else:
-        selected_nuke = nuke_roots[0] if nuke_roots else None
-
-    nuke_choices = nuke_roots if nuke_roots else ["No Nuke installations found"]
-
-    # Compute gizmo path choices based on the selected nuke
-    gizmo_candidates = compute_gizmo_install_path_choices(selected_nuke, root_to_exe)
+    gizmo_candidates = compute_gizmo_install_path_choices()
     gizmo_choices = gizmo_candidates + [GIZMO_INSTALL_CUSTOM]
 
     # Resolve the saved gizmo install path selection
@@ -90,18 +77,6 @@ def get_nuke_publish_options(request: GetPublishOptionsRequest) -> GetPublishOpt
 
     fields = [
         PublishOptionField(
-            name="nuke",
-            label="Nuke Installation",
-            field_type=PublishFieldType.DROPDOWN,
-            tooltip=(
-                "Nuke install location (version folder under /Applications, Program Files, etc.). "
-                "The main Nuke binary for that install is used automatically."
-            ),
-            choices=nuke_choices,
-            default_value=selected_nuke,
-            depends_on=None,
-        ),
-        PublishOptionField(
             name="gizmo_install_path",
             label="Gizmo Install Path",
             field_type=PublishFieldType.DROPDOWN,
@@ -110,7 +85,7 @@ def get_nuke_publish_options(request: GetPublishOptionsRequest) -> GetPublishOpt
             ),
             choices=gizmo_choices,
             default_value=selected_gizmo,
-            depends_on="nuke",
+            depends_on=None,
         ),
         PublishOptionField(
             name="custom_gizmo_path",

--- a/tests/unit/test_nuke_discovery.py
+++ b/tests/unit/test_nuke_discovery.py
@@ -1,0 +1,50 @@
+"""Tests for gizmo install-path choice computation (NUKE_PATH + ~/.nuke only)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from publish_gizmo.nuke_discovery import (
+    GIZMO_INSTALL_CUSTOM,
+    compute_gizmo_install_path_choices,
+    default_gizmo_path,
+    normalize_path_str,
+)
+
+
+class TestComputeGizmoInstallPathChoices:
+    def test_always_includes_dot_nuke_first(self, monkeypatch) -> None:
+        monkeypatch.delenv("NUKE_PATH", raising=False)
+        choices = compute_gizmo_install_path_choices()
+        assert choices[0] == normalize_path_str(str(Path.home() / ".nuke"))
+
+    def test_includes_nuke_path_segments(self, monkeypatch, tmp_path) -> None:
+        extra = tmp_path / "extra_plugins"
+        monkeypatch.setenv("NUKE_PATH", str(extra))
+        choices = compute_gizmo_install_path_choices()
+        assert normalize_path_str(str(extra)) in choices
+
+    def test_dedups_nuke_path_segment_matching_dot_nuke(self, monkeypatch) -> None:
+        dot_nuke = str(Path.home() / ".nuke")
+        monkeypatch.setenv("NUKE_PATH", dot_nuke)
+        choices = compute_gizmo_install_path_choices()
+        assert choices.count(normalize_path_str(dot_nuke)) == 1
+
+    def test_no_nuke_path_returns_only_dot_nuke(self, monkeypatch) -> None:
+        monkeypatch.delenv("NUKE_PATH", raising=False)
+        choices = compute_gizmo_install_path_choices()
+        assert choices == [normalize_path_str(str(Path.home() / ".nuke"))]
+
+
+class TestDefaultGizmoPath:
+    def test_prefers_dot_nuke_even_when_not_first(self) -> None:
+        dot_nuke = normalize_path_str(str(Path.home() / ".nuke"))
+        candidates = ["/some/other/path", dot_nuke, GIZMO_INSTALL_CUSTOM]
+        assert default_gizmo_path(candidates) == dot_nuke
+
+    def test_falls_back_to_first_candidate_when_no_dot_nuke(self) -> None:
+        candidates = ["/some/other/path", "/another/path"]
+        assert default_gizmo_path(candidates) == "/some/other/path"
+
+    def test_falls_back_to_dot_nuke_when_no_candidates(self) -> None:
+        assert default_gizmo_path([]) == normalize_path_str(str(Path.home() / ".nuke"))

--- a/tests/unit/test_nuke_publish_options.py
+++ b/tests/unit/test_nuke_publish_options.py
@@ -1,0 +1,74 @@
+"""Tests for the simplified Nuke publish dialog options (no Nuke-executable dropdown)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from griptape_nodes.retained_mode.events.workflow_events import GetPublishOptionsRequest
+
+from publish_gizmo.nuke_discovery import GIZMO_INSTALL_CUSTOM, normalize_path_str
+from publish_gizmo.nuke_publish_options import get_nuke_publish_options
+
+
+def _request(current_selections: dict | None = None) -> GetPublishOptionsRequest:
+    return GetPublishOptionsRequest(
+        workflow_name="my_workflow", publisher_name="nuke", current_selections=current_selections
+    )
+
+
+@patch("publish_gizmo.nuke_publish_options._find_nuke_start_flow_node", return_value=None)
+class TestGetNukePublishOptions:
+    def test_no_nuke_installation_field(self, _mock_find, monkeypatch) -> None:
+        monkeypatch.delenv("NUKE_PATH", raising=False)
+        result = get_nuke_publish_options(_request({}))
+        names = [f.name for f in result.fields]
+        assert "nuke" not in names
+
+    def test_gizmo_install_path_field_has_no_dependency(self, _mock_find, monkeypatch) -> None:
+        monkeypatch.delenv("NUKE_PATH", raising=False)
+        result = get_nuke_publish_options(_request({}))
+        gizmo_field = next(f for f in result.fields if f.name == "gizmo_install_path")
+        assert gizmo_field.depends_on is None
+
+    def test_default_choice_is_dot_nuke(self, _mock_find, monkeypatch) -> None:
+        monkeypatch.delenv("NUKE_PATH", raising=False)
+        result = get_nuke_publish_options(_request({}))
+        gizmo_field = next(f for f in result.fields if f.name == "gizmo_install_path")
+        assert gizmo_field.default_value == normalize_path_str(str(Path.home() / ".nuke"))
+        assert gizmo_field.choices is not None
+        assert gizmo_field.choices[0] == normalize_path_str(str(Path.home() / ".nuke"))
+        assert gizmo_field.choices[-1] == GIZMO_INSTALL_CUSTOM
+
+    def test_custom_gizmo_path_hidden_unless_custom_selected(self, _mock_find, monkeypatch) -> None:
+        monkeypatch.delenv("NUKE_PATH", raising=False)
+        result = get_nuke_publish_options(_request({"gizmo_install_path": GIZMO_INSTALL_CUSTOM}))
+        custom_field = next(f for f in result.fields if f.name == "custom_gizmo_path")
+        assert custom_field.hidden is False
+
+        result = get_nuke_publish_options(_request({}))
+        custom_field = next(f for f in result.fields if f.name == "custom_gizmo_path")
+        assert custom_field.hidden is True
+
+    def test_restores_from_saved_publish_config_with_stale_nuke_key(self, _mock_find, monkeypatch) -> None:
+        """Old publish_config blobs saved before this simplification may still carry
+        a 'nuke' key — restoring them must not error even though the field is gone."""
+        monkeypatch.delenv("NUKE_PATH", raising=False)
+        start_flow = MagicMock()
+        start_flow.metadata = {
+            "publish_config": {
+                "nuke": "/Applications/Nuke16.0v7",
+                "gizmo_install_path": normalize_path_str(str(Path.home() / ".nuke")),
+                "custom_gizmo_path": None,
+                "gizmo_path": "/some/gizmo/path",
+                "version": 2,
+            }
+        }
+        with patch("publish_gizmo.nuke_publish_options._find_nuke_start_flow_node", return_value=start_flow):
+            result = get_nuke_publish_options(_request(None))
+
+        names = [f.name for f in result.fields]
+        assert "nuke" not in names
+        assert "update_mode" in names
+        gizmo_field = next(f for f in result.fields if f.name == "gizmo_install_path")
+        assert gizmo_field.default_value == normalize_path_str(str(Path.home() / ".nuke"))


### PR DESCRIPTION
## Summary

Drops the "Nuke Installation" dropdown from the gizmo publish dialog and simplifies the "Gizmo Install Path" dropdown to a single, direct source of truth: `~/.nuke` + `NUKE_PATH` segments + a custom path option.

Closes #108

## Why

The publish flow never runs the `nuke` binary and never validates the generated `.gizmo` TCL against a specific Nuke version. The "Nuke Installation" selection only existed to guess plausible `<install>/plugins` subfolders to offer as extra choices in the "Gizmo Install Path" dropdown — it had no bearing on correctness and added an executable-discovery dependency plus a second dependent dropdown for no real benefit.

`execution/installations.py`'s own use of `discover_nuke_executables()` for the `NukeScriptNode` launch path (an unrelated, legitimate consumer that actually runs `nuke -t`) is untouched.

## Changes

- `publish_gizmo/nuke_discovery.py`: removed `install_root_for_nuke_executable`, `pick_preferred_executable_for_root`, `discover_nuke_install_roots_and_map`, and `versioned_gizmo_paths_for_exe`. `compute_gizmo_install_path_choices()` is now a zero-arg function returning `[~/.nuke, *NUKE_PATH segments]`.
- `publish_gizmo/nuke_publish_options.py`: removed the "Nuke Installation" field and its dependent-dropdown wiring; `gizmo_install_path` no longer has a `depends_on`.
- `publish_gizmo/nuke_gizmo_publisher.py`: `_save_publish_config()` no longer persists a `nuke` key.
- `README.md`: updated the feature bullet and publish-dialog step to reflect the simplified dropdown.

## Test plan

- [x] Added `tests/unit/test_nuke_discovery.py` covering `compute_gizmo_install_path_choices()` and `default_gizmo_path()`.
- [x] Added `tests/unit/test_nuke_publish_options.py` covering the dialog's field list, `depends_on`, default selection, custom-path visibility, and backward-compat restore from a saved `publish_config` with a stale `nuke` key.
- [x] `uv run pytest tests/unit/` — 266 passed.
- [x] `make check` — ruff format/lint, pyright, JSON validation all pass.