### PR TITLE
fix(gizmo): absolutize the install path and bake set values into knobs

### DIFF
--- a/publish_gizmo/nuke_gizmo_builder.py
+++ b/publish_gizmo/nuke_gizmo_builder.py
@@ -151,6 +151,66 @@ def _label(name: str) -> str:
     return name.replace("_", " ").title()
 
 
+def _as_bool(value: object) -> bool | None:
+    """Coerce a knob default to bool, or None when there is no value to write.
+
+    None is the signal to omit the value line entirely, which leaves the knob at
+    Nuke's own initial value. Dynamically added parameters carry "" rather than
+    None, so an empty string must read as absent too.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "1", "yes", "on"):
+            return True
+        if lowered in ("false", "0", "no", "off"):
+            return False
+    return None
+
+
+def _as_int(value: object) -> int | None:
+    """Coerce a knob default to int, or None when there is no usable value."""
+    # bool is an int subclass, but a checkbox value on an int knob is a type
+    # mismatch rather than a 0/1 the user chose, so leave the knob alone.
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        return int(value)  # type: ignore[call-overload]
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_text(value: object) -> str | None:
+    """Coerce a knob default to text, or None when there is no usable value.
+
+    Only scalars are accepted. An artifact or container would stringify to a Python
+    repr, which is worse in the knob than leaving it empty — and the writer's TCL
+    escaping requires a str.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (bool, int, float)):
+        return str(value)
+    return None
+
+
+def _as_float(value: object) -> float | None:
+    """Coerce a knob default to float, or None when there is no usable value."""
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
 def _build_knob_changed_code() -> str:
     """Return Python code for the gizmo's knobChanged callback.
 
@@ -449,19 +509,19 @@ class NukeGizmoBuilder:
             default_index = choices.index(default) if default and default in choices else None
             w.add_enumeration_knob(knob_name, label, choices, default_index=default_index)
         elif param_type in _FILE_PATH_TYPES:
-            w.add_file_knob(knob_name, label, default=default or None, tooltip=_TCL_HINT_TOOLTIP)
+            w.add_file_knob(knob_name, label, default=_as_text(default), tooltip=_TCL_HINT_TOOLTIP)
             self._write_link_button(w, knob_name)
         elif param_type == "bool":
-            w.add_bool_knob(knob_name, label, default=default if type(default) is bool else None)
+            w.add_bool_knob(knob_name, label, default=_as_bool(default))
         elif param_type == "float":
-            w.add_double_knob(knob_name, label, default=default if type(default) is float else None)
+            w.add_double_knob(knob_name, label, default=_as_float(default))
         elif param_type == "int":
-            w.add_int_knob(knob_name, label, default=default if type(default) is int else None)
+            w.add_int_knob(knob_name, label, default=_as_int(default))
         elif param_type in _MULTILINE_TYPES:
-            w.add_multiline_string_knob(knob_name, label, default=default or None, tooltip=_TCL_HINT_TOOLTIP)
+            w.add_multiline_string_knob(knob_name, label, default=_as_text(default), tooltip=_TCL_HINT_TOOLTIP)
             self._write_link_button(w, knob_name)
         else:
-            w.add_string_knob(knob_name, label, default=default or None, tooltip=_TCL_HINT_TOOLTIP)
+            w.add_string_knob(knob_name, label, default=_as_text(default), tooltip=_TCL_HINT_TOOLTIP)
             self._write_link_button(w, knob_name)
 
     @staticmethod

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -49,6 +49,7 @@ from publish_gizmo.constants import (
 )
 from publish_gizmo.nuke_discovery import GIZMO_INSTALL_CUSTOM
 from publish_gizmo.nuke_gizmo_builder import NukeGizmoBuilder
+from publish_gizmo.output_paths import absolutize
 
 if TYPE_CHECKING:
     from griptape_nodes.node_library.workflow_registry import Workflow
@@ -72,6 +73,7 @@ class NukeGizmoPublisher:
 
             self._packager.emit_progress(5.0, "Extracting workflow shape...")
             workflow_shape = GriptapeNodes.WorkflowManager().extract_workflow_shape(self._workflow_name)
+            self._overlay_current_values(workflow_shape)
             logger.info("Workflow shape: %s", workflow_shape)
 
             self._packager.emit_progress(5.0, "Saving workflow...")
@@ -152,6 +154,37 @@ class NukeGizmoPublisher:
         except Exception as e:
             logger.exception("Failed to publish workflow '%s'", self._workflow_name)
             return PublishWorkflowResultFailure(result_details=f"Failed to publish workflow: {e}")
+
+    @staticmethod
+    def _overlay_current_values(workflow_shape: dict) -> None:
+        """Replace declared defaults in *workflow_shape* with the values set on the canvas.
+
+        ``extract_workflow_shape`` reports ``Parameter.default_value`` and never consults
+        ``node.parameter_values``. Every NukeStartFlow input is a user-added parameter whose
+        declared default is None, so the value the artist typed lives only in
+        ``parameter_values`` — without this the gizmo's knobs are built with no value line
+        and Nuke initializes them to 0 / empty, which run_button.py then sends back as a
+        real input and writes over the value the bundled workflow saved correctly.
+
+        A path baked from this machine may not resolve on the machine that runs the gizmo;
+        the per-knob Link button is how an artist repoints one.
+        """
+        node_manager = GriptapeNodes.NodeManager()
+        for node_name, params in workflow_shape.get("input", {}).items():
+            try:
+                node = node_manager.get_node_by_name(node_name)
+            except Exception:  # noqa: BLE001
+                logger.debug("Could not resolve node '%s' for value overlay; keeping declared defaults", node_name)
+                continue
+            for param_name, info in params.items():
+                # Only params the artist actually set; an untouched one keeps its
+                # declared default, which is already right.
+                if param_name not in node.parameter_values:
+                    continue
+                try:
+                    info["default_value"] = node.get_parameter_value(param_name)
+                except Exception:  # noqa: BLE001
+                    logger.debug("Could not read '%s.%s' for value overlay", node_name, param_name)
 
     # -- Bundle assembly --
 
@@ -370,17 +403,43 @@ class NukeGizmoPublisher:
         if self._get_nuke_start_flow_node() is None:
             errors.append(ValueError("No NukeStartFlow node found in the workflow."))
             return errors
-        if self._resolve_gizmo_install_path() is None:
+        install_dir = self._resolve_gizmo_install_path()
+        if install_dir is None:
             errors.append(ValueError("Gizmo install path is not configured. Please set it in the publish dialog."))
+        elif not install_dir.is_dir():
+            # Reported with the resolved path so a relative pick that got anchored to the
+            # workspace is visible, and caught here so the publish stops before it writes
+            # a partial bundle to the wrong place.
+            errors.append(
+                ValueError(
+                    f"Gizmo install path '{install_dir}' is not an existing directory. "
+                    "Please choose an existing directory in the publish dialog."
+                )
+            )
         return errors
 
     def _resolve_gizmo_install_path(self) -> Path | None:
+        """Return the install directory as an absolute path, anchoring a relative one to the workspace.
+
+        A relative path cannot survive this publish: the flow resolves paths against
+        three different bases. The event layer anchors a relative path to the workspace
+        on write (WriteFileRequest, MakeDirectoryRequest, ...) but to the engine's
+        current working directory on read (ReadFileRequest bypasses that resolution),
+        and the plain ``pathlib`` calls here use the working directory too. So the
+        bundle gets written under the workspace and read back from somewhere else.
+        The file picker hands back workspace-relative paths, which is how one gets in.
+
+        ``absolutize`` rather than the engine's ``resolve_workspace_path`` because the
+        latter calls ``Path.resolve()`` on absolute paths too. A studio share is
+        routinely reached through a symlink, and resolving it substitutes a
+        host-specific target for the path the publisher actually chose.
+        """
         choice = self._metadata.get("gizmo_install_path")
         if choice == GIZMO_INSTALL_CUSTOM:
             choice = self._metadata.get("custom_gizmo_path")
         if not choice:
             return None
-        return Path(choice)
+        return Path(absolutize(str(choice), str(GriptapeNodes.ConfigManager().workspace_path)))
 
     def _get_nuke_start_flow_node(self):  # noqa: ANN202
         result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
@@ -432,9 +491,14 @@ class NukeGizmoPublisher:
         start_flow = self._get_nuke_start_flow_node()
         if start_flow is None:
             return
+        # Store the resolved custom path so the next publish dialog round-trips an
+        # absolute value instead of the relative one the file picker handed back.
+        custom_path = self._metadata.get("custom_gizmo_path")
+        if custom_path:
+            custom_path = absolutize(str(custom_path), str(GriptapeNodes.ConfigManager().workspace_path))
         start_flow.metadata["publish_config"] = {
             "gizmo_install_path": self._metadata.get("gizmo_install_path"),
-            "custom_gizmo_path": self._metadata.get("custom_gizmo_path"),
+            "custom_gizmo_path": custom_path,
             "gizmo_path": str(gizmo_path),
             "version": version,
         }

--- a/publish_gizmo/nuke_gizmo_publisher.py
+++ b/publish_gizmo/nuke_gizmo_publisher.py
@@ -89,6 +89,10 @@ class NukeGizmoPublisher:
             if install_dir is None:
                 msg = "Gizmo install path is not set."
                 raise ValueError(msg)
+            # Checked before anything writes: the staging mkdir and every WriteFileRequest
+            # create parents, so by the time the publish finishes the directory exists
+            # either way and there is no telling afterwards whether we made it.
+            install_dir_created = not install_dir.exists()
 
             workflow_file_path = Path(WorkflowRegistry.get_complete_file_path(workflow.file_path))
             workflow_stem = workflow_file_path.stem
@@ -138,6 +142,11 @@ class NukeGizmoPublisher:
 
             self._packager.emit_progress(10.0, "Gizmo installed successfully!")
             details = f"Gizmo v{version} installed to: {gizmo_path}"
+            if install_dir_created:
+                # A typo'd or accidentally workspace-relative pick now silently becomes a
+                # real directory; saying so is the only thing standing between that and a
+                # gizmo the artist cannot find.
+                details += f"\n\nNote: the install directory did not exist and was created: {install_dir}"
             if lock_error:
                 # Surface the skipped lock in the publish result, not just the log:
                 # without it the artist running the gizmo is the first to find out.
@@ -406,14 +415,16 @@ class NukeGizmoPublisher:
         install_dir = self._resolve_gizmo_install_path()
         if install_dir is None:
             errors.append(ValueError("Gizmo install path is not configured. Please set it in the publish dialog."))
-        elif not install_dir.is_dir():
-            # Reported with the resolved path so a relative pick that got anchored to the
-            # workspace is visible, and caught here so the publish stops before it writes
-            # a partial bundle to the wrong place.
+        elif install_dir.exists() and not install_dir.is_dir():
+            # A directory that does not exist yet is fine -- the publish creates it, which
+            # is how first-time config of a machine with no ~/.nuke works. Only something
+            # already occupying the path is fatal, and it is caught here so the publish
+            # stops before it writes a partial bundle. Reported with the resolved path so
+            # a relative pick that got anchored to the workspace is visible.
             errors.append(
                 ValueError(
-                    f"Gizmo install path '{install_dir}' is not an existing directory. "
-                    "Please choose an existing directory in the publish dialog."
+                    f"Gizmo install path '{install_dir}' exists but is not a directory. "
+                    "Please choose a directory in the publish dialog."
                 )
             )
         return errors
@@ -421,13 +432,13 @@ class NukeGizmoPublisher:
     def _resolve_gizmo_install_path(self) -> Path | None:
         """Return the install directory as an absolute path, anchoring a relative one to the workspace.
 
