### PR TITLE
fix(gizmo): make the gizmo child process environment hermetic

### DIFF
--- a/execution/direct.py
+++ b/execution/direct.py
@@ -17,6 +17,18 @@ if TYPE_CHECKING:
 
 _CANCEL_GRACE_SECONDS = 5
 
+# Qt plugin paths inherited from the engine's venv (e.g. cv2 ships its own) shadow
+# Nuke's bundled Qt plugins and crash the headless process on Linux.
+_STRIPPED_QT_VARS = ("QT_PLUGIN_PATH", "QT_QPA_PLATFORM_PLUGIN_PATH")
+
+# The engine runs in a Python 3.12 venv; `nuke -t` runs Nuke's own bundled
+# interpreter (3.10/3.11 depending on the release). Leaking the engine's Python
+# vars puts 3.12 site-packages -- including compiled extensions built against a
+# different ABI -- ahead of Nuke's own, which crashes it rather than failing to
+# import. Same leak in the opposite direction as _LEAKED_PYTHON_VARS in
+# publish_gizmo/run_button.py.
+_STRIPPED_PYTHON_VARS = ("PYTHONPATH", "PYTHONHOME", "PYTHONEXECUTABLE", "VIRTUAL_ENV")
+
 
 class DirectSubprocessProvider:
     """Runs Nuke as a direct child process. Default provider for local dev."""
@@ -63,11 +75,11 @@ class DirectSubprocessProvider:
         out_manifest = tmp.name + ".out.json"
         self._output_manifest_paths[handle] = out_manifest
         env = os.environ.copy()
-        # Strip inherited Qt plugin paths (e.g. cv2 ships its own) that would
-        # shadow Nuke's bundled Qt plugins and crash the headless process on Linux.
+        # Strip inherited Qt plugin paths and the engine's own Python vars, which would
+        # otherwise shadow what Nuke's bundled interpreter and Qt need.
         # Done before manifest overrides so callers can explicitly set these if needed.
-        for _qt_var in ("QT_PLUGIN_PATH", "QT_QPA_PLATFORM_PLUGIN_PATH"):
-            env.pop(_qt_var, None)
+        for _var in (*_STRIPPED_QT_VARS, *_STRIPPED_PYTHON_VARS):
+            env.pop(_var, None)
         if self._installation is not None:
             env.update(self._installation.env_overrides)
         env.update(manifest.env)

--- a/execution/direct.py
+++ b/execution/direct.py
@@ -27,6 +27,14 @@ _STRIPPED_QT_VARS = ("QT_PLUGIN_PATH", "QT_QPA_PLATFORM_PLUGIN_PATH")
 # different ABI -- ahead of Nuke's own, which crashes it rather than failing to
 # import. Same leak in the opposite direction as _LEAKED_PYTHON_VARS in
 # publish_gizmo/run_button.py.
+#
+# Deliberately narrower than that list, and duplicated rather than shared:
+# run_button.py is exec'd standalone inside Nuke and can only import its own
+# companion-bundle siblings, so it cannot read this constant. The differences are
+# intentional -- UV_PYTHON/UV_SYSTEM_PYTHON are meaningless here (no uv involved),
+# and PYTHONNOUSERSITE is omitted because user site-packages are version-keyed, so
+# a 3.12 user tree won't load under Nuke's 3.10/3.11 anyway. Add to both lists when
+# the var would hijack either interpreter.
 _STRIPPED_PYTHON_VARS = ("PYTHONPATH", "PYTHONHOME", "PYTHONEXECUTABLE", "VIRTUAL_ENV")
 
 

--- a/nuke_nodes/nuke_script_node.py
+++ b/nuke_nodes/nuke_script_node.py
@@ -10,6 +10,7 @@ import subprocess
 import tempfile
 import urllib.request
 import uuid
+from collections.abc import Mapping
 from typing import Any
 
 from griptape_nodes.common.macro_parser import ParsedMacro
@@ -35,7 +36,7 @@ from griptape_nodes.traits.file_system_picker import FileSystemPicker
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
-from execution.direct import DirectSubprocessProvider
+from execution.direct import _STRIPPED_PYTHON_VARS, _STRIPPED_QT_VARS, DirectSubprocessProvider
 from execution.installations import NukeInstallation, find_installation, merged_installations
 from nuke_plugin.installer import get_plugin_path
 from nuke_runner.manifest import JobManifest, KnobOverride, ManifestInput, ManifestOutput
