### PR TITLE
Survive undefined output directory macro

### DIFF
--- a/publish_gizmo/constants.py
+++ b/publish_gizmo/constants.py
@@ -13,6 +13,12 @@ INIT_MARKER = "# griptape-plugin-path"
 # Filename of the run-button script copied into each companion directory
 RUN_BUTTON_FILENAME = "run_button.py"
 
+# Directory name (relative to the .nk script) where workflow outputs land when the
+# gizmo's Output Directory knob is left blank. Stamped into the bundled project.yml
+# at publish time and quoted in the gizmo's Run tab help text — shared here so the
+# documented default and the actual default cannot drift apart.
+OUTPUTS_DIR_NAME = "griptape_outputs"
+
 # Prefix for the hidden companion knob that stores a Link button's TCL expression
 # (the visible knob shows the evaluated value). Kept in sync with the local copy
 # in the bundled tcl_utils.py, which cannot import this module at runtime.

--- a/publish_gizmo/gizmo_writer.py
+++ b/publish_gizmo/gizmo_writer.py
@@ -41,7 +41,9 @@ class NukeKnobType:
     DOUBLE = 7
     PYSCRIPT = 22
     TAB = 20
-    DIVIDER = 26
+    # Nuke's Text_Knob: renders its T content as static text, or a horizontal
+    # divider when there is no content.
+    TEXT = 26
     MULTILINE_STRING = 28
 
 
@@ -125,11 +127,19 @@ class GizmoWriter:
 
     def add_divider(self, knob_name: str, label: str, flags: str = "+STARTLINE") -> None:
         """Add a horizontal divider / section label."""
-        self._knobs.append((NukeKnobType.DIVIDER, knob_name))
+        self._knobs.append((NukeKnobType.TEXT, knob_name))
         if flags:
-            self._lines.append(f' addUserKnob {{{NukeKnobType.DIVIDER} {knob_name} l "{label}" {flags}}}')
+            self._lines.append(f' addUserKnob {{{NukeKnobType.TEXT} {knob_name} l "{label}" {flags}}}')
         else:
-            self._lines.append(f' addUserKnob {{{NukeKnobType.DIVIDER} {knob_name} l "{label}"}}')
+            self._lines.append(f' addUserKnob {{{NukeKnobType.TEXT} {knob_name} l "{label}"}}')
+
+    def add_text_knob(self, knob_name: str, text: str, label: str = "", flags: str = "+STARTLINE") -> None:
+        """Add a static text knob (inline help text rendered in the panel)."""
+        self._knobs.append((NukeKnobType.TEXT, knob_name))
+        flag_suffix = f" {flags}" if flags else ""
+        self._lines.append(
+            f' addUserKnob {{{NukeKnobType.TEXT} {knob_name} l "{label}" T "{_tcl_escape_literal(text)}"{flag_suffix}}}'
+        )
 
     # -- Value knobs --
 

--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 
-from publish_gizmo.constants import GT_EXPR_PREFIX, RUN_BUTTON_FILENAME, versioned_node_name
+from publish_gizmo.constants import GT_EXPR_PREFIX, OUTPUTS_DIR_NAME, RUN_BUTTON_FILENAME, versioned_node_name
 from publish_gizmo.gizmo_validator import validate_gizmo
 from publish_gizmo.gizmo_writer import GizmoWriter, NukeKnobType
 
@@ -79,8 +79,12 @@ _TCL_HINT_TOOLTIP = (
     "Expressions are evaluated when the workflow runs."
 )
 _OUTPUT_DIR_TOOLTIP = (
-    "Directory for workflow outputs. Supports TCL expressions, e.g. [file dirname [value root.name]]/griptape."
+    f"Directory for workflow outputs. Leave blank to save to a '{OUTPUTS_DIR_NAME}' folder next to the .nk script. "
+    "Supports TCL expressions, e.g. [file dirname [value root.name]]/griptape."
 )