-        A relative path cannot survive this publish: the flow resolves paths against
-        three different bases. The event layer anchors a relative path to the workspace
-        on write (WriteFileRequest, MakeDirectoryRequest, ...) but to the engine's
-        current working directory on read (ReadFileRequest bypasses that resolution),
-        and the plain ``pathlib`` calls here use the working directory too. So the
-        bundle gets written under the workspace and read back from somewhere else.
-        The file picker hands back workspace-relative paths, which is how one gets in.
+        A relative path cannot survive this publish, because one value gets resolved
+        against different bases depending on which layer touches it: the engine's event
+        layer anchors relative paths to the workspace, while the plain ``pathlib`` calls
+        here anchor them to the engine's working directory. Which requests do which has
+        varied across engine releases, and a re-publish to a workspace-relative path
+        fails even on an engine that anchors both reads and writes. Anchoring once, here,
+        makes the publish independent of all of that.
 
         ``absolutize`` rather than the engine's ``resolve_workspace_path`` because the
         latter calls ``Path.resolve()`` on absolute paths too. A studio share is

--- a/publish_gizmo/nuke_publish_options.py
+++ b/publish_gizmo/nuke_publish_options.py
@@ -72,8 +72,9 @@ def get_nuke_publish_options(request: GetPublishOptionsRequest) -> GetPublishOpt
         selected_gizmo = default_gizmo_path(gizmo_choices)
 
     # Absolutized like the dropdown selection above, but anchored to the workspace rather