@@ -145,6 +146,18 @@ for o in data.get("knob_overrides", []):
     except Exception as exc:
         print("Griptape open-in-nuke: " + o["node"] + "." + o["knob"] + ": " + str(exc), file=sys.stderr)
 """
+
+
+def _sanitize_nuke_launch_env(base_env: Mapping[str, str], env_overrides: Mapping[str, str]) -> dict[str, str]:
+    """Return base_env minus the vars that would shadow Nuke's own Qt and interpreter, plus overrides."""
+    # The GUI counterpart of what DirectSubprocessProvider.submit does for `nuke -t`:
+    # the engine runs in a 3.12 venv, Nuke runs its own 3.10/3.11, and a leaked
+    # PYTHONPATH puts mismatched-ABI extensions ahead of Nuke's -- which takes the whole
+    # app down rather than failing a single headless job.  Overrides are applied *after*
+    # the strip, matching direct.py, so an installation can still set these deliberately.
+    env = {k: v for k, v in base_env.items() if k not in (*_STRIPPED_QT_VARS, *_STRIPPED_PYTHON_VARS)}
+    env.update(env_overrides)
+    return env
 
 
 def _build_open_in_nuke_launch(
@@ -328,10 +341,7 @@ class NukeScriptNode(SuccessFailureNode):
             if installation is not None
             else int(GriptapeNodes.ConfigManager().get_config_value("nuke.annotator_nuke_version") or 16)
         )
-        env: dict[str, str] = {**os.environ, **self._build_env(installation)}
-        # Strip third-party Qt plugin paths (e.g. cv2) that shadow Nuke's bundled Qt.
-        for _qt_var in ("QT_PLUGIN_PATH", "QT_QPA_PLATFORM_PLUGIN_PATH"):
-            env.pop(_qt_var, None)
+        env: dict[str, str] = _sanitize_nuke_launch_env(os.environ, self._build_env(installation))
 
         try:
             plugin_path = get_plugin_path(nuke_major)

--- a/publish_gizmo/nuke_workflow_runner.py
+++ b/publish_gizmo/nuke_workflow_runner.py
@@ -116,8 +116,21 @@ def _load_workflow_module(workflow_file: str):
     return module
 
 
+def _log_interpreter() -> None:
+    """Log which interpreter is running and whether a host PYTHONPATH leaked in.
+
+    run_button.py streams this to the gizmo's progress dialog, so an environment
+    leak (a wrapper's site-packages shadowing the venv) is visible at a glance
+    instead of surfacing as a bare ImportError from deep inside the engine.
+    """
+    logger.info("Interpreter: %s", sys.executable)
+    logger.info("Python version: %s", sys.version.split()[0])
+    logger.info("PYTHONPATH: %s", os.environ.get("PYTHONPATH", "") or "(empty)")
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
+    _log_interpreter()
 
     parser = argparse.ArgumentParser(description="Run a Griptape Nodes workflow from a gizmo.")
     parser.add_argument("--workflow-file", required=True, help="Path to the workflow .py file")
@@ -182,7 +195,20 @@ def main() -> None:
 
         register_bundled_libraries()
     except Exception as e:
-        print(json.dumps({"error": f"Failed to register bundled libraries: {e}"}))
+        # This is the message an artist copies into a bug report, and the usual cause
+        # is a host env var pointing the interpreter at foreign packages -- so name the
+        # interpreter and any leaked PYTHONPATH here rather than only in the log stream.
+        print(
+            json.dumps(
+                {
+                    "error": (
+                        f"Failed to register bundled libraries: {e}"
+                        f" [interpreter={sys.executable} python={sys.version.split()[0]}"
+                        f" PYTHONPATH={os.environ.get('PYTHONPATH', '') or '(empty)'}]"
+                    )
+                }
+            )
+        )
         sys.exit(1)
 
     # Download HuggingFace models if a download script was bundled at publish time.

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -93,6 +93,34 @@ def _has_lockfile(companion: str) -> bool:
     return os.path.isfile(os.path.join(companion, "uv.lock"))
 
 