+# Static Run-tab text under the Output Directory field. The blank-field default is
+# otherwise invisible until the user hovers the tooltip or finds the Outputs tab.
+_OUTPUT_DIR_HELP_TEXT = f"When blank, outputs are saved to a '{OUTPUTS_DIR_NAME}' folder next to this .nk script."
 _LINK_BUTTON_TOOLTIP = (
     "Link this field to the gizmo name, script folder, script name, frame, or any node.knob. "
     "The field shows the linked value; editing it by hand removes the link."
@@ -306,6 +310,7 @@ class NukeGizmoBuilder:
         w.add_tab("run_tab", label="Run")
         w.add_string_knob("output_dir", label="Output Directory", tooltip=_OUTPUT_DIR_TOOLTIP)
         self._write_link_button(w, "output_dir")
+        w.add_text_knob("_output_dir_help", text=_OUTPUT_DIR_HELP_TEXT)
         run_code = self._build_run_button_bootstrap(
             input_params,
             list(output_params.keys()),

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -41,6 +41,7 @@ from griptape_nodes.retained_mode.publishing import WorkflowPackager
 from publish_gizmo.constants import (
     GRIPTAPE_DIR_NAME,
     INIT_MARKER,
+    OUTPUTS_DIR_NAME,
     versioned_gizmo_filename,
 )
 from publish_gizmo.nuke_discovery import GIZMO_INSTALL_CUSTOM
@@ -269,7 +270,7 @@ class NukeGizmoPublisher:
 
         template.directories["outputs"] = DirectoryDefinition(
             name="outputs",
-            path_macro="griptape_outputs",
+            path_macro=OUTPUTS_DIR_NAME,
         )
 
         template.situations["save_node_output"] = SituationTemplate(

--- a/tests/unit/test_gizmo_writer.py
+++ b/tests/unit/test_gizmo_writer.py
@@ -1,8 +1,8 @@
-"""Tests for gizmo_writer TCL literal escaping."""
+"""Tests for gizmo_writer TCL literal escaping and knob emission."""
 
 from __future__ import annotations
 
-from publish_gizmo.gizmo_writer import _tcl_escape_literal
+from publish_gizmo.gizmo_writer import GizmoWriter, _tcl_escape_literal
 
 
 class TestTclEscapeLiteral:
@@ -29,3 +29,21 @@ class TestTclEscapeLiteral:
 
     def test_newline_preserved(self) -> None:
         assert _tcl_escape_literal("line1\nline2") == "line1\nline2"
+
+
+class TestAddTextKnob:
+    def test_text_knob_emits_type_26_with_text_content(self) -> None:
+        w = GizmoWriter()
+        w.add_text_knob("_help", text="Saved next to the script.")
+        line = w.render().splitlines()[0]
+        assert line.startswith(" addUserKnob {26 _help")
+        assert 'l ""' in line
+        assert 'T "Saved next to the script."' in line
+        assert "+STARTLINE" in line
+
+    def test_text_knob_escapes_tcl_specials(self) -> None:
+        w = GizmoWriter()
+        w.add_text_knob("_help", text='use [value root.name] or "quotes"')
+        line = w.render().splitlines()[0]
+        assert r"\[value root.name]" in line
+        assert r"\"quotes\"" in line

--- a/tests/unit/test_nuke_gizmo_builder.py
+++ b/tests/unit/test_nuke_gizmo_builder.py
@@ -4,6 +4,7 @@ import ast
 
 import pytest
 
+from publish_gizmo.constants import OUTPUTS_DIR_NAME
 from publish_gizmo.nuke_gizmo_builder import NukeGizmoBuilder, _build_knob_changed_code
 
 
@@ -307,6 +308,29 @@ class TestTclHintTooltips:
         gizmo = _generate_gizmo({"count": {"type": "int", "default_value": 1}})
         knob_line = next(line for line in gizmo.splitlines() if "addUserKnob {3 count" in line)
         assert ' t "' not in knob_line
+
+
+class TestOutputDirDefaultDocumented:
+    """The Run tab must say where outputs land when Output Directory is blank (issue #98)."""
+
+    def test_run_tab_help_text_names_default_output_folder(self) -> None:
+        gizmo = _generate_gizmo({})
+        help_line = next(line for line in gizmo.splitlines() if "addUserKnob {26 _output_dir_help" in line)
+        assert OUTPUTS_DIR_NAME in help_line
+        assert ".nk script" in help_line
+
+    def test_help_text_sits_between_output_dir_knob_and_run_button(self) -> None:
+        gizmo = _generate_gizmo({})
+        lines = gizmo.splitlines()
+        knob_idx = next(i for i, line in enumerate(lines) if "addUserKnob {1 output_dir" in line)
+        help_idx = next(i for i, line in enumerate(lines) if "addUserKnob {26 _output_dir_help" in line)
+        button_idx = next(i for i, line in enumerate(lines) if "addUserKnob {22 run_workflow" in line)
+        assert knob_idx < help_idx < button_idx
+
+    def test_output_dir_tooltip_states_blank_default(self) -> None:
+        gizmo = _generate_gizmo({})
+        knob_line = next(line for line in gizmo.splitlines() if "addUserKnob {1 output_dir" in line)
+        assert OUTPUTS_DIR_NAME in knob_line
 
 
 class TestExpressionLinkButtons:

--- a/tests/unit/test_nuke_gizmo_publisher_output.py
+++ b/tests/unit/test_nuke_gizmo_publisher_output.py
@@ -30,6 +30,18 @@ def _find_situation_template_call(func: ast.FunctionDef) -> ast.Call:
     raise AssertionError(msg)
 
 
+def _find_directory_definition_call(func: ast.FunctionDef) -> ast.Call:
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            func_node = node.func
+            if isinstance(func_node, ast.Name) and func_node.id == "DirectoryDefinition":
+                return node
+            if isinstance(func_node, ast.Attribute) and func_node.attr == "DirectoryDefinition":
+                return node
+    msg = "DirectoryDefinition() call not found in _customize_project_yml"
+    raise AssertionError(msg)
+
+
 def _get_keyword_value(call: ast.Call, name: str) -> ast.expr:
     for kw in call.keywords:
         if kw.arg == name:
@@ -65,3 +77,14 @@ class TestCustomizeProjectYmlOutput:
         assert on_collision_node.attr == "CREATE_NEW", (
             f"Expected CREATE_NEW collision policy, got: {on_collision_node.attr!r}"
         )
+
+    def test_outputs_path_macro_uses_shared_constant(self) -> None:
+        """The gizmo's Run tab help text quotes OUTPUTS_DIR_NAME; the project.yml
+        must be stamped from the same constant or the two silently drift."""
+        func = _get_customize_project_yml_source()
+        call = _find_directory_definition_call(func)
+        path_macro_node = _get_keyword_value(call, "path_macro")
+        assert isinstance(path_macro_node, ast.Name), (
+            f"Expected path_macro to reference OUTPUTS_DIR_NAME, got: {ast.dump(path_macro_node)}"
+        )
+        assert path_macro_node.id == "OUTPUTS_DIR_NAME"


### PR DESCRIPTION
Closes https://github.com/griptape-ai/griptape-nodes-library-nuke/issues/98

Claude overly implemented some changes from #100 

On a published gizmo, a blank Output Directory silently defaults to a griptape_outputs folder next to the .nk script — but nothing on the Run tab said so. The only hints were a tooltip that didn't state the default and the Outputs tab, which first-time users miss entirely.

Changes:

The Run tab now shows static help text directly under the field: "When blank, outputs are saved to a 'griptape_outputs' folder next to this .nk script." The knob tooltip states the same default before the TCL-expression hint.
New OUTPUTS_DIR_NAME constant in publish_gizmo/constants.py, used by both the publisher (which stamps it into the bundled project.yml as the outputs macro) and the builder (which quotes it in the help text/tooltip) — so the documented default and the actual default can't drift.
GizmoWriter gains add_text_knob(). NukeKnobType.DIVIDER is renamed to TEXT (type 26 is Nuke's Text_Knob; a divider is just one with no content — the name was only used inside gizmo_writer.py).
Tests: text-knob emission and TCL escaping; the help text names the default folder and sits between the output_dir knob and the Run button; an AST check that the publisher's path_macro references OUTPUTS_DIR_NAME.

Note: this will conflict trivially with fix/relative-output-dir (#100) — both edit _OUTPUT_DIR_TOOLTIP. Resolution is to keep both sentences (blank default + relative-path resolution).