-    # than via normalize_path_str: the file picker returns workspace-relative paths, and
-    # normalize_path_str would resolve those against the engine's working directory.
+    # than via normalize_path_str, which would resolve a relative saved value against the
+    # engine's working directory. Matches _resolve_gizmo_install_path so the dialog shows
+    # the path the publish will actually use.
     saved_custom = current.get("custom_gizmo_path")
     custom_gizmo_default = (
         absolutize(str(saved_custom), str(GriptapeNodes.ConfigManager().workspace_path))

--- a/publish_gizmo/nuke_publish_options.py
+++ b/publish_gizmo/nuke_publish_options.py
@@ -25,6 +25,7 @@ from publish_gizmo.nuke_discovery import (
     default_gizmo_path,
     normalize_path_str,
 )
+from publish_gizmo.output_paths import absolutize
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,15 @@ def get_nuke_publish_options(request: GetPublishOptionsRequest) -> GetPublishOpt
     else:
         selected_gizmo = default_gizmo_path(gizmo_choices)
 
-    custom_gizmo_default = current.get("custom_gizmo_path", str(Path.home() / ".nuke"))
+    # Absolutized like the dropdown selection above, but anchored to the workspace rather
+    # than via normalize_path_str: the file picker returns workspace-relative paths, and
+    # normalize_path_str would resolve those against the engine's working directory.
+    saved_custom = current.get("custom_gizmo_path")
+    custom_gizmo_default = (
+        absolutize(str(saved_custom), str(GriptapeNodes.ConfigManager().workspace_path))
+        if saved_custom
+        else str(Path.home() / ".nuke")
+    )
     custom_hidden = selected_gizmo != GIZMO_INSTALL_CUSTOM
 
     is_update = bool(current.get("gizmo_path") and current.get("version") is not None)

--- a/tests/unit/test_nuke_gizmo_builder.py
+++ b/tests/unit/test_nuke_gizmo_builder.py
@@ -98,6 +98,65 @@ class TestValidDefaultsArePreserved:
         assert any('prompt "hello"' in line for line in lines)
 
 
+class TestCrossTypedDefaultsAreCoerced:
+    """A value carried over from the canvas may not match the param's declared type.
+
+    Emitting nothing leaves Nuke to initialize the knob to 0, which run_button then
+    sends back as a real input.
+    """
+
+    def test_int_param_with_string_default_emits_value(self) -> None:
+        gizmo = _generate_gizmo({"seed": {"type": "int", "default_value": "42"}})
+        assert any(line.strip() == "seed 42" for line in gizmo.splitlines())
+
+    def test_float_param_with_int_default_emits_value(self) -> None:
+        gizmo = _generate_gizmo({"scale": {"type": "float", "default_value": 5}})
+        assert any(line.strip() == "scale 5.0" for line in gizmo.splitlines())
+
+    def test_int_param_with_float_default_truncates(self) -> None:
+        gizmo = _generate_gizmo({"count": {"type": "int", "default_value": 2.7}})
+        assert any(line.strip() == "count 2" for line in gizmo.splitlines())
+
+    def test_bool_param_with_string_default_emits_value(self) -> None:
+        gizmo = _generate_gizmo({"enabled": {"type": "bool", "default_value": "true"}})
+        assert any(line.strip() == "enabled 1" for line in gizmo.splitlines())
+
+    def test_int_param_with_bool_default_omits_value(self) -> None:
+        # A checkbox value on an int knob is a type mismatch, not a 0/1 the user chose.
+        gizmo = _generate_gizmo({"count": {"type": "int", "default_value": True}})
+        assert [line for line in gizmo.splitlines() if line.strip().startswith("count ")] == []
+
+    def test_int_param_with_unparseable_default_omits_value(self) -> None:
+        gizmo = _generate_gizmo({"count": {"type": "int", "default_value": "abc"}})
+        assert [line for line in gizmo.splitlines() if line.strip().startswith("count ")] == []
+
+    def test_zero_is_emitted_not_treated_as_absent(self) -> None:
+        gizmo = _generate_gizmo({"seed": {"type": "int", "default_value": 0}})
+        assert any(line.strip() == "seed 0" for line in gizmo.splitlines())
+
+    def test_string_param_with_int_default_emits_text(self) -> None:
+        gizmo = _generate_gizmo({"label": {"type": "str", "default_value": 7}})
+        assert any('label "7"' in line for line in gizmo.splitlines())
+
+    def test_string_param_with_object_default_omits_value(self) -> None:
+        # An artifact would stringify to a Python repr, and the writer's TCL escaping
+        # needs a str at all.
+        gizmo = _generate_gizmo({"image": {"type": "str", "default_value": {"a": 1}}})
+        assert [line for line in gizmo.splitlines() if line.strip().startswith('image "')] == []
+
+    def test_dropdown_uses_selected_value_index(self) -> None:
+        gizmo = _generate_gizmo(
+            {
+                "mode": {
+                    "type": "str",
+                    "default_value": "fast",
+                    "ui_options": {"simple_dropdown": ["slow", "fast"]},
+                }
+            }
+        )
+        assert any(line.strip() == "mode 1" for line in gizmo.splitlines())
+
+
 class TestNoneDefaultOmitsValueLine:
     """None default_value must not emit a value line for any type."""
 
@@ -124,15 +183,15 @@ class TestMismatchedDefaultTypeIgnored:
         value_lines = [line for line in lines if line.strip().startswith("scale ")]
         assert value_lines == []
 
-    def test_string_default_for_bool_param_ignored(self) -> None:
-        gizmo = _generate_gizmo({"flag": {"type": "bool", "default_value": "yes"}})
+    def test_unrecognized_string_default_for_bool_param_ignored(self) -> None:
+        gizmo = _generate_gizmo({"flag": {"type": "bool", "default_value": "maybe"}})
         lines = gizmo.splitlines()
         value_lines = [line for line in lines if line.strip().startswith("flag ")]
         assert value_lines == []
 
 
-class TestSubclassDefaultsRejectedByStrictTypeCheck:
-    """type(x) is T rejects subclass matches that isinstance would accept."""
+class TestBoolDefaultsRejectedForNumericParams:
+    """A checkbox value on a numeric knob is a type mismatch, not a 0/1 the user chose."""
 
     def test_bool_default_rejected_for_int_param(self) -> None:
         gizmo = _generate_gizmo({"count": {"type": "int", "default_value": True}})
@@ -142,12 +201,6 @@ class TestSubclassDefaultsRejectedByStrictTypeCheck:
 
     def test_bool_default_rejected_for_float_param(self) -> None:
         gizmo = _generate_gizmo({"scale": {"type": "float", "default_value": False}})
-        lines = gizmo.splitlines()
-        value_lines = [line for line in lines if line.strip().startswith("scale ")]
-        assert value_lines == []
-
-    def test_int_default_rejected_for_float_param(self) -> None:
-        gizmo = _generate_gizmo({"scale": {"type": "float", "default_value": 3}})
         lines = gizmo.splitlines()
         value_lines = [line for line in lines if line.strip().startswith("scale ")]
         assert value_lines == []

--- a/tests/unit/test_nuke_gizmo_publisher_paths.py
+++ b/tests/unit/test_nuke_gizmo_publisher_paths.py
@@ -1,0 +1,120 @@
+"""Tests that the gizmo install path is absolute by the time the publish uses it.
+
+A relative install dir cannot survive the publish: the event layer anchors a relative
+path to the workspace on write but to the engine's working directory on read, and the
+publisher's plain ``pathlib`` calls use the working directory too. The file picker
+returns workspace-relative paths, so the publisher must anchor them itself.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from publish_gizmo.nuke_discovery import GIZMO_INSTALL_CUSTOM
+from publish_gizmo.nuke_gizmo_publisher import NukeGizmoPublisher
+
+WORKSPACE = "/home/user/workspace"
+
+
+def _publisher(metadata: dict) -> NukeGizmoPublisher:
+    with mock.patch("publish_gizmo.nuke_gizmo_publisher.WorkflowPackager"):
+        return NukeGizmoPublisher(workflow_name="wf", metadata=metadata)
+
+
+def _resolve(metadata: dict, workspace: str = WORKSPACE) -> Path | None:
+    publisher = _publisher(metadata)
+    with mock.patch("publish_gizmo.nuke_gizmo_publisher.GriptapeNodes") as griptape_nodes:
+        griptape_nodes.ConfigManager.return_value.workspace_path = Path(workspace)
+        return publisher._resolve_gizmo_install_path()  # noqa: SLF001
+
+
+def _custom(path: str) -> dict:
+    return {"gizmo_install_path": GIZMO_INSTALL_CUSTOM, "custom_gizmo_path": path}
+
+
+class TestResolveGizmoInstallPath:
+    def test_relative_custom_path_is_anchored_to_the_workspace(self) -> None:
+        assert _resolve(_custom("gizmos/nuke")) == Path(f"{WORKSPACE}/gizmos/nuke")
+
+    def test_absolute_custom_path_is_unchanged(self) -> None:
+        assert _resolve(_custom("/opt/studio/gizmos")) == Path("/opt/studio/gizmos")
+
+    def test_tilde_is_expanded(self) -> None:
+        assert _resolve(_custom("~/.nuke")) == Path.home() / ".nuke"
+
+    def test_dropdown_selection_is_also_absolutized(self) -> None:
+        assert _resolve({"gizmo_install_path": "dotnuke"}) == Path(f"{WORKSPACE}/dotnuke")
+
+    def test_missing_path_returns_none(self) -> None:
+        assert _resolve({"gizmo_install_path": GIZMO_INSTALL_CUSTOM, "custom_gizmo_path": ""}) is None
+        assert _resolve({}) is None
+
+    def test_redundant_separators_are_normalized(self) -> None:
+        assert _resolve(_custom("/opt//studio/./gizmos")) == Path("/opt/studio/gizmos")
+
+    def test_share_path_is_not_symlink_resolved(self, tmp_path) -> None:
+        """A studio share is routinely reached through a symlink whose target differs per host.
+
+        Resolving it would put a host-specific path into pluginAddPath and the
+        reported gizmo path.
+        """
+        target = tmp_path / "net" / "fileserver" / "studio"
+        target.mkdir(parents=True)
+        link = tmp_path / "mnt_studio"
+        link.symlink_to(target)
+
+        assert _resolve(_custom(str(link))) == link
+
+    @pytest.mark.skipif(os.name != "nt", reason="drive-letter paths are only absolute on Windows")
+    def test_windows_share_path_is_unchanged(self) -> None:
+        assert str(_resolve(_custom("Z:/gizmos"))) == "Z:/gizmos"
+
+
+class TestValidateInstallPath:
+    def _validate(self, metadata: dict) -> list[Exception]:
+        publisher = _publisher(metadata)
+        with (
+            mock.patch.object(publisher, "_get_nuke_start_flow_node", return_value=mock.Mock()),
+            mock.patch("publish_gizmo.nuke_gizmo_publisher.GriptapeNodes") as griptape_nodes,
+        ):
+            griptape_nodes.ConfigManager.return_value.workspace_path = Path(WORKSPACE)
+            return publisher._validate()  # noqa: SLF001
+
+    def test_missing_directory_is_reported_with_the_resolved_path(self) -> None:
+        errors = self._validate(_custom("gizmos/nuke"))
+        assert len(errors) == 1
+        assert f"{WORKSPACE}/gizmos/nuke" in str(errors[0])
+
+    def test_unconfigured_path_is_reported(self) -> None:
+        errors = self._validate({})
+        assert len(errors) == 1
+        assert "not configured" in str(errors[0])
+
+    def test_existing_directory_passes(self, tmp_path) -> None:
+        assert self._validate(_custom(str(tmp_path))) == []
+
+    def test_file_instead_of_directory_is_rejected(self, tmp_path) -> None:
+        target = tmp_path / "not_a_dir"
+        target.write_text("")
+        errors = self._validate(_custom(str(target)))
+        assert len(errors) == 1
+
+
+class TestSavePublishConfig:
+    def test_resolved_custom_path_is_stored(self) -> None:
+        """The dialog re-reads this value, so storing the relative one reintroduces the bug."""
+        publisher = _publisher(_custom("gizmos/nuke"))
+        start_flow = mock.Mock()
+        start_flow.metadata = {}
+        with (
+            mock.patch.object(publisher, "_get_nuke_start_flow_node", return_value=start_flow),
+            mock.patch("publish_gizmo.nuke_gizmo_publisher.GriptapeNodes") as griptape_nodes,
+        ):
+            griptape_nodes.ConfigManager.return_value.workspace_path = Path(WORKSPACE)
+            publisher._save_publish_config(Path("/opt/studio/gizmos/wf_v1.gizmo"), 1)  # noqa: SLF001
+
+        assert start_flow.metadata["publish_config"]["custom_gizmo_path"] == f"{WORKSPACE}/gizmos/nuke"

--- a/tests/unit/test_nuke_gizmo_publisher_paths.py
+++ b/tests/unit/test_nuke_gizmo_publisher_paths.py
@@ -1,9 +1,9 @@
 """Tests that the gizmo install path is absolute by the time the publish uses it.
 
-A relative install dir cannot survive the publish: the event layer anchors a relative
-path to the workspace on write but to the engine's working directory on read, and the
-publisher's plain ``pathlib`` calls use the working directory too. The file picker
-returns workspace-relative paths, so the publisher must anchor them itself.
+A relative install dir cannot survive the publish: one value gets resolved against
+different bases depending on which layer touches it -- the engine's event layer anchors
+to the workspace, the publisher's plain ``pathlib`` calls to the engine's working
+directory -- so the publisher anchors it once itself.
 """
 
 from __future__ import annotations
@@ -84,10 +84,9 @@ class TestValidateInstallPath:
             griptape_nodes.ConfigManager.return_value.workspace_path = Path(WORKSPACE)
             return publisher._validate()  # noqa: SLF001
 
-    def test_missing_directory_is_reported_with_the_resolved_path(self) -> None:
-        errors = self._validate(_custom("gizmos/nuke"))
-        assert len(errors) == 1
-        assert f"{WORKSPACE}/gizmos/nuke" in str(errors[0])
+    def test_missing_directory_passes_because_the_publish_creates_it(self) -> None:
+        """First-time config of a machine has no ~/.nuke yet, and that has to publish."""
+        assert self._validate(_custom("gizmos/nuke")) == []
 
     def test_unconfigured_path_is_reported(self) -> None:
         errors = self._validate({})
@@ -98,10 +97,12 @@ class TestValidateInstallPath:
         assert self._validate(_custom(str(tmp_path))) == []
 
     def test_file_instead_of_directory_is_rejected(self, tmp_path) -> None:
+        """Named with the resolved path, so an accidentally workspace-relative pick is visible."""
         target = tmp_path / "not_a_dir"
         target.write_text("")
         errors = self._validate(_custom(str(target)))
         assert len(errors) == 1
+        assert str(target) in str(errors[0])
 
 
 class TestSavePublishConfig:

--- a/tests/unit/test_nuke_gizmo_publisher_values.py
+++ b/tests/unit/test_nuke_gizmo_publisher_values.py
@@ -1,0 +1,72 @@
+"""Tests that values set on the canvas reach the gizmo's knobs.
+
+``extract_workflow_shape`` reports declared defaults only. Every NukeStartFlow input is
+user-added with a declared default of None, so without this overlay the gizmo's knobs are
+written with no value line and Nuke initializes them to 0 / empty.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from publish_gizmo.nuke_gizmo_publisher import NukeGizmoPublisher
+
+
+def _overlay(shape: dict, node: mock.Mock) -> dict:
+    with mock.patch("publish_gizmo.nuke_gizmo_publisher.GriptapeNodes") as griptape_nodes:
+        griptape_nodes.NodeManager.return_value.get_node_by_name.return_value = node
+        NukeGizmoPublisher._overlay_current_values(shape)  # noqa: SLF001
+    return shape
+
+
+def _shape(params: dict) -> dict:
+    return {"input": {"Nuke Start Flow": params}, "output": {"Nuke End Flow": {}}}
+
+
+def _node(parameter_values: dict) -> mock.Mock:
+    node = mock.Mock()
+    node.parameter_values = parameter_values
+    node.get_parameter_value.side_effect = parameter_values.get
+    return node
+
+
+class TestOverlayCurrentValues:
+    def test_set_value_replaces_the_declared_default(self) -> None:
+        shape = _overlay(
+            _shape({"seed": {"type": "int", "default_value": None}}),
+            _node({"seed": 42}),
+        )
+        assert shape["input"]["Nuke Start Flow"]["seed"]["default_value"] == 42
+
+    def test_unset_param_keeps_its_declared_default(self) -> None:
+        shape = _overlay(
+            _shape({"seed": {"type": "int", "default_value": 7}}),
+            _node({}),
+        )
+        assert shape["input"]["Nuke Start Flow"]["seed"]["default_value"] == 7
+
+    def test_falsy_set_value_is_still_applied(self) -> None:
+        shape = _overlay(
+            _shape({"enabled": {"type": "bool", "default_value": True}}),
+            _node({"enabled": False}),
+        )
+        assert shape["input"]["Nuke Start Flow"]["enabled"]["default_value"] is False
+
+    def test_lookup_failure_leaves_the_declared_default(self) -> None:
+        """Value introspection is best-effort; it must never fail a publish."""
+        node = _node({"seed": 42})
+        node.get_parameter_value.side_effect = RuntimeError("boom")
+        shape = _overlay(_shape({"seed": {"type": "int", "default_value": 7}}), node)
+        assert shape["input"]["Nuke Start Flow"]["seed"]["default_value"] == 7
+
+    def test_missing_node_leaves_the_shape_untouched(self) -> None:
+        shape = _shape({"seed": {"type": "int", "default_value": 7}})
+        with mock.patch("publish_gizmo.nuke_gizmo_publisher.GriptapeNodes") as griptape_nodes:
+            griptape_nodes.NodeManager.return_value.get_node_by_name.side_effect = KeyError("gone")
+            NukeGizmoPublisher._overlay_current_values(shape)  # noqa: SLF001
+        assert shape["input"]["Nuke Start Flow"]["seed"]["default_value"] == 7
+
+    def test_shape_without_inputs_is_tolerated(self) -> None:
+        shape = {"output": {}}
+        _overlay(shape, _node({}))
+        assert shape == {"output": {}}

--- a/tests/unit/test_nuke_publish_options.py
+++ b/tests/unit/test_nuke_publish_options.py
@@ -72,3 +72,15 @@ class TestGetNukePublishOptions:
         assert "update_mode" in names
         gizmo_field = next(f for f in result.fields if f.name == "gizmo_install_path")
         assert gizmo_field.default_value == normalize_path_str(str(Path.home() / ".nuke"))
+
+    def test_saved_relative_custom_path_is_shown_absolute(self, _mock_find, monkeypatch) -> None:
+        """Anchored to the workspace, since that is the base the file picker used."""
+        monkeypatch.delenv("NUKE_PATH", raising=False)
+        with patch("publish_gizmo.nuke_publish_options.GriptapeNodes") as griptape_nodes:
+            griptape_nodes.ConfigManager.return_value.workspace_path = Path("/home/user/workspace")
+            result = get_nuke_publish_options(
+                _request({"gizmo_install_path": GIZMO_INSTALL_CUSTOM, "custom_gizmo_path": "gizmos/nuke"})
+            )
+
+        custom_field = next(f for f in result.fields if f.name == "custom_gizmo_path")
+        assert custom_field.default_value == "/home/user/workspace/gizmos/nuke"


### PR DESCRIPTION
## Summary

Two independent defects in the gizmo publish path.

### A relative gizmo install path could never work

One relative value gets resolved against different bases depending on which layer touches it: the engine's event layer anchors relative paths to the workspace, while the publisher's own `pathlib` calls anchor them to the engine's working directory. So the bundle could be written under the workspace and read back from somewhere else. Which requests anchor to what has varied across engine releases, and a re-publish to a workspace-relative path fails even on an engine that anchors both reads and writes — so the publisher anchors the path once, itself, and stops depending on any of it.

`_resolve_gizmo_install_path` uses `output_paths.absolutize`, deliberately **not** the engine's `resolve_workspace_path`: the latter calls `Path.resolve()` on absolute paths too, and a share reached through a symlink would get a host-specific target baked into `pluginAddPath` and the reported gizmo path.

`_validate` rejects a path that *exists but is not a directory*, naming the resolved path so an accidentally workspace-relative pick is visible, and stops the publish before it writes a partial bundle. A directory that doesn't exist yet still publishes and is created, as before. When it was created, the publish result says so, so a typo'd path doesn't silently become a real directory. The resolved value is stored in `publish_config`, and the options provider shows a saved relative value as absolute, so the dialog round-trips.

### A value set on the canvas did not reach the gizmo knob

`extract_workflow_shape` reports `Parameter.default_value` only and never consults `node.parameter_values`. Every `NukeStartFlow` input is user-added with a declared default of `None`, so the knob was written with no value line and Nuke initialized it to `0`/empty. `run_button` then collects every declared input knob with no "was it set?" test, so that `0` was sent back as a real workflow input — overwriting the value the bundled workflow had serialized correctly.

- `_overlay_current_values` replaces declared defaults with the effective values before the gizmo is built, best-effort so value introspection can never fail a publish.
- `_write_input_knob`'s strict `type(x) is int` / `is float` identity checks also rejected correct-but-cross-typed values (`"42"`, or an `int` on a float param) and emitted nothing. They're replaced by `_as_bool` / `_as_int` / `_as_float` / `_as_text`, which return `None` (omit the value line) only for `None`, `""` and unparseable input. This is defensive — the GUI type-guards on set, so a mismatch is unlikely.
- `_as_text` guards a newly reachable crash: a non-`str` default now flows to knobs whose TCL escaping requires a `str`.

## Testing

- Unit tests in `test_nuke_gizmo_publisher_paths.py` (resolution, validation, symlink preservation, config round-trip), `test_nuke_gizmo_publisher_values.py` (value overlay), plus knob-writer coverage in `test_nuke_gizmo_builder.py` and dialog coverage in `test_nuke_publish_options.py`.
- `make check` clean.
- Manually verified end-to-end against a real Nuke install: published to a workspace-relative custom directory picked through the file picker, confirmed the bundle landed at the resolved absolute path, the dialog re-opened with an absolute value, a path occupied by a file is rejected before anything is written, a directory that doesn't exist is created and reported, a symlinked target is not resolved, and a value set on the canvas arrives in the gizmo knob and survives a run.

One pre-existing unit failure on `main` is untouched by this branch: `test_nuke_gizmo_publisher_lock.py::TestWriteLockfile::test_skips_when_uv_absent` leaks the real `shutil.which` and fails on any machine with `uv` installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