+# Host Python env vars must not leak into the gizmo's uv venv.  Nuke is often
+# launched through a wrapper (rez, modules, conda, an activated venv) that exports
+# PYTHONPATH pointing at that wrapper's own site-packages -- and PYTHONPATH is
+# placed *ahead* of the venv's site-packages in sys.path, so the child 3.12
+# interpreter imports the wrapper's copy of a dependency instead of the version the
+# engine pinned.  Pure-Python packages import fine across minor versions, so this
+# shows up as a wrong-version ImportError rather than a missing module.  Mirrors the
+# desktop app's list in griptape-nodes-desktop/src/common/config/env.ts -- keep the
+# two in sync.  UV_PYTHON/UV_SYSTEM_PYTHON are stripped as well because an
+# inherited value fights the bundle's pinned requires-python.
+_LEAKED_PYTHON_VARS = (
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONSTARTUP",
+    "PYTHONUSERBASE",
+    "PYTHONEXECUTABLE",
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+    "UV_PYTHON",
+    "UV_SYSTEM_PYTHON",
+)
+
+# Deliberately NOT stripped: PATH, LD_LIBRARY_PATH, DYLD_LIBRARY_PATH.  A rez/studio
+# environment uses those to supply GPU, driver and system libraries that nodes in the
+# child process legitimately need; clearing them breaks far more than it fixes.
+_KEEP_PYTHONPATH_VAR = "GTN_GIZMO_KEEP_PYTHONPATH"
+
+
 def _build_child_env(local_dir: str, base_env: dict, *, frozen: bool = True) -> dict:
     """Return a subprocess env pointing config and the uv venv at the local dir.
 
@@ -105,12 +133,25 @@ def _build_child_env(local_dir: str, base_env: dict, *, frozen: bool = True) -> 
     lock present uv refuses to run at all. When unfrozen, an inherited
     UV_FROZEN/UV_LOCKED is cleared too, so a site-wide export can't reintroduce
     the same failure. local_dir must already be an absolute forward-slashed path.
+
+    Host Python vars are dropped (see _LEAKED_PYTHON_VARS) so the child resolves
+    imports only against its own venv. A site that deliberately injects packages
+    via PYTHONPATH can opt out by exporting GTN_GIZMO_KEEP_PYTHONPATH=1 in the
+    environment Nuke is launched with; every other var is still stripped.
     """
     env = {
         **base_env,
         "XDG_CONFIG_HOME": local_dir + "/.gtn_config",
         "UV_PROJECT_ENVIRONMENT": local_dir + "/.venv",
+        # A host ~/.local/lib/pythonX.Y/site-packages would shadow the venv the
+        # same way PYTHONPATH does, and no env var points at it to strip.
+        "PYTHONNOUSERSITE": "1",
     }
+    keep_pythonpath = str(base_env.get(_KEEP_PYTHONPATH_VAR, "")).strip().lower() not in ("", "0", "false", "no")
+    for _var in _LEAKED_PYTHON_VARS:
+        if _var == "PYTHONPATH" and keep_pythonpath:
+            continue
+        env.pop(_var, None)
     if frozen:
         env["UV_FROZEN"] = "1"
     else:

--- a/publish_gizmo/run_button.py
+++ b/publish_gizmo/run_button.py
@@ -100,9 +100,11 @@ def _has_lockfile(companion: str) -> bool:
 # interpreter imports the wrapper's copy of a dependency instead of the version the
 # engine pinned.  Pure-Python packages import fine across minor versions, so this
 # shows up as a wrong-version ImportError rather than a missing module.  Mirrors the
-# desktop app's list in griptape-nodes-desktop/src/common/config/env.ts -- keep the
-# two in sync.  UV_PYTHON/UV_SYSTEM_PYTHON are stripped as well because an
-# inherited value fights the bundle's pinned requires-python.
+# desktop app's list in griptape-nodes-desktop/src/common/config/env.ts, which solves
+# the same problem for the bundled engine -- add here when that list grows (a unit test
+# only enforces the floor, it cannot see that repo change).  UV_PYTHON/UV_SYSTEM_PYTHON
+# are stripped as well because an inherited value fights the bundle's pinned
+# requires-python.
 _LEAKED_PYTHON_VARS = (
     "PYTHONPATH",
     "PYTHONHOME",

--- a/tests/unit/test_direct.py
+++ b/tests/unit/test_direct.py
@@ -60,6 +60,36 @@ def test_submit_writes_manifest_env_into_subprocess_env() -> None:
     assert env_kwarg["OCIO"] == "/ocio/config"
 
 
+def test_submit_strips_engine_python_vars_from_nuke_env(monkeypatch) -> None:
+    """The engine's 3.12 venv must not shadow Nuke's own bundled interpreter."""
+    monkeypatch.setenv("PYTHONPATH", "/engine/.venv/lib/python3.12/site-packages")
+    monkeypatch.setenv("PYTHONHOME", "/engine/.venv")
+    monkeypatch.setenv("PYTHONEXECUTABLE", "/engine/.venv/bin/python")
+    monkeypatch.setenv("VIRTUAL_ENV", "/engine/.venv")
+
+    provider = _make_provider()
+    with patch("execution.direct.subprocess.Popen") as mock_popen:
+        mock_popen.return_value = _mock_process()
+        provider.submit(_make_manifest())
+
+    env_kwarg = mock_popen.call_args[1]["env"]
+    for key in ("PYTHONPATH", "PYTHONHOME", "PYTHONEXECUTABLE", "VIRTUAL_ENV"):
+        assert key not in env_kwarg
+
+
+def test_submit_lets_manifest_env_reinstate_a_stripped_var(monkeypatch) -> None:
+    """Stripping happens before overrides, so a caller can still set these deliberately."""
+    monkeypatch.setenv("PYTHONPATH", "/engine/.venv/lib/python3.12/site-packages")
+
+    provider = _make_provider()
+    manifest = _make_manifest(env={"PYTHONPATH": "/studio/nuke/pythonpath"})
+    with patch("execution.direct.subprocess.Popen") as mock_popen:
+        mock_popen.return_value = _mock_process()
+        provider.submit(manifest)
+
+    assert mock_popen.call_args[1]["env"]["PYTHONPATH"] == "/studio/nuke/pythonpath"
+
+
 def test_submit_returns_unique_handles_per_call() -> None:
     provider = _make_provider()
     with patch("execution.direct.subprocess.Popen", return_value=_mock_process()):

--- a/tests/unit/test_open_in_nuke.py
+++ b/tests/unit/test_open_in_nuke.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 
-from nuke_nodes.nuke_script_node import _build_open_in_nuke_launch
+from nuke_nodes.nuke_script_node import _build_open_in_nuke_launch, _sanitize_nuke_launch_env
 from nuke_runner.manifest import KnobOverride
 
 
@@ -82,3 +82,41 @@ def test_empty_overrides_produces_empty_array() -> None:
     with open(manifest_path, encoding="utf-8") as f:
         data = json.load(f)
     assert data["knob_overrides"] == []
+
+
+class TestSanitizeNukeLaunchEnv:
+    """The GUI launch env must not shadow Nuke's own Qt plugins or interpreter."""
+
+    def test_strips_engine_python_vars(self) -> None:
+        base = {
+            "PYTHONPATH": "/opt/venvs/engine/lib/python3.12/site-packages",
+            "PYTHONHOME": "/opt/py312",
+            "PYTHONEXECUTABLE": "/opt/venvs/engine/bin/python",
+            "VIRTUAL_ENV": "/opt/venvs/engine",
+        }
+        env = _sanitize_nuke_launch_env(base, {})
+        for key in base:
+            assert key not in env
+
+    def test_strips_qt_plugin_paths(self) -> None:
+        base = {"QT_PLUGIN_PATH": "/opt/venvs/engine/lib/cv2/plugins", "QT_QPA_PLATFORM_PLUGIN_PATH": "/opt/plugins"}
+        env = _sanitize_nuke_launch_env(base, {})
+        for key in base:
+            assert key not in env
+
+    def test_preserves_unrelated_vars(self) -> None:
+        base = {"PATH": "/usr/bin", "LD_LIBRARY_PATH": "/opt/nuke/lib", "foundry_LICENSE": "set-by-secrets-panel"}
+        env = _sanitize_nuke_launch_env(base, {})
+        for key, value in base.items():
+            assert env[key] == value
+
+    def test_overrides_win_over_the_strip(self) -> None:
+        """The ordering guarantee: an installation can deliberately reinstate a stripped var."""
+        env = _sanitize_nuke_launch_env({"PYTHONPATH": "/leaked"}, {"PYTHONPATH": "/deliberate/site-packages"})
+        assert env["PYTHONPATH"] == "/deliberate/site-packages"
+
+    def test_does_not_mutate_base_env(self) -> None:
+        base = {"PYTHONPATH": "/leaked", "PATH": "/usr/bin"}
+        original = dict(base)
+        _sanitize_nuke_launch_env(base, {"HOME": "/home/user"})
+        assert base == original

--- a/tests/unit/test_run_button_env.py
+++ b/tests/unit/test_run_button_env.py
@@ -229,8 +229,14 @@ class TestChildEnvPythonIsolation:
         _build_child_env(self._LOCAL, base)
         assert base == original
 
-    def test_strip_list_matches_the_desktop_app(self) -> None:
-        """Kept in sync with griptape-nodes-desktop/src/common/config/env.ts."""
+    def test_strip_list_covers_at_least_the_desktop_apps_vars(self) -> None:
+        """A floor on the strip list, not a sync check.
+
+        desktop_vars is transcribed from griptape-nodes-desktop/src/common/config/env.ts,
+        so this catches us *dropping* one of those vars. It cannot see the desktop app
+        adding a var -- that direction needs a shared constant, which isn't possible
+        across a Python library and an Electron app.
+        """
         desktop_vars = {"PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE", "VIRTUAL_ENV"}
         assert desktop_vars <= set(_LEAKED_PYTHON_VARS)
 

--- a/tests/unit/test_run_button_env.py
+++ b/tests/unit/test_run_button_env.py
@@ -14,24 +14,38 @@ from pathlib import Path
 _RUN_BUTTON = Path(__file__).parent.parent.parent / "publish_gizmo" / "run_button.py"
 
 
-def _func_source(func_name: str) -> str:
-    """Return the source lines of a top-level function from run_button.py."""
+def _top_level_source(first_line_prefix: str) -> str:
+    """Return a top-level definition from run_button.py, including its continuation lines."""
     source = _RUN_BUTTON.read_text(encoding="utf-8")
     lines = source.splitlines()
-    start = next(i for i, line in enumerate(lines) if line.startswith(f"def {func_name}("))
+    start = next(i for i, line in enumerate(lines) if line.startswith(first_line_prefix))
     body_lines = [lines[start]]
     for line in lines[start + 1 :]:
+        # A top-level statement ends at the next line that starts in column 0,
+        # except for the closing bracket of a multi-line literal.
         if line and not line[0].isspace():
+            if line.startswith(")"):
+                body_lines.append(line)
             break
         body_lines.append(line)
     return "\n".join(body_lines)
 
 
+def _func_source(func_name: str) -> str:
+    """Return the source lines of a top-level function from run_button.py."""
+    return _top_level_source(f"def {func_name}(")
+
+
 # Load the pure helpers into one shared namespace so _gizmo_local_dir can call
 # _venv_root, without running run_button.py's module-scope Nuke/Qt code.
 _NS: dict = {"os": os, "re": re, "hashlib": hashlib}
+# _build_child_env reads these module-level constants, so they must be in scope too.
+for _const in ("_LEAKED_PYTHON_VARS = (", "_KEEP_PYTHONPATH_VAR = "):
+    exec(_top_level_source(_const), _NS)  # noqa: S102
 for _name in ("_venv_root", "_gizmo_local_dir", "_has_lockfile", "_build_child_env"):
     exec(_func_source(_name), _NS)  # noqa: S102
+
+_LEAKED_PYTHON_VARS = _NS["_LEAKED_PYTHON_VARS"]
 
 _venv_root = _NS["_venv_root"]
 _build_child_env = _NS["_build_child_env"]
@@ -138,12 +152,87 @@ class TestBuildChildEnv:
         assert "\\" not in env["XDG_CONFIG_HOME"]
         assert "\\" not in env["UV_PROJECT_ENVIRONMENT"]
 
-    def test_preserves_all_base_env_keys(self) -> None:
-        """All existing env keys must be present in the child env."""
+    def test_preserves_base_env_keys_outside_the_strip_list(self) -> None:
+        """Env keys that aren't interpreter-hijacking must survive untouched."""
         base = {"PATH": "/usr/bin", "HOME": "/home/user", "CUSTOM_VAR": "value"}
         env = _build_child_env(self._LOCAL, base)
         for key, value in base.items():
             assert env[key] == value
+
+
+class TestChildEnvPythonIsolation:
+    """Host Python vars must not shadow the gizmo venv's own site-packages."""
+
+    _LOCAL = "/home/user/.local/share/griptape_nodes/venvs/wf-abcd1234"
+    # A wrapper-supplied python3.11 tree, whose older copy of an engine dependency
+    # would otherwise be imported ahead of the 3.12 venv's pinned version.
+    _WRAPPER_PYTHONPATH = "/opt/wrapper_python_envs/shared/3.11.9/lib/python3.11/site-packages"
+
+    def test_strips_inherited_pythonpath(self) -> None:
+        env = _build_child_env(self._LOCAL, {"PYTHONPATH": self._WRAPPER_PYTHONPATH})
+        assert "PYTHONPATH" not in env
+
+    def test_strips_pythonhome_and_virtual_env(self) -> None:
+        base = {
+            "PYTHONHOME": "/opt/wrapper_python_envs/shared/3.11.9",
+            "PYTHONEXECUTABLE": "/usr/bin/python3.11",
+            "PYTHONSTARTUP": "/etc/pythonstart.py",
+            "PYTHONUSERBASE": "/home/user/.local",
+            "VIRTUAL_ENV": "/some/other/.venv",
+            "CONDA_PREFIX": "/opt/conda",
+        }
+        env = _build_child_env(self._LOCAL, base)
+        for key in base:
+            assert key not in env
+
+    def test_strips_uv_python_overrides(self) -> None:
+        """An inherited UV_PYTHON would fight the bundle's pinned requires-python."""
+        env = _build_child_env(self._LOCAL, {"UV_PYTHON": "3.11", "UV_SYSTEM_PYTHON": "1"})
+        assert "UV_PYTHON" not in env
+        assert "UV_SYSTEM_PYTHON" not in env
+
+    def test_sets_pythonnousersite(self) -> None:
+        """A host user site-packages dir shadows the venv and no env var points at it."""
+        env = _build_child_env(self._LOCAL, {})
+        assert env["PYTHONNOUSERSITE"] == "1"
+
+    def test_keeps_pythonpath_when_opt_out_set(self) -> None:
+        base = {"PYTHONPATH": self._WRAPPER_PYTHONPATH, "GTN_GIZMO_KEEP_PYTHONPATH": "1"}
+        env = _build_child_env(self._LOCAL, base)
+        assert env["PYTHONPATH"] == self._WRAPPER_PYTHONPATH
+
+    def test_opt_out_still_strips_the_other_vars(self) -> None:
+        """The escape hatch is scoped to PYTHONPATH; PYTHONHOME still breaks the venv."""
+        base = {"PYTHONHOME": "/opt/py311", "GTN_GIZMO_KEEP_PYTHONPATH": "1"}
+        env = _build_child_env(self._LOCAL, base)
+        assert "PYTHONHOME" not in env
+
+    def test_falsy_opt_out_still_strips_pythonpath(self) -> None:
+        base = {"PYTHONPATH": self._WRAPPER_PYTHONPATH, "GTN_GIZMO_KEEP_PYTHONPATH": "0"}
+        env = _build_child_env(self._LOCAL, base)
+        assert "PYTHONPATH" not in env
+
+    def test_leaves_ld_library_path_intact(self) -> None:
+        """A wrapper env supplies GPU/driver libs this way — stripping it breaks more than it fixes."""
+        base = {
+            "LD_LIBRARY_PATH": "/opt/nuke/lib:/usr/lib64",
+            "DYLD_LIBRARY_PATH": "/opt/lib",
+            "PATH": "/usr/bin",
+        }
+        env = _build_child_env(self._LOCAL, base)
+        for key, value in base.items():
+            assert env[key] == value
+
+    def test_does_not_mutate_base_env_when_stripping(self) -> None:
+        base = {"PYTHONPATH": self._WRAPPER_PYTHONPATH, "PYTHONHOME": "/opt/py311"}
+        original = dict(base)
+        _build_child_env(self._LOCAL, base)
+        assert base == original
+
+    def test_strip_list_matches_the_desktop_app(self) -> None:
+        """Kept in sync with griptape-nodes-desktop/src/common/config/env.ts."""
+        desktop_vars = {"PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE", "VIRTUAL_ENV"}
+        assert desktop_vars <= set(_LEAKED_PYTHON_VARS)
 
     def test_does_not_mutate_base_env(self) -> None:
         base = {"PATH": "/usr/bin"}

--- a/tests/unit/test_workflow_runner_env.py
+++ b/tests/unit/test_workflow_runner_env.py
@@ -19,17 +19,20 @@ _RUNNER = Path(__file__).parent.parent.parent / "publish_gizmo" / "nuke_workflow
 _API_KEY = "GT_CLOUD_API_KEY"
 
 
-def _load_bundled_env_fn():
+def _extract_fn(name: str, ns: dict):
     src = _RUNNER.read_text(encoding="utf-8")
     tree = ast.parse(src)
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "_load_bundled_env":
+        if isinstance(node, ast.FunctionDef) and node.name == name:
             func_src = textwrap.dedent(ast.get_source_segment(src, node) or "")
-            ns: dict = {"os": os, "dotenv_values": dotenv_values, "Path": Path}
             exec(func_src, ns)  # noqa: S102
-            return ns["_load_bundled_env"]
-    msg = "_load_bundled_env not found in nuke_workflow_runner.py"
+            return ns[name]
+    msg = f"{name} not found in nuke_workflow_runner.py"
     raise AssertionError(msg)
+
+
+def _load_bundled_env_fn():
+    return _extract_fn("_load_bundled_env", {"os": os, "dotenv_values": dotenv_values, "Path": Path})
 
 
 @pytest.fixture
@@ -89,3 +92,34 @@ def test_blank_bundled_value_is_not_exported(load_bundled_env, env_file) -> None
 def test_quoted_values_are_parsed_not_taken_literally(load_bundled_env, env_file) -> None:
     load_bundled_env(env_file(f'{_API_KEY}="key with spaces"\n'))
     assert os.environ[_API_KEY] == "key with spaces"
+
+
+class TestInterpreterLogging:
+    """The runner announces its interpreter so an env leak is diagnosable from the dialog."""
+
+    @staticmethod
+    def _run(caplog) -> str:
+        import logging
+        import sys
+
+        ns: dict = {"os": os, "sys": sys, "logger": logging.getLogger("test_runner_interp")}
+        log_interpreter = _extract_fn("_log_interpreter", ns)
+        with caplog.at_level(logging.INFO, logger="test_runner_interp"):
+            log_interpreter()
+        return caplog.text
+
+    def test_logs_interpreter_path_and_version(self, caplog) -> None:
+        import sys
+
+        text = self._run(caplog)
+        assert sys.executable in text
+        assert sys.version.split()[0] in text
+
+    def test_logs_leaked_pythonpath(self, caplog, monkeypatch) -> None:
+        monkeypatch.setenv("PYTHONPATH", "/rez/python3.11/site-packages")
+        assert "/rez/python3.11/site-packages" in self._run(caplog)
+
+    def test_reports_empty_pythonpath_explicitly(self, caplog, monkeypatch) -> None:
+        """A blank line would be ambiguous — 'not set' must be distinguishable."""
+        monkeypatch.delenv("PYTHONPATH", raising=False)
+        assert "(empty)" in self._run(caplog)


### PR DESCRIPTION
Nuke is commonly launched through a wrapper (rez, environment modules, conda, an activated venv) that exports `PYTHONPATH` pointing at that wrapper's own `site-packages`. `_build_child_env` copied `os.environ` wholesale, and `PYTHONPATH` sits *ahead* of a venv's `site-packages` in `sys.path` — so the gizmo's child process could import the wrapper's copy of an engine dependency instead of the version the bundle pinned.

Because pure-Python packages import fine across minor versions, this presents as a confusing wrong-version `ImportError` rather than a missing module, which makes it look like an interpreter-version problem. It isn't: Nuke's bundled Python only ever runs `run_button.py`, and the child is already on the 3.12 that the companion `pyproject.toml` pins via `requires-python`. Nothing about Nuke's own Python version is a prerequisite.

## Changes

- **`publish_gizmo/run_button.py`** — strip host Python vars (`_LEAKED_PYTHON_VARS`) and set `PYTHONNOUSERSITE=1`, since a host user `site-packages` shadows the venv the same way and no env var points at it. Escape hatch for sites that inject packages deliberately: `GTN_GIZMO_KEEP_PYTHONPATH=1`, scoped to `PYTHONPATH` only. `PATH` / `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH` are kept on purpose — a wrapper environment supplies GPU, driver and system libraries through them, and clearing them breaks far more than it fixes. There's a comment saying so, so it doesn't get "fixed" later by accident.
- **`publish_gizmo/nuke_workflow_runner.py`** — log the interpreter, version and `PYTHONPATH` at startup, and repeat those three facts in the register-libraries error payload. `run_button.py` streams child stderr into the progress dialog, so the next environment leak is visible at a glance instead of surfacing as a bare `ImportError` from deep inside the engine.
- **`execution/direct.py`** — close the same leak in the opposite direction (engine venv → `nuke -t`). That direction is worse: leaked Python vars can put mismatched-ABI compiled extensions ahead of Nuke's own and crash the process rather than merely fail an import. Stripping stays **before** `installation.env_overrides` and `manifest.env` are applied, so an installation can still set these deliberately. The two strip lists are deliberately different and deliberately duplicated (`run_button.py` is exec'd standalone inside Nuke and can only import its own bundle siblings); a comment on each explains why.
- **`nuke_nodes/nuke_script_node.py`** — the GUI counterpart. *Open in Nuke* stripped only the Qt vars before `Popen`, so the engine's Python vars still reached Nuke's own interpreter — and here a mismatched-ABI extension takes the whole application down rather than failing one headless job. Extracted `_sanitize_nuke_launch_env(base_env, env_overrides)`, which strips first and applies overrides second, preserving the same ordering guarantee as `direct.py`. The node's headless paths already went through `DirectSubprocessProvider` and were unaffected.

## Prior art

`griptape-nodes-desktop/src/common/config/env.ts` has done exactly this since it shipped ("The bundled Python is hermetic. Host Python env vars … must not leak in"). The gizmo launcher is the same class of process spawn and never got the same treatment. `_LEAKED_PYTHON_VARS` is now a superset of that list, and a unit test asserts the subset relation. To be precise about what that buys: the desktop list is transcribed by hand, so the test catches us *dropping* one of those vars, but it cannot see the desktop app adding one — a real sync check would need a shared constant across a Python library and an Electron app. The test name and docstring say so.

Generalizable rule: any process spawning a hermetic Python must strip host Python env vars. There are four such spawn sites — the desktop app, the gizmo run button, `execution/direct.py` (headless `nuke -t`), and `nuke_script_node.py` (*Open in Nuke*, GUI).

## Tests

- `tests/unit/test_run_button_env.py` — new `TestChildEnvPythonIsolation`: each var stripped, `PYTHONNOUSERSITE` set, the opt-out honored and correctly scoped, falsy opt-out values still strip, `LD_LIBRARY_PATH` left intact, `base_env` not mutated, and the strip list covering at least the desktop app's vars. `test_preserves_all_base_env_keys` was narrowed to `test_preserves_base_env_keys_outside_the_strip_list`, since asserting total pass-through is what this change intentionally breaks.
- `tests/unit/test_direct.py` — the engine's Python vars are absent from the launch env, and a `manifest.env`-supplied `PYTHONPATH` still survives (the ordering guarantee).
- `tests/unit/test_open_in_nuke.py` — new `TestSanitizeNukeLaunchEnv`: Python and Qt vars stripped, unrelated vars (including `foundry_LICENSE` and `LD_LIBRARY_PATH`) preserved, an override-supplied `PYTHONPATH` still winning, and `base_env` not mutated.
- `tests/unit/test_workflow_runner_env.py` — the runner logs its interpreter path and version, logs a leaked `PYTHONPATH`, and reports an unset one as `(empty)` rather than a blank.

`make check` is clean. Unit tests: 351 passed, 1 failed — `test_nuke_gizmo_publisher_lock.py::TestWriteLockfile::test_skips_when_uv_absent`, which fails identically on a clean `main` and is unrelated to this change.

Not run here (no Nuke installation available): `tests/integration/`, and an end-to-end check in a wrapper-launched Nuke confirming the dialog reports a 3.12 interpreter under the per-machine venv with an empty `PYTHONPATH`.

## Deployment note

The fix ships inside the companion bundle, so **existing gizmos must be re-published** to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

