### PR TITLE
feat(host-api): split loading out of execute into NukeLoadWorkflowRequest

### DIFF
--- a/nuke_host_api/INTEGRATION.md
+++ b/nuke_host_api/INTEGRATION.md
@@ -678,11 +678,17 @@ Check `rejected_inputs` on every execution. A rejection does not fail the execut
 workflow executes with whatever value was already present and returns plausible output
 computed from the wrong input. Surface rejections immediately.
 
-Two kinds land in `rejected_inputs`. A pair that is not a declared input parameter is rejected
-with `"Not a declared input parameter of this workflow."` and never reaches the engine; address
-inputs only by the `node` and `parameter` `NukeDescribeWorkflowRequest` or
-`NukeLoadWorkflowRequest` returned. A declared pair the engine itself refused carries the
-engine's own reason instead, and was already forwarded when it was refused.
+Two kinds are turned away before the engine sees them, and both are the host's own to fix. A
+`node` whose value is not an object of parameters is rejected with
+`"Expected an object of parameters."` and `parameter` set to `"*"`, since no single parameter
+was named; do not look `"*"` up in what describe returned. A pair that is not a declared input
+parameter is rejected with `"Not a declared input parameter of this workflow."`; address inputs
+only by the `node` and `parameter` `NukeDescribeWorkflowRequest` or `NukeLoadWorkflowRequest`
+returned.
+
+Any other reason is the engine's own, on a declared pair that was already forwarded when it was
+refused. Split on that rather than on counting kinds: a reason the host did not write above is
+the engine's.
 
 Sending inputs to a loaded graph that declares no input parameters is refused instead, rather
 than rejecting every one of them. The case a host meets is an unsaved graph: with `workflow_id`

--- a/nuke_host_api/INTEGRATION.md
+++ b/nuke_host_api/INTEGRATION.md
@@ -691,6 +691,15 @@ there would hand the host its own parameter names back as if they were wrong, wh
 went ahead on the author's values. The refusal says to save the workflow and load it by id, or
 to send no inputs and run it as it stands.
 
+A registry the engine cannot read gets a separate refusal, naming a retry. It leaves the same
+empty allow-list behind, so the two are easy to conflate, but only one of them is the host's to
+fix: a workflow that declares nothing still will next time, and a host told to save a workflow
+it already saved has been sent down the wrong recovery path. Distinguish them by the reason
+text, or retry once and see whether the refusal changes.
+
+Neither refusal fires when `inputs` is empty. With nothing to check, what the workflow declares
+does not bear on the run, so a graph with no declared shape still executes.
+
 A `workflow_id` naming anything other than the loaded workflow is refused, not loaded.
 Honouring it would make execute destructive; ignoring it would run a workflow the host did not
 ask for while reporting success. The refusal names both ids and says to load first.

--- a/nuke_host_api/INTEGRATION.md
+++ b/nuke_host_api/INTEGRATION.md
@@ -497,7 +497,8 @@ before `NukeExecuteWorkflowRequest`, `NukeGetParameterValuesRequest`, or
 
 **Destructive.** The engine clears all object state to load a graph, so this discards whatever
 was loaded before, including a graph an editor user has open on the same engine. Confirm with
-the artist before sending it.
+the artist before sending it. It clears before it knows the load will succeed, so a failed load
+can leave nothing loaded at all.
 
 | Request field | Type | Default | Notes |
 |---|---|---|---|
@@ -598,7 +599,7 @@ Loading a file the engine has never seen:
 { "file_path": "/shots/sq010/comp_v012.py" }
 ```
 
-Refused, and nothing is loaded or discarded:
+Refused, and nothing is loaded:
 
 | Condition | `because` names |
 |---|---|
@@ -608,9 +609,23 @@ Refused, and nothing is loaded or discarded:
 | The file cannot be imported | the engine's own reason |
 | The id is not registered | that no workflow with that name exists |
 | The registry cannot be read | that the engine could not read it, which is worth retrying |
+| The engine could not load the workflow | the engine's own reason, and that the previous graph is already gone |
 
-Every one of those is decided before the engine's state is touched, so a refused load leaves
-the previous graph exactly as it was.
+Every row but the last is decided before the engine's state is touched, so those refusals leave
+the previous graph exactly as it was. The last one cannot: `run_with_clean_slate` makes the
+engine clear all object state before it builds the graph, so a workflow that fails inside its
+own file, on a missing library or an exception, leaves nothing loaded. That failure alone
+carries `engine_state_cleared: true`.
+
+Branch on `engine_state_cleared`, not on the reason text. When it is `false`, the knobs a host
+is showing still match what the engine holds and a retry is free. When it is `true`, the graph
+the host was driving is gone: drop the knobs, and tell the artist before retrying, because the
+comp they had open went with it.
+
+| `NukeLoadWorkflowResultFailure` field | Type | Notes |
+|---|---|---|
+| `workflow_id` | `str` | The id asked for, or the one resolved from `file_path`. Empty when the request never got far enough to name one |
+| `engine_state_cleared` | `bool` | `true` only when the engine had already discarded the previous graph before it failed |
 
 ### NukeExecuteWorkflowRequest
 
@@ -667,6 +682,14 @@ A pair that is not a declared input parameter is rejected with
 `"Not a declared input parameter of this workflow."` and never reaches the engine. Address
 inputs only by the `node` and `parameter` `NukeDescribeWorkflowRequest` or
 `NukeLoadWorkflowRequest` returned.
+
+Sending inputs to a loaded graph that declares no input parameters is refused instead, rather
+than rejecting every one of them. The case a host meets is an unsaved graph: with `workflow_id`
+empty, execute runs whatever the engine holds, and the graph an editor user is working on lives
+in the engine's registry under an `unsaved:` key with no declared shape. Rejecting each input
+there would hand the host its own parameter names back as if they were wrong, while the run
+went ahead on the author's values. The refusal says to save the workflow and load it by id, or
+to send no inputs and run it as it stands.
 
 A `workflow_id` naming anything other than the loaded workflow is refused, not loaded.
 Honouring it would make execute destructive; ignoring it would run a workflow the host did not

--- a/nuke_host_api/INTEGRATION.md
+++ b/nuke_host_api/INTEGRATION.md
@@ -678,10 +678,11 @@ Check `rejected_inputs` on every execution. A rejection does not fail the execut
 workflow executes with whatever value was already present and returns plausible output
 computed from the wrong input. Surface rejections immediately.
 
-A pair that is not a declared input parameter is rejected with
-`"Not a declared input parameter of this workflow."` and never reaches the engine. Address
+Two kinds land in `rejected_inputs`. A pair that is not a declared input parameter is rejected
+with `"Not a declared input parameter of this workflow."` and never reaches the engine; address
 inputs only by the `node` and `parameter` `NukeDescribeWorkflowRequest` or
-`NukeLoadWorkflowRequest` returned.
+`NukeLoadWorkflowRequest` returned. A declared pair the engine itself refused carries the
+engine's own reason instead, and was already forwarded when it was refused.
 
 Sending inputs to a loaded graph that declares no input parameters is refused instead, rather
 than rejecting every one of them. The case a host meets is an unsaved graph: with `workflow_id`
@@ -691,13 +692,14 @@ there would hand the host its own parameter names back as if they were wrong, wh
 went ahead on the author's values. The refusal says to save the workflow and load it by id, or
 to send no inputs and run it as it stands.
 
-A registry the engine cannot read gets a separate refusal, naming a retry. It leaves the same
-empty allow-list behind, so the two are easy to conflate, but only one of them is the host's to
-fix: a workflow that declares nothing still will next time, and a host told to save a workflow
-it already saved has been sent down the wrong recovery path. Distinguish them by the reason
-text, or retry once and see whether the refusal changes.
+A registry the engine cannot read gets a separate refusal, naming a retry, and so does a loaded
+id that is no longer in the registry at all, naming a reload. All three leave the same empty
+allow-list behind, so they are easy to conflate, but only one of them is the host's to fix by
+saving: a workflow that declares nothing still will next time, while the other two are engine
+state that moved. A host told to save a workflow it already saved has been sent down the wrong
+recovery path.
 
-Neither refusal fires when `inputs` is empty. With nothing to check, what the workflow declares
+None of the three fires when `inputs` is empty. With nothing to check, what the workflow declares
 does not bear on the run, so a graph with no declared shape still executes.
 
 A `workflow_id` naming anything other than the loaded workflow is refused, not loaded.

--- a/nuke_host_api/INTEGRATION.md
+++ b/nuke_host_api/INTEGRATION.md
@@ -28,7 +28,7 @@ has been compiled against this version, so the surface can still change.
 
 | Category | Members |
 |---|---|
-| Verbs | `NukeConnectRequest`, `NukeListWorkflowsRequest`, `NukeDescribeWorkflowRequest`, `NukeExecuteWorkflowRequest`, `NukeGetExecutionStateRequest`, `NukeGetParameterValuesRequest`, `NukeCancelExecutionRequest` |
+| Verbs | `NukeConnectRequest`, `NukeListWorkflowsRequest`, `NukeDescribeWorkflowRequest`, `NukeLoadWorkflowRequest`, `NukeExecuteWorkflowRequest`, `NukeGetExecutionStateRequest`, `NukeGetParameterValuesRequest`, `NukeCancelExecutionRequest` |
 | Notifications | `NukeNodeStateEvent`, `NukeParameterValueEvent`, `NukeExecutionStateEvent` |
 | Value types | `GTImage`, `GTMovie`, `GTFile`, `GTText`, `GTNumber`, `GTBool`, `GTNull` |
 | Source kinds | `path`, `url`, `inline`, `macro` |
@@ -44,6 +44,28 @@ Binding rules:
 | Ignore unknown fields | Fields are added without a version bump; a strict parser breaks on a routine engine upgrade |
 | Ignore unknown enum values, never treat as fatal | New value types and states may appear within a version |
 | Never branch on `engine_version` or `engine_type` | Both are diagnostic only |
+
+### Which verbs need a loaded workflow
+
+`NukeListWorkflowsRequest` and `NukeDescribeWorkflowRequest` read the engine's registry and
+answer for any registered workflow, loaded or not. Everything else answers for the graph the
+engine currently holds and needs `NukeLoadWorkflowRequest` first:
+
+| Verb | Needs a loaded workflow | Takes a `workflow_id` |
+|---|---|---|
+| `NukeConnectRequest` | no | no |
+| `NukeListWorkflowsRequest` | no | no |
+| `NukeDescribeWorkflowRequest` | no | yes, required |
+| `NukeLoadWorkflowRequest` | no, it is what loads one | yes, or a `file_path` |
+| `NukeExecuteWorkflowRequest` | yes | optional, and must match what is loaded |
+| `NukeGetParameterValuesRequest` | yes | no |
+| `NukeGetExecutionStateRequest` | yes | no |
+| `NukeCancelExecutionRequest` | yes | no |
+
+A parameter's live value exists on a loaded node, so no read verb can select one by
+`workflow_id`: for an unloaded workflow there is nothing to read. Loading is the only way to
+make one readable, and it is destructive, so it is a verb of its own rather than something a
+read does on a host's behalf.
 
 ## Connecting
 
@@ -466,19 +488,148 @@ arrives. Never branch on the declared type at runtime.
 Build host knobs from this. Control-flow parameters are already removed, so every listed parameter
 carries data.
 
-### NukeExecuteWorkflowRequest
+### NukeLoadWorkflowRequest
 
-Returns once execution has started. Progress and the terminal state arrive as
-notifications.
+Puts a workflow in the engine and returns everything needed to build and initialize knobs:
+the declared parameters and their current values, for both sides, in one reply. Required
+before `NukeExecuteWorkflowRequest`, `NukeGetParameterValuesRequest`, or
+`NukeGetExecutionStateRequest` can answer for the workflow a host means.
+
+**Destructive.** The engine clears all object state to load a graph, so this discards whatever
+was loaded before, including a graph an editor user has open on the same engine. Confirm with
+the artist before sending it.
 
 | Request field | Type | Default | Notes |
 |---|---|---|---|
-| `workflow_id` | `str` | required | From `NukeListWorkflowsRequest` |
+| `workflow_id` | `str` | `""` | From `NukeListWorkflowsRequest`. Mutually exclusive with `file_path` |
+| `file_path` | `str` | `""` | Absolute path to a workflow file the engine has not registered. Imported, registered, then loaded. Mutually exclusive with `workflow_id` |
+
+Send exactly one. Both is refused rather than resolved, because they can name different
+workflows; neither is refused too.
+
+| `NukeLoadWorkflowResultSuccess` field | Type | Notes |
+|---|---|---|
+| `workflow_id` | `str` | The loaded workflow's id. Resolved from `file_path` when that is what was sent, so this is how a host learns the id to use afterwards |
+| `name` | `str` | Display label |
+| `description` | `str` | |
+| `inputs` | `list[dict]` | Declared start-flow parameter descriptors, identical to `NukeDescribeWorkflowResultSuccess.inputs`. Build knobs from these |
+| `outputs` | `list[dict]` | Declared end-flow parameter descriptors |
+| `input_values` | `dict` | `{node: {parameter: value_descriptor}}`, identical in shape to `NukeGetParameterValuesResultSuccess.inputs`. Initialize knobs to these |
+| `output_values` | `dict` | Same shape, end-flow side. Carries real values for a workflow that has run before, empty descriptors for one that has not |
+| `unavailable` | `list[dict]` | `{section, node, parameter, reason}` for declared parameters the engine would not read. Reported, not omitted |
+
+Four fields rather than two because a parameter's declaration and its current value are
+different questions: the declaration is fixed for the workflow, the value changes on every
+run. Both shapes are ones a host already parses from describe and from the bulk read verb, so
+there is nothing new to write.
+
+**Initialize knobs from `input_values`, not from a descriptor's `default`.** `default` is the
+workflow author's value; `input_values` is what the graph currently holds. They differ for any
+workflow whose inputs have been touched.
+
+```json
+{ "workflow_id": "nuke_api_smoke" }
+```
+
+```json
+{
+  "workflow_id": "nuke_api_smoke",
+  "name": "Nuke API Smoke",
+  "description": "",
+  "inputs": [
+    {
+      "node": "Start Flow",
+      "parameter": "topic",
+      "name": "Start Flow.topic",
+      "type": "GTText",
+      "default": {
+        "value_type": "GTText",
+        "sources": [],
+        "colorspace": null,
+        "engine_type": "str"
+      },
+      "tooltip": "What the shot is about.",
+      "settable": true
+    }
+  ],
+  "outputs": [
+    {
+      "node": "End Flow",
+      "parameter": "was_successful",
+      "name": "End Flow.was_successful",
+      "type": "GTBool",
+      "default": {
+        "value_type": "GTNull",
+        "sources": [],
+        "colorspace": null,
+        "engine_type": "NoneType"
+      },
+      "tooltip": "",
+      "settable": true
+    }
+  ],
+  "input_values": {
+    "Start Flow": {
+      "topic": {
+        "value_type": "GTText",
+        "sources": [],
+        "colorspace": null,
+        "engine_type": "str"
+      }
+    }
+  },
+  "output_values": {
+    "End Flow": {
+      "was_successful": {
+        "value_type": "GTNull",
+        "sources": [],
+        "colorspace": null,
+        "engine_type": "NoneType"
+      }
+    }
+  },
+  "unavailable": []
+}
+```
+
+Loading a file the engine has never seen:
+
+```json
+{ "file_path": "/shots/sq010/comp_v012.py" }
+```
+
+Refused, and nothing is loaded or discarded:
+
+| Condition | `because` names |
+|---|---|
+| Both `workflow_id` and `file_path` | that they may name different workflows |
+| Neither | that there is nothing to load |
+| A run is in progress | that loading discards the running graph, and `NukeCancelExecutionRequest` |
+| The file cannot be imported | the engine's own reason |
+| The id is not registered | that no workflow with that name exists |
+| The registry cannot be read | that the engine could not read it, which is worth retrying |
+
+Every one of those is decided before the engine's state is touched, so a refused load leaves
+the previous graph exactly as it was.
+
+### NukeExecuteWorkflowRequest
+
+Applies inputs to the loaded workflow and starts it. Loads nothing: call
+`NukeLoadWorkflowRequest` first. Returns once execution has started; progress and the terminal
+state arrive as notifications.
+
+| Request field | Type | Default | Notes |
+|---|---|---|---|
+| `workflow_id` | `str` | `""` | Optional. Empty runs whatever is loaded. Set, it must be the loaded workflow or the request is refused |
 | `inputs` | `dict[str, dict[str, Any]]` | `{}` | `{node: {parameter: value}}` keyed by describe's `node` and `parameter`. Plain JSON values |
+
+Send `workflow_id` if the host tracks what it loaded. It costs nothing and turns a graph
+swapped out from under the host, by an editor user or another tool, into a refusal instead of a
+run of the wrong workflow. Leave it empty to drive a graph the host did not load itself.
 
 | `NukeExecuteWorkflowResultSuccess` field | Type | Notes |
 |---|---|---|
-| `workflow_id` | `str` | Echoed |
+| `workflow_id` | `str` | The workflow that ran. Always the loaded one, so a host that sent no id still learns what it started |
 | `state` | `str` | An execution state |
 | `applied_inputs` | `list[dict]` | `{node, parameter}` the engine accepted |
 | `rejected_inputs` | `list[dict]` | `{node, parameter, reason}` |
@@ -514,7 +665,14 @@ computed from the wrong input. Surface rejections immediately.
 
 A pair that is not a declared input parameter is rejected with
 `"Not a declared input parameter of this workflow."` and never reaches the engine. Address
-inputs only by the `node` and `parameter` `NukeDescribeWorkflowRequest` returned.
+inputs only by the `node` and `parameter` `NukeDescribeWorkflowRequest` or
+`NukeLoadWorkflowRequest` returned.
+
+A `workflow_id` naming anything other than the loaded workflow is refused, not loaded.
+Honouring it would make execute destructive; ignoring it would run a workflow the host did not
+ask for while reporting success. The refusal names both ids and says to load first.
+
+Nothing loaded is also a refusal, naming `NukeLoadWorkflowRequest`.
 
 One execution at a time. Starting a run while one is in progress returns
 `NukeExecuteWorkflowResultFailure` rather than displacing it, because the engine threads no
@@ -556,8 +714,12 @@ a host polling only for liveness should not pay for it.
 The bulk value-reading path. Reads every declared start-flow or end-flow parameter's
 current value in one call instead of one `GetParameterValueRequest`-per-parameter round trip a
 host would otherwise have to issue itself. Values exist only for the loaded graph, so this
-takes no `workflow_id`: it always answers for whatever `NukeExecuteWorkflowRequest` most
-recently loaded.
+takes no `workflow_id`: it always answers for whatever `NukeLoadWorkflowRequest` most recently
+loaded.
+
+`NukeLoadWorkflowRequest` already returns these values once. This is the verb for reading them
+again: after a run finishes, or after a reconnect that missed every notification. Both go
+through one reader in the library, so they cannot disagree.
 
 | Request field | Type | Default | Notes |
 |---|---|---|---|

--- a/nuke_host_api/README.md
+++ b/nuke_host_api/README.md
@@ -18,10 +18,12 @@ nuke_host_api/
     __init__.py                      ROUTES: the only verb -> handler binding
     connect.py                       version negotiation, event stream opening
     workflows.py                     list, describe
+    load.py                          load one workflow, describe and read it back
     execution.py                     execute, state, cancel
     values.py                        bulk parameter-value reads, selectable by side
   engine.py                        engine request narrowing and shared queries
   shape.py                         workflow_shape -> host-visible parameters
+  parameter_values.py              reading a loaded workflow's values, shared by load and values
   dispatch.py                      handler calling convention: request guard, failure wording
   library_version.py               the shipped version, read from the manifest
   execution_bridge.py              engine execution events -> host notifications
@@ -32,11 +34,13 @@ tests/unit/
   test_macros.py                   macro resolution, patterns, unresolved tokens
   test_shape.py                    shape parsing, parameter narrowing, runnability
   test_engine.py                   narrowing, event topic, shared queries
+  test_parameter_values.py         section reading, unavailable reporting, control exclusion
   test_dispatch.py                 request guard, failure wording
   test_library_version.py          manifest read and reload reset
   test_handlers_routes.py          every declared verb is routed exactly once
   test_handlers_connect.py         negotiation, event stream gating
   test_handlers_workflows.py       discovery and parameter publication
+  test_handlers_load.py            argument checks, load ordering, read-back
   test_handlers_execution.py       run guards, input allow-list, state, cancel
   test_handlers_values.py          section selection, unavailable reporting, normalization
   test_execution_bridge.py         subscription symmetry, event translation
@@ -56,7 +60,7 @@ make test/unit
 There is no reference client in the repo. `INTEGRATION.md` is the contract; a host is
 verified against a running engine by hand until the plugin exists.
 
-## The five capabilities
+## The capabilities
 
 ### 1. Connect
 
@@ -70,10 +74,51 @@ a host holds the `websocket_direct` URL as its own setting, defaulted to
 `engines.json` is app-layer internal and deliberately not part of what a host reads. See
 `INTEGRATION.md`.
 
-### 2. Execute workflows
+### 2. Load a workflow
+
+Two kinds of verb, and which kind a host is holding decides what it must know.
+
+| Addressed by | Verbs | Answers with |
+|---|---|---|
+| `workflow_id`, from the registry | `NukeListWorkflowsRequest`, `NukeDescribeWorkflowRequest` | what a workflow declares, loaded or not |
+| the engine's loaded graph | `NukeGetParameterValuesRequest`, `NukeGetExecutionStateRequest`, `NukeCancelExecutionRequest`, `NukeExecuteWorkflowRequest` | what the engine currently holds |
+
+`NukeLoadWorkflowRequest` is the only verb that moves a workflow from the first row to the
+second, and the only one that changes what is loaded.
+
+The split is not decorative. A parameter's live value exists on a loaded node, so a verb
+reading one cannot take a `workflow_id` and mean it: for an unloaded workflow there is nothing
+to read, and the only way to make one readable is to load it, which clears all object state.
+A read verb that quietly did that would discard a graph an editor user had open. So loading is
+its own verb, called deliberately, and a host is expected to confirm it with the artist.
+
+Before it existed, loading was a side effect of `NukeExecuteWorkflowRequest`, which left a
+host unable to read or set a parameter's live value without starting a run.
+
+One host verb, up to five engine requests, because the engine has no load-and-describe entry
+point: `ImportWorkflowRequest` registers a file the engine has not seen,
+`RunWorkflowFromRegistryRequest` builds the graph, and values come back one
+`GetParameterValueRequest` at a time.
+
+The reply carries four fields rather than two: `inputs` and `outputs` are exactly
+`describe_workflow`'s parameter lists, and `input_values` and `output_values` are exactly
+`NukeGetParameterValuesRequest`'s maps. No new shape, and no field with two meanings. A
+parameter's declaration and its current value have different lifetimes, so folding a value
+into a descriptor would make `default` and `value` look like variants of one thing.
+
+`workflow_id` or `file_path`, never both, since they can name different workflows and guessing
+is worse than refusing. A `file_path` is imported and registered first, so a host can hand
+over a file an artist picked and learn the resulting id from the reply.
+
+Every check that can happen before the engine is touched happens first, including reading the
+registry to reject an unknown id. Loading is destructive, so a request that cannot succeed
+must leave the previous graph intact.
+
+### 3. Execute workflows
 
 `NukeListWorkflowsRequest` (with `runnable_only`) and `NukeDescribeWorkflowRequest` for
-discovery, then `NukeExecuteWorkflowRequest`, with `NukeGetExecutionStateRequest` and
+discovery, `NukeLoadWorkflowRequest` to put one in the engine, then
+`NukeExecuteWorkflowRequest`, with `NukeGetExecutionStateRequest` and
 `NukeCancelExecutionRequest` against the engine.
 
 No execution identifier, deliberately. The engine threads none through its execution events, so
@@ -83,13 +128,19 @@ drives the engine, including the editor. Adding an id once the engine carries on
 additive change and costs no version bump, so there is no reason to fake one now.
 
 What makes that survivable is refusing to start a second run while one is in progress.
-Without the guard, a host could load a graph over a running one and then be unable to tell
-which run any following notification described, or which one a cancel would stop.
+Without the guard, a host could not tell which run any following notification described, or
+which one a cancel would stop. `NukeLoadWorkflowRequest` refuses mid-run for the same reason
+and a stronger one: it would discard the running graph.
 
-One host verb, three engine requests. The engine has no execute-with-inputs entry point:
-`RunWorkflowFromRegistryRequest` loads the graph, `SetParameterValueRequest` applies
-each input to the loaded start node, and `StartFlowRequest` executes. A host should not
-have to know that sequence, or that it may change.
+One host verb, two engine requests, and neither of them loads. `SetParameterValueRequest`
+applies each input to the loaded start node and `StartFlowRequest` executes, so running a
+workflow does not rebuild the graph whose knobs a host has just been setting.
+
+`workflow_id` is optional. Empty runs whatever is loaded, which is what a host driving a graph
+an editor user opened has to do. Set, it must be the loaded workflow, and a mismatch is
+refused: honouring it would put loading back inside execute, and ignoring it would run a
+workflow the host did not ask for while reporting success. A host that tracks what it loaded
+should send it, because that turns a graph swapped out from under it into a refusal.
 
 `NukeExecuteWorkflowResultSuccess` reports `applied_inputs` and `rejected_inputs`, because a
 silently dropped input is worse than a failed execution: the workflow produces plausible
@@ -102,7 +153,7 @@ alongside its type, because a host builds knobs from this and a knob with no def
 nothing to initialize to. The default is a value descriptor, so a parameter's default and its
 live value are one shape.
 
-### 3. Read every declared parameter value
+### 4. Read every declared parameter value
 
 `NukeGetExecutionStateRequest` answers exactly one question: is the engine running, and
 which nodes are involved. `NukeGetParameterValuesRequest` answers a different one: what does
@@ -121,15 +172,19 @@ Answered by one engine request per declared parameter rather than the engine's o
 `GetAllNodeInfoRequest`, which batches a node's info into one call but keys its parameter
 values by internal element id, hands artifacts back display-serialized into plain dicts
 rather than the instances the normalizer inspects, and drops any parameter whose value is
-`None`. See `handlers/values.py` for the full comparison.
+`None`. See `parameter_values.py` for the full comparison.
 
-### 4. Node execution changes
+The reading itself lives in `parameter_values.py`, shared with `NukeLoadWorkflowRequest`, so
+the values a host is handed at load and the values it reads back later cannot disagree, and
+neither can how an unreadable parameter is reported.
+
+### 5. Node execution changes
 
 Eight engine execution events collapse into four states (`unresolved`, `running`,
 `resolved`, `failed`) delivered as `NukeNodeStateEvent`. The ratio is the point: the
 engine can add a ninth event type without the host learning anything.
 
-### 5. Parameter value changes
+### 6. Parameter value changes
 
 `NukeParameterValueEvent` carries a **normalized descriptor**, not a raw engine value.
 The same normalizer that types parameters in `describe_workflow` shapes every live update, so
@@ -386,17 +441,25 @@ Load-bearing for the design, and documented nowhere obvious.
 - **A host addresses inputs by node name.** Node names are editable in the canvas, so
   renaming a start node breaks a host's saved knob mapping. Re-describing on connect is the
   only mitigation today.
-- **A stuck node locks a host out.** `_flow_is_running` is true while the engine reports any
-  resolving or control node, and execute refuses while it is. A node that never returns, a
-  Nuke subprocess that hangs, leaves that state set and every later execute refused. The
-  escape is `NukeCancelExecutionRequest`, and whether cancel actually clears a node wedged
-  inside `process()` is unverified. If it does not, only an engine restart recovers.
+- **A stuck node locks a host out.** `flow_is_running` is true while the engine reports any
+  resolving or control node, and both execute and load refuse while it is. A node that never
+  returns, a Nuke subprocess that hangs, leaves that state set and every later execute and load
+  refused. The escape is `NukeCancelExecutionRequest`, and whether cancel actually clears a node
+  wedged inside `process()` is unverified. If it does not, only an engine restart recovers.
+- **Loading is destructive and nothing but a host's own UI guards it.**
+  `NukeLoadWorkflowRequest` clears all object state, which discards whatever the engine held,
+  including a graph an editor user has open on the same engine. The engine offers no
+  load-into-a-side-context entry point, so this layer cannot make it non-destructive. A host
+  should confirm with the artist before sending it.
+- **A host cannot set a value without running.** Inputs are applied by
+  `NukeExecuteWorkflowRequest` and nothing else, so a host that wants to stay live with the
+  engine as an artist edits a knob has no verb for it. A bulk `NukeSetParameterValuesRequest`
+  is the missing half of `NukeGetParameterValuesRequest`.
 - **`websocket_direct` ships disabled.** Every machine needs a config edit before a plugin can
   reach an engine. Worth an engine-side default.
-- **`NukeGetParameterValuesRequest` costs one engine request per declared parameter, with no
-  transport-level batching in this layer.** A workflow's declared surface is knobs, not
-  hundreds of them, so the cost has not mattered in practice. If it ever does, the fix is
-  the engine's own `EventRequestBatch` wire envelope (`INTEGRATION.md`, Frame formats),
-  which packs many host verb frames into one WebSocket message; it is a transport
-  optimization a host applies itself, not something this verb's handler can opt into on a
-  host's behalf.
+- **`NukeGetParameterValuesRequest` and `NukeLoadWorkflowRequest` cost one engine request per
+  declared parameter, with no transport-level batching in this layer.** A workflow's declared
+  surface is knobs, not hundreds of them, so the cost has not mattered in practice. If it ever
+  does, the fix is the engine's own `EventRequestBatch` wire envelope (`INTEGRATION.md`, Frame
+  formats), which packs many host verb frames into one WebSocket message; it is a transport
+  optimization a host applies itself, not something a handler can opt into on a host's behalf.

--- a/nuke_host_api/README.md
+++ b/nuke_host_api/README.md
@@ -135,12 +135,15 @@ Without the guard, a host could not tell which run any following notification de
 which one a cancel would stop. `NukeLoadWorkflowRequest` refuses mid-run for the same reason
 and a stronger one: it would discard the running graph.
 
-Six engine requests plus one per applied input, and none of them loads.
-`SetParameterValueRequest` applies each input to the loaded start node and `StartFlowRequest`
-executes, so running a workflow does not rebuild the graph whose knobs a host has just been
-setting. The rest is preflight: what the engine is running, what it has loaded, what that
-workflow declares, and which flow to start. A rejected input costs no request, because it never
-reaches the engine.
+Six engine requests plus one per input forwarded to the engine, and none of them loads.
+`SetParameterValueRequest` applies each declared input to the loaded start node and
+`StartFlowRequest` executes, so running a workflow does not rebuild the graph whose knobs a host
+has just been setting. The rest is preflight: what the engine is running, what it has loaded,
+what that workflow declares, and which flow to start.
+
+A pair outside the allow-list is the only rejection that costs nothing, because it never reaches
+the engine. A declared pair is forwarded before its outcome is known, so an input the engine
+refuses has already cost its request.
 
 `workflow_id` is optional. Empty runs whatever is loaded, which is what a host driving a graph
 an editor user opened has to do. Set, it must be the loaded workflow, and a mismatch is
@@ -161,11 +164,12 @@ under an `unsaved:` key with no declared shape. Rejecting each input there would
 host's own parameter names back at it as if they were wrong, while the run went ahead on the
 author's values.
 
-An unreadable registry produces the same empty allow-list for an unrelated reason, and gets its
-own refusal naming a retry. A workflow that declares nothing will still declare nothing on the
-next call; a registry that would not answer probably will. Telling a host to save a workflow it
-already saved sends it down the wrong recovery path. Neither refusal fires when no inputs were
-sent, because then there is nothing to check against the allow-list.
+An unreadable registry, and an id that has vanished from a readable one, leave the same empty
+allow-list for unrelated reasons, and each gets a refusal of its own: retry the registry, or
+load the workflow again. A workflow that declares nothing will still declare nothing on the
+next call; the other two are not the host's doing. Telling a host to save a workflow it already
+saved sends it down the wrong recovery path. None of the three fires when no inputs were sent,
+because then there is nothing to check against the allow-list.
 
 `NukeDescribeWorkflowRequest` carries each parameter's `default`, `tooltip`, and `settable`
 alongside its type, because a host builds knobs from this and a knob with no default has

--- a/nuke_host_api/README.md
+++ b/nuke_host_api/README.md
@@ -95,9 +95,9 @@ its own verb, called deliberately, and a host is expected to confirm it with the
 Before it existed, loading was a side effect of `NukeExecuteWorkflowRequest`, which left a
 host unable to read or set a parameter's live value without starting a run.
 
-One host verb, up to five engine requests, because the engine has no load-and-describe entry
-point: `ImportWorkflowRequest` registers a file the engine has not seen,
-`RunWorkflowFromRegistryRequest` builds the graph, and values come back one
+One host verb, four engine requests plus one per declared parameter, because the engine has no
+load-and-describe entry point: `ImportWorkflowRequest` registers a file the engine has not seen
+and costs one more, `RunWorkflowFromRegistryRequest` builds the graph, and values come back one
 `GetParameterValueRequest` at a time.
 
 The reply carries four fields rather than two: `inputs` and `outputs` are exactly
@@ -110,9 +110,12 @@ into a descriptor would make `default` and `value` look like variants of one thi
 is worse than refusing. A `file_path` is imported and registered first, so a host can hand
 over a file an artist picked and learn the resulting id from the reply.
 
-Every check that can happen before the engine is touched happens first, including reading the
-registry to reject an unknown id. Loading is destructive, so a request that cannot succeed
-must leave the previous graph intact.
+Every check this verb makes itself happens before the engine is touched, including reading the
+registry to reject an unknown id, so a request refused on its own arguments leaves the previous
+graph intact. The engine's own load is not atomic and cannot offer that: `run_with_clean_slate`
+clears all object state before the graph is built, so a workflow that fails inside its own file
+leaves nothing loaded. That failure reports `engine_state_cleared`, and a host must drop the
+knobs it was showing when it sees it.
 
 ### 3. Execute workflows
 
@@ -147,6 +150,13 @@ silently dropped input is worse than a failed execution: the workflow produces p
 output from the wrong values. Inputs are checked against the parameters `describe_workflow`
 declared before they reach the engine, which would otherwise set a parameter on any node in
 the loaded graph for a caller this transport never authenticated.
+
+By the same rule, inputs sent to a loaded graph that declares no input parameters are refused
+rather than rejected one by one. `workflow_id` empty is how a host drives a graph it did not
+load, and the engine keeps the unsaved graph an editor user is working on in its registry
+under an `unsaved:` key with no declared shape. Rejecting each input there would report the
+host's own parameter names back at it as if they were wrong, while the run went ahead on the
+author's values.
 
 `NukeDescribeWorkflowRequest` carries each parameter's `default`, `tooltip`, and `settable`
 alongside its type, because a host builds knobs from this and a knob with no default has

--- a/nuke_host_api/README.md
+++ b/nuke_host_api/README.md
@@ -141,9 +141,10 @@ Six engine requests plus one per input forwarded to the engine, and none of them
 has just been setting. The rest is preflight: what the engine is running, what it has loaded,
 what that workflow declares, and which flow to start.
 
-A pair outside the allow-list is the only rejection that costs nothing, because it never reaches
-the engine. A declared pair is forwarded before its outcome is known, so an input the engine
-refuses has already cost its request.
+Only a forwarded input can be rejected by the engine. A malformed node and a pair outside the
+allow-list are both turned away before any request, so they cost nothing; a declared pair is
+forwarded before its outcome is known, so an input the engine refuses has already cost its
+request.
 
 `workflow_id` is optional. Empty runs whatever is loaded, which is what a host driving a graph
 an editor user opened has to do. Set, it must be the loaded workflow, and a mismatch is

--- a/nuke_host_api/README.md
+++ b/nuke_host_api/README.md
@@ -135,9 +135,12 @@ Without the guard, a host could not tell which run any following notification de
 which one a cancel would stop. `NukeLoadWorkflowRequest` refuses mid-run for the same reason
 and a stronger one: it would discard the running graph.
 
-One host verb, two engine requests, and neither of them loads. `SetParameterValueRequest`
-applies each input to the loaded start node and `StartFlowRequest` executes, so running a
-workflow does not rebuild the graph whose knobs a host has just been setting.
+Six engine requests plus one per applied input, and none of them loads.
+`SetParameterValueRequest` applies each input to the loaded start node and `StartFlowRequest`
+executes, so running a workflow does not rebuild the graph whose knobs a host has just been
+setting. The rest is preflight: what the engine is running, what it has loaded, what that
+workflow declares, and which flow to start. A rejected input costs no request, because it never
+reaches the engine.
 
 `workflow_id` is optional. Empty runs whatever is loaded, which is what a host driving a graph
 an editor user opened has to do. Set, it must be the loaded workflow, and a mismatch is
@@ -157,6 +160,12 @@ load, and the engine keeps the unsaved graph an editor user is working on in its
 under an `unsaved:` key with no declared shape. Rejecting each input there would report the
 host's own parameter names back at it as if they were wrong, while the run went ahead on the
 author's values.
+
+An unreadable registry produces the same empty allow-list for an unrelated reason, and gets its
+own refusal naming a retry. A workflow that declares nothing will still declare nothing on the
+next call; a registry that would not answer probably will. Telling a host to save a workflow it
+already saved sends it down the wrong recovery path. Neither refusal fires when no inputs were
+sent, because then there is nothing to check against the allow-list.
 
 `NukeDescribeWorkflowRequest` carries each parameter's `default`, `tooltip`, and `settable`
 alongside its type, because a host builds knobs from this and a knob with no default has

--- a/nuke_host_api/engine.py
+++ b/nuke_host_api/engine.py
@@ -118,15 +118,36 @@ def workflow_table() -> dict | None:
     return attempt.value.workflows
 
 
+@dataclass(frozen=True)
+class WorkflowLookup:
+    """One registry lookup, keeping an unreadable registry apart from an unknown id.
+
+    Two verbs word different failures for the two, because one is worth retrying and the
+    other never is. Sharing the lookup rather than the wording is what keeps them from
+    drifting: a host matching on reason text would otherwise see one verb change and not
+    the other.
+    """
+
+    entry: dict | None
+    registry_readable: bool
+
+
+def lookup_workflow(workflow_id: str) -> WorkflowLookup:
+    """Look one id up in the engine's registry, distinguishing why it was not found."""
+    table = workflow_table()
+    if table is None:
+        return WorkflowLookup(entry=None, registry_readable=False)
+    entry = table.get(workflow_id)
+    return WorkflowLookup(entry=entry if isinstance(entry, dict) else None, registry_readable=True)
+
+
 def workflow_entry(workflow_id: str) -> dict | None:
     """Return one registry entry, or None when the registry is unreadable or the id is unknown.
 
     For callers that treat both the same. A verb that must tell a host which of the two
-    happened reads ``workflow_table`` and indexes it itself.
+    happened reads ``lookup_workflow``.
     """
-    table = workflow_table()
-    entry = table.get(workflow_id) if table else None
-    return entry if isinstance(entry, dict) else None
+    return lookup_workflow(workflow_id).entry
 
 
 def flow_state(flow_name: str) -> Attempt[GetFlowStateResultSuccess]:

--- a/nuke_host_api/events.py
+++ b/nuke_host_api/events.py
@@ -238,7 +238,7 @@ class NukeExecuteWorkflowRequest(RequestPayload):
     """Apply inputs to the loaded workflow and start it.
 
     Loads nothing. A host loads with ``NukeLoadWorkflowRequest`` and starts with this, so
-    starting a run costs one engine round trip per input plus one to start, and never a
+    starting a run costs six engine requests plus one per applied input, and never a
     clear-and-reload of the graph the host just set up.
 
     Returns once execution has started. Progress and the terminal result arrive as
@@ -255,7 +255,7 @@ class NukeExecuteWorkflowRequest(RequestPayload):
             reported in ``rejected_inputs``. Sending inputs to a workflow that declares none,
             which includes an unsaved editor graph, is refused rather than run: none of them
             could be applied, and the run would produce plausible output from the author's
-            values instead of the host's.
+            values instead of the host's. Send none to run a graph as it stands.
     """
 
     workflow_id: str = ""
@@ -292,8 +292,10 @@ class NukeExecuteWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFai
     """Execution could not be started.
 
     Covers a run already in progress, nothing loaded to run, a ``workflow_id`` naming a
-    workflow other than the loaded one, and inputs sent to a loaded graph that declares no
-    input parameters to address them to.
+    workflow other than the loaded one, inputs sent to a loaded graph that declares no input
+    parameters to address them to, and a registry the engine could not read to find out what it
+    declares. The last two leave the same empty allow-list behind and are worded apart on
+    purpose: only one of them is fixed by retrying.
     """
 
     workflow_id: str = ""

--- a/nuke_host_api/events.py
+++ b/nuke_host_api/events.py
@@ -238,8 +238,8 @@ class NukeExecuteWorkflowRequest(RequestPayload):
     """Apply inputs to the loaded workflow and start it.
 
     Loads nothing. A host loads with ``NukeLoadWorkflowRequest`` and starts with this, so
-    starting a run costs six engine requests plus one per applied input, and never a
-    clear-and-reload of the graph the host just set up.
+    starting a run costs six engine requests plus one per input forwarded to the engine, and
+    never a clear-and-reload of the graph the host just set up.
 
     Returns once execution has started. Progress and the terminal result arrive as
     notifications on ``event_topic``.
@@ -277,7 +277,9 @@ class NukeExecuteWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
         state: One of ``protocol.ExecutionState``.
         applied_inputs: Inputs the engine accepted, so a host can detect a silently
             dropped input rather than wondering why the output looks wrong.
-        rejected_inputs: Entries of ``{node, parameter, reason}``.
+        rejected_inputs: Entries of ``{node, parameter, reason}``. Two kinds land here: a pair
+            that is not a declared input, filtered before the engine sees it, and a declared
+            pair the engine itself refused.
     """
 
     workflow_id: str
@@ -292,10 +294,11 @@ class NukeExecuteWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFai
     """Execution could not be started.
 
     Covers a run already in progress, nothing loaded to run, a ``workflow_id`` naming a
-    workflow other than the loaded one, inputs sent to a loaded graph that declares no input
-    parameters to address them to, and a registry the engine could not read to find out what it
-    declares. The last two leave the same empty allow-list behind and are worded apart on
-    purpose: only one of them is fixed by retrying.
+    workflow other than the loaded one, and three ways inputs can arrive with nothing to apply
+    them to: a loaded graph that declares no input parameters, a registry the engine could not
+    read to find out what it declares, and a loaded id that is no longer in the registry at all.
+    Those three leave the same empty allow-list behind and are worded apart on purpose, because
+    each is fixed differently.
     """
 
     workflow_id: str = ""

--- a/nuke_host_api/events.py
+++ b/nuke_host_api/events.py
@@ -277,9 +277,12 @@ class NukeExecuteWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
         state: One of ``protocol.ExecutionState``.
         applied_inputs: Inputs the engine accepted, so a host can detect a silently
             dropped input rather than wondering why the output looks wrong.
-        rejected_inputs: Entries of ``{node, parameter, reason}``. Two kinds land here: a pair
-            that is not a declared input, filtered before the engine sees it, and a declared
-            pair the engine itself refused.
+        rejected_inputs: Entries of ``{node, parameter, reason}``. A rejection is either the
+            host's own to fix or the engine's, and the split is whether the input was forwarded
+            at all. Two are turned away first: a ``node`` whose value is not an object of
+            parameters, reported with ``parameter`` as ``"*"`` since no single parameter was
+            named, and a pair that is not a declared input. Anything else is a declared pair the
+            engine itself refused, carrying the engine's own reason.
     """
 
     workflow_id: str

--- a/nuke_host_api/events.py
+++ b/nuke_host_api/events.py
@@ -136,25 +136,116 @@ class NukeDescribeWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFa
     workflow_id: str
 
 
+# Loading
+
+
+@dataclass
+@PayloadRegistry.register
+class NukeLoadWorkflowRequest(RequestPayload):
+    """Load a workflow into the engine and read back everything a host needs to drive it.
+
+    The only verb that changes which workflow is loaded, and the only one a host must call
+    before ``NukeExecuteWorkflowRequest``, ``NukeGetParameterValuesRequest``, or
+    ``NukeGetExecutionStateRequest`` can answer for the workflow it means.
+
+    Destructive on purpose, and worth a confirmation in a host's UI: the engine clears all
+    object state to load a graph, so this discards whatever was loaded before, including a
+    graph an editor user has open on the same engine.
+
+    Args:
+        workflow_id: Id from NukeListWorkflowsRequest. Mutually exclusive with file_path.
+        file_path: Absolute path to a workflow file the engine has not registered yet. It is
+            imported, registered, and then loaded, so a host can hand over a file an artist
+            picked without a separate registration step. Mutually exclusive with workflow_id.
+    """
+
+    workflow_id: str = ""
+    file_path: str = ""
+
+
+@dataclass
+@PayloadRegistry.register
+class NukeLoadWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """The workflow is loaded, described, and read back in one reply.
+
+    Four fields rather than two, because a parameter's declaration and its current value are
+    different questions with different lifetimes, and no field in this protocol carries two
+    meanings. Both shapes are ones a host already parses: ``inputs`` and ``outputs`` are
+    exactly ``NukeDescribeWorkflowResultSuccess``'s lists, and ``input_values`` and
+    ``output_values`` are exactly ``NukeGetParameterValuesResultSuccess``'s maps. A host that
+    reads both of those verbs today needs no new parsing for this one.
+
+    Args:
+        workflow_id: The loaded workflow's id. Resolved from ``file_path`` when that was
+            what the host sent, so this is how a host learns the id to use afterwards.
+        name: Display label.
+        description: Author's description, empty when there is none.
+        inputs: Declared start-flow parameter descriptors. Build knobs from these.
+        outputs: Declared end-flow parameter descriptors.
+        input_values: ``{node: {parameter: value_descriptor}}`` for the start-flow side.
+            Initialize knobs to these rather than to a descriptor's ``default``, which is the
+            author's value and not what the graph currently holds.
+        output_values: Same shape, for the end-flow side. Populated for a workflow that has
+            run before; empty descriptors for one that has not.
+        unavailable: Declared parameters the engine would not read, as
+            ``{section, node, parameter, reason}``. Reported rather than omitted, for the same
+            reason as on NukeGetParameterValuesRequest: an absent entry and an empty one mean
+            different things to a host building a knob.
+    """
+
+    workflow_id: str
+    name: str
+    description: str
+    inputs: list[dict[str, Any]] = field(default_factory=list)
+    outputs: list[dict[str, Any]] = field(default_factory=list)
+    input_values: dict[str, dict[str, Any]] = field(default_factory=dict)
+    output_values: dict[str, dict[str, Any]] = field(default_factory=dict)
+    unavailable: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class NukeLoadWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Nothing was loaded, and whatever was loaded before is untouched.
+
+    Covers an ambiguous or empty request, an unknown id, a file the engine could not import,
+    a workflow the engine could not load, and a run already in progress.
+
+    Args:
+        workflow_id: The id asked for, or the one resolved from ``file_path``. Empty when the
+            request never got far enough to name one.
+    """
+
+    workflow_id: str = ""
+
+
 # Execution
 
 
 @dataclass
 @PayloadRegistry.register
 class NukeExecuteWorkflowRequest(RequestPayload):
-    """Load a workflow, apply inputs, and start it.
+    """Apply inputs to the loaded workflow and start it.
+
+    Loads nothing. A host loads with ``NukeLoadWorkflowRequest`` and starts with this, so
+    starting a run costs one engine round trip per input plus one to start, and never a
+    clear-and-reload of the graph the host just set up.
 
     Returns once execution has started. Progress and the terminal result arrive as
     notifications on ``event_topic``.
 
     Args:
-        workflow_id: Id from NukeListWorkflowsRequest.
+        workflow_id: Optional. When set, it must be the workflow already loaded, and the
+            request is refused if it is not. Empty runs whatever is loaded. Send it if the
+            host tracks what it loaded, which turns a graph swapped out from under it, by an
+            editor user or another tool, into a refusal instead of a run of the wrong
+            workflow.
         inputs: ``{node_name: {parameter_name: value}}``. Values are plain JSON. Only pairs
             NukeDescribeWorkflowRequest declared as inputs are accepted; anything else is
             reported in ``rejected_inputs``.
     """
 
-    workflow_id: str
+    workflow_id: str = ""
     inputs: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
@@ -168,7 +259,8 @@ class NukeExecuteWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
     that follow. Adding one once the engine supports it is an additive change.
 
     Args:
-        workflow_id: Echoed for convenience.
+        workflow_id: The workflow that ran. Always the loaded workflow's id, so a host that
+            sent none still learns which workflow it started.
         state: One of ``protocol.ExecutionState``.
         applied_inputs: Inputs the engine accepted, so a host can detect a silently
             dropped input rather than wondering why the output looks wrong.
@@ -184,9 +276,13 @@ class NukeExecuteWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
 @dataclass
 @PayloadRegistry.register
 class NukeExecuteWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
-    """Execution could not be started, including when a run is already in progress."""
+    """Execution could not be started.
 
-    workflow_id: str
+    Covers a run already in progress, nothing loaded to run, and a ``workflow_id`` naming a
+    workflow other than the loaded one.
+    """
+
+    workflow_id: str = ""
 
 
 @dataclass
@@ -242,8 +338,10 @@ class NukeGetParameterValuesRequest(RequestPayload):
     this reads what they currently hold.
 
     Values exist only for the loaded graph, so this takes no ``workflow_id``: it always
-    answers for whatever ``NukeExecuteWorkflowRequest`` most recently loaded, the same
-    workflow ``NukeGetExecutionStateResultSuccess.workflow_id`` names.
+    answers for whatever ``NukeLoadWorkflowRequest`` most recently loaded, the same workflow
+    ``NukeGetExecutionStateResultSuccess.workflow_id`` names. Load already returns these
+    values once, so this is the verb for reading them *again*: after a run finishes, or after
+    a reconnect that missed every notification.
 
     Args:
         sections: Which of ``protocol.PARAMETER_SECTIONS`` to read. Empty means every section,

--- a/nuke_host_api/events.py
+++ b/nuke_host_api/events.py
@@ -150,7 +150,9 @@ class NukeLoadWorkflowRequest(RequestPayload):
 
     Destructive on purpose, and worth a confirmation in a host's UI: the engine clears all
     object state to load a graph, so this discards whatever was loaded before, including a
-    graph an editor user has open on the same engine.
+    graph an editor user has open on the same engine. It discards it before it knows the load
+    will succeed, so a failure can leave nothing loaded at all; see
+    ``NukeLoadWorkflowResultFailure.engine_state_cleared``.
 
     Args:
         workflow_id: Id from NukeListWorkflowsRequest. Mutually exclusive with file_path.
@@ -206,17 +208,25 @@ class NukeLoadWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucces
 @dataclass
 @PayloadRegistry.register
 class NukeLoadWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
-    """Nothing was loaded, and whatever was loaded before is untouched.
+    """Nothing was loaded. Whether the previous graph survived depends on how far the load got.
 
     Covers an ambiguous or empty request, an unknown id, a file the engine could not import,
-    a workflow the engine could not load, and a run already in progress.
+    a workflow the engine could not load, and a run already in progress. Every one of those
+    except the engine's own load failure is decided before the engine is touched.
 
     Args:
         workflow_id: The id asked for, or the one resolved from ``file_path``. Empty when the
             request never got far enough to name one.
+        engine_state_cleared: True when the engine had already discarded the previous graph
+            before it failed. Loading asks for a clean slate, and the engine clears all object
+            state before it builds the graph, so a workflow that fails inside its own file
+            leaves the engine empty. A host that keeps showing knobs for what it had loaded
+            must drop them when this is set, and must ask an artist before retrying, since the
+            comp they had open is already gone.
     """
 
     workflow_id: str = ""
+    engine_state_cleared: bool = False
 
 
 # Execution
@@ -242,7 +252,10 @@ class NukeExecuteWorkflowRequest(RequestPayload):
             workflow.
         inputs: ``{node_name: {parameter_name: value}}``. Values are plain JSON. Only pairs
             NukeDescribeWorkflowRequest declared as inputs are accepted; anything else is
-            reported in ``rejected_inputs``.
+            reported in ``rejected_inputs``. Sending inputs to a workflow that declares none,
+            which includes an unsaved editor graph, is refused rather than run: none of them
+            could be applied, and the run would produce plausible output from the author's
+            values instead of the host's.
     """
 
     workflow_id: str = ""
@@ -278,8 +291,9 @@ class NukeExecuteWorkflowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
 class NukeExecuteWorkflowResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Execution could not be started.
 
-    Covers a run already in progress, nothing loaded to run, and a ``workflow_id`` naming a
-    workflow other than the loaded one.
+    Covers a run already in progress, nothing loaded to run, a ``workflow_id`` naming a
+    workflow other than the loaded one, and inputs sent to a loaded graph that declares no
+    input parameters to address them to.
     """
 
     workflow_id: str = ""

--- a/nuke_host_api/execution_bridge.py
+++ b/nuke_host_api/execution_bridge.py
@@ -18,7 +18,7 @@ see ``ensure_installed``.
 
 Stateless by design. The bridge holds no execution state beyond its own subscription
 flag. Values a host wants are read from the engine on demand via
-NukeGetExecutionStateRequest, so there is no copy of engine state here to go stale.
+NukeGetParameterValuesRequest, so there is no copy of engine state here to go stale.
 
 One callback is not request-free. ``_on_parameter_value`` normalizes every streamed
 value through the same ``normalize_value`` used everywhere else, and that normalizer
@@ -183,7 +183,7 @@ class ExecutionBridge:
         Values are deliberately not gathered here. The engine asks listeners to stay
         cheap and non-blocking, and issuing engine requests from inside an execution
         event callback would violate that. A host reads outputs with
-        NukeGetExecutionStateRequest instead.
+        NukeGetParameterValuesRequest instead.
 
         ControlFlowResolvedEvent fires on both a clean run and an errored one, and carries
         no status field, so COMPLETED is all this layer actually knows. It must not infer

--- a/nuke_host_api/handlers/__init__.py
+++ b/nuke_host_api/handlers/__init__.py
@@ -19,6 +19,7 @@ from nuke_host_api.events import (
     NukeGetExecutionStateRequest,
     NukeGetParameterValuesRequest,
     NukeListWorkflowsRequest,
+    NukeLoadWorkflowRequest,
 )
 from nuke_host_api.handlers.connect import handle_connect
 from nuke_host_api.handlers.execution import (
@@ -26,6 +27,7 @@ from nuke_host_api.handlers.execution import (
     handle_execute_workflow,
     handle_get_execution_state,
 )
+from nuke_host_api.handlers.load import handle_load_workflow
 from nuke_host_api.handlers.values import handle_get_parameter_values
 from nuke_host_api.handlers.workflows import handle_describe_workflow, handle_list_workflows
 
@@ -38,6 +40,7 @@ ROUTES: tuple[tuple[type[RequestPayload], Callable[[RequestPayload], ResultPaylo
     (NukeConnectRequest, handle_connect),
     (NukeListWorkflowsRequest, handle_list_workflows),
     (NukeDescribeWorkflowRequest, handle_describe_workflow),
+    (NukeLoadWorkflowRequest, handle_load_workflow),
     (NukeExecuteWorkflowRequest, handle_execute_workflow),
     (NukeGetExecutionStateRequest, handle_get_execution_state),
     (NukeGetParameterValuesRequest, handle_get_parameter_values),
@@ -53,4 +56,5 @@ __all__ = [
     "handle_get_execution_state",
     "handle_get_parameter_values",
     "handle_list_workflows",
+    "handle_load_workflow",
 ]

--- a/nuke_host_api/handlers/execution.py
+++ b/nuke_host_api/handlers/execution.py
@@ -45,11 +45,11 @@ def handle_execute_workflow(
     events a host could not tell which run the notifications that followed belonged to, nor
     which one a cancel would stop. Serial execution is what makes those two gaps survivable.
 
-    Also refuses inputs it could not apply at all, and says which of two reasons it hit.
+    Also refuses inputs it could not apply at all, and says which of three reasons it hit.
     ``current_workflow_id`` answers for any graph the engine holds, including the unsaved one
     an editor user is working on, and an unsaved graph publishes no declared shape to address
-    inputs to. An unreadable registry produces the same empty allow-list for an entirely
-    different reason, and only one of the two is worth retrying.
+    inputs to. An unreadable registry and an entry that has vanished from a readable one leave
+    the same empty allow-list behind for unrelated reasons, and each is fixed differently.
     """
     attempted = (
         f"to execute workflow '{request.workflow_id}'" if request.workflow_id else "to execute the loaded workflow"
@@ -88,38 +88,16 @@ def handle_execute_workflow(
             workflow_id=request.workflow_id,
         )
 
-    declared, registry_readable = _declared_input_parameters(loaded_id)
+    found = engine.lookup_workflow(loaded_id)
+    declared = shape.input_parameter_ids(found.entry) if found.entry is not None else set()
 
     # Only checked when there are inputs to check. With none, what the workflow declares does
     # not bear on the run, and a graph with no declared shape is exactly what an empty
     # workflow_id is for.
-    if request.inputs and not registry_readable:
-        return failure(
-            NukeExecuteWorkflowResultFailure,
-            attempted=attempted,
-            because=(
-                f"the engine could not read the workflow registry, so what '{loaded_id}' declares as inputs is "
-                f"unknown and the inputs sent could not be checked against it. Retry, or send no inputs to run "
-                f"the graph as it stands."
-            ),
-            workflow_id=loaded_id,
-        )
-
-    # Starting anyway would run the author's values while reporting success, and every input
-    # the host sent would come back rejected for a reason that reads like it named the wrong
-    # parameters. An unsaved editor graph is the case that gets here: the engine keeps it in
-    # the registry under an "unsaved:" key with no declared shape.
-    if request.inputs and not declared:
-        return failure(
-            NukeExecuteWorkflowResultFailure,
-            attempted=attempted,
-            because=(
-                f"the loaded workflow '{loaded_id}' declares no input parameters, so none of the inputs sent "
-                f"could be applied. An unsaved graph an editor user is working on has no declared shape: save "
-                f"it and load it by id, or send no inputs to run it as it stands."
-            ),
-            workflow_id=loaded_id,
-        )
+    if request.inputs:
+        refusal = _refuse_unaddressable_inputs(attempted, loaded_id, found, declared)
+        if refusal is not None:
+            return refusal
 
     applied, rejected = _apply_inputs(request.inputs, declared)
 
@@ -150,22 +128,56 @@ def handle_execute_workflow(
     )
 
 
-def _declared_input_parameters(workflow_id: str) -> tuple[set[tuple[str, str]], bool]:
-    """Return the parameters a host may set, and whether the registry could be read at all.
+def _refuse_unaddressable_inputs(
+    attempted: str, loaded_id: str, found: engine.WorkflowLookup, declared: set[tuple[str, str]]
+) -> NukeExecuteWorkflowResultFailure | None:
+    """Refuse inputs nothing could be applied to, naming which of three causes it was.
 
-    Two reasons produce no parameters and they are not the same refusal: a graph that declares
-    no shape is permanent and a host must stop sending inputs, an unreadable registry is
-    transient and a retry fixes it. Collapsing them would tell a host to save a workflow it
-    already saved.
-
-    An empty set is not the same as a workflow that refuses to run: a graph with no declared
-    shape still executes, it just cannot be addressed. The caller decides what that means,
-    which depends on whether the host sent any inputs at all.
+    All three leave an empty allow-list, and each sends a host somewhere different: retry the
+    registry, load the workflow again, or save the graph first. Collapsing any two of them names
+    a cause the host cannot act on, and starting the run instead would report success while
+    running the author's values.
     """
-    found = engine.lookup_workflow(workflow_id)
+    if not found.registry_readable:
+        return failure(
+            NukeExecuteWorkflowResultFailure,
+            attempted=attempted,
+            because=(
+                f"the engine could not read the workflow registry, so what '{loaded_id}' declares as inputs is "
+                f"unknown and the inputs sent could not be checked against it. Retry, or send no inputs to run "
+                f"the graph as it stands."
+            ),
+            workflow_id=loaded_id,
+        )
+    # A stale context key over a live registry: the engine can drop an entry without touching
+    # the context stack. Worded as NukeGetParameterValuesRequest words the same state, so two
+    # verbs do not describe one engine condition two ways.
     if found.entry is None:
-        return set(), found.registry_readable
-    return shape.input_parameter_ids(found.entry), True
+        return failure(
+            NukeExecuteWorkflowResultFailure,
+            attempted=attempted,
+            because=(
+                f"the loaded workflow '{loaded_id}' is no longer in the registry, so the inputs sent could not "
+                f"be checked against what it declares. Load it again with NukeLoadWorkflowRequest."
+            ),
+            error=KeyError,
+            workflow_id=loaded_id,
+        )
+    # An unsaved editor graph: the engine keeps it in the registry under an "unsaved:" key with
+    # no declared shape. Reachable only with an entry actually found, which is the case this
+    # message describes.
+    if not declared:
+        return failure(
+            NukeExecuteWorkflowResultFailure,
+            attempted=attempted,
+            because=(
+                f"the loaded workflow '{loaded_id}' declares no input parameters, so none of the inputs sent "
+                f"could be applied. An unsaved graph an editor user is working on has no declared shape: save "
+                f"it and load it by id, or send no inputs to run it as it stands."
+            ),
+            workflow_id=loaded_id,
+        )
+    return None
 
 
 def _apply_inputs(
@@ -175,7 +187,8 @@ def _apply_inputs(
 
     A silently dropped input is worse than a failed execution: the workflow produces plausible
     output from the wrong values. So rejections are reported rather than logged and
-    forgotten.
+    forgotten. Two kinds reach ``rejected``, and only one is free: a pair outside ``allowed``
+    never reaches the engine, while a declared pair is forwarded before its outcome is known.
 
     Only pairs describe_workflow declared are forwarded. The engine would happily set a
     parameter on any node in the loaded graph, and this transport carries no authentication,

--- a/nuke_host_api/handlers/execution.py
+++ b/nuke_host_api/handlers/execution.py
@@ -14,10 +14,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     SetParameterValueRequest,
     SetParameterValueResultSuccess,
 )
-from griptape_nodes.retained_mode.events.workflow_events import (
-    RunWorkflowFromRegistryRequest,
-    RunWorkflowFromRegistryResultSuccess,
-)
 
 from nuke_host_api import engine, shape
 from nuke_host_api.dispatch import failure, verb
@@ -39,19 +35,19 @@ from nuke_host_api.protocol import ExecutionState
 def handle_execute_workflow(
     request: NukeExecuteWorkflowRequest,
 ) -> NukeExecuteWorkflowResultSuccess | NukeExecuteWorkflowResultFailure:
-    """Load the workflow, apply inputs, then start the flow.
+    """Apply inputs to the loaded workflow, then start the flow.
 
-    Three engine requests behind one host verb. The engine has no execute-with-inputs entry
-    point: RunWorkflowFromRegistryRequest loads the graph, parameter values are set on
-    the loaded start node, and StartFlowRequest executes. A host should not have to know
-    that sequence, or that it may change.
+    Loads nothing. ``NukeLoadWorkflowRequest`` owns that, so this verb cannot discard the
+    graph whose parameters a host has just been setting, and a host can set values, read them
+    back, and run without the engine rebuilding the graph in between.
 
-    Refuses to start over a run already in progress. Loading a second graph would discard
-    the first mid-flight, and with no execution id in the engine's events a host could not
-    tell which run the notifications that followed belonged to, nor which one a cancel
-    would stop. Serial execution is what makes those two gaps survivable.
+    Refuses to start over a run already in progress. With no execution id in the engine's
+    events a host could not tell which run the notifications that followed belonged to, nor
+    which one a cancel would stop. Serial execution is what makes those two gaps survivable.
     """
-    attempted = f"to execute workflow '{request.workflow_id}'"
+    attempted = (
+        f"to execute workflow '{request.workflow_id}'" if request.workflow_id else "to execute the loaded workflow"
+    )
 
     if engine.is_running():
         return failure(
@@ -64,21 +60,29 @@ def handle_execute_workflow(
             workflow_id=request.workflow_id,
         )
 
-    allowed_inputs = _declared_input_parameters(request.workflow_id)
-
-    loaded = engine.request(
-        RunWorkflowFromRegistryRequest(workflow_name=request.workflow_id, run_with_clean_slate=True),
-        RunWorkflowFromRegistryResultSuccess,
-    )
-    if loaded.value is None:
+    loaded_id = engine.current_workflow_id()
+    if not loaded_id:
         return failure(
             NukeExecuteWorkflowResultFailure,
             attempted=attempted,
-            because=f"the engine could not load it. {loaded.details}",
+            because="no workflow is loaded, so there is nothing to run. Load one with NukeLoadWorkflowRequest.",
             workflow_id=request.workflow_id,
         )
 
-    applied, rejected = _apply_inputs(request.inputs, allowed_inputs)
+    # Refused rather than loaded. Honouring the id would put loading back inside execute, and
+    # ignoring it would run a workflow the host did not ask for while reporting success.
+    if request.workflow_id and request.workflow_id != loaded_id:
+        return failure(
+            NukeExecuteWorkflowResultFailure,
+            attempted=attempted,
+            because=(
+                f"the engine has '{loaded_id}' loaded, not '{request.workflow_id}'. "
+                f"Load it with NukeLoadWorkflowRequest first, then execute."
+            ),
+            workflow_id=request.workflow_id,
+        )
+
+    applied, rejected = _apply_inputs(request.inputs, _declared_input_parameters(loaded_id))
 
     flow_name = engine.top_level_flow_name()
     if flow_name is None:
@@ -86,7 +90,7 @@ def handle_execute_workflow(
             NukeExecuteWorkflowResultFailure,
             attempted=attempted,
             because="the loaded workflow has no top-level flow to start.",
-            workflow_id=request.workflow_id,
+            workflow_id=loaded_id,
         )
 
     started = engine.request(StartFlowRequest(flow_name=flow_name), StartFlowResultSuccess)
@@ -95,20 +99,25 @@ def handle_execute_workflow(
             NukeExecuteWorkflowResultFailure,
             attempted=attempted,
             because=f"the engine would not start the flow. {started.details}",
-            workflow_id=request.workflow_id,
+            workflow_id=loaded_id,
         )
 
     return NukeExecuteWorkflowResultSuccess(
-        workflow_id=request.workflow_id,
+        workflow_id=loaded_id,
         state=ExecutionState.RUNNING,
         applied_inputs=applied,
         rejected_inputs=rejected,
-        result_details=f"Started workflow '{request.workflow_id}'.",
+        result_details=f"Started workflow '{loaded_id}'.",
     )
 
 
 def _declared_input_parameters(workflow_id: str) -> set[tuple[str, str]]:
-    """Return the parameters a host may set, or nothing when the workflow cannot be read."""
+    """Return the parameters a host may set, or nothing when the workflow cannot be read.
+
+    An empty set is the safe answer, not a failure: a workflow the registry cannot describe
+    still runs, it just accepts no inputs, and every one a host sent is reported rejected
+    rather than silently dropped.
+    """
     entry = engine.workflow_entry(workflow_id)
     if entry is None:
         return set()
@@ -176,7 +185,7 @@ def handle_get_execution_state(
         return failure(
             NukeGetExecutionStateResultFailure,
             attempted=attempted,
-            because="no workflow is loaded, so there is no flow to report on.",
+            because="no workflow is loaded, so there is no flow to report on. Load one with NukeLoadWorkflowRequest.",
         )
 
     state = engine.flow_state(flow_name)

--- a/nuke_host_api/handlers/execution.py
+++ b/nuke_host_api/handlers/execution.py
@@ -45,9 +45,11 @@ def handle_execute_workflow(
     events a host could not tell which run the notifications that followed belonged to, nor
     which one a cancel would stop. Serial execution is what makes those two gaps survivable.
 
-    Also refuses inputs it could not apply at all. ``current_workflow_id`` answers for any
-    graph the engine holds, including the unsaved one an editor user is working on, and an
-    unsaved graph publishes no declared shape to address inputs to.
+    Also refuses inputs it could not apply at all, and says which of two reasons it hit.
+    ``current_workflow_id`` answers for any graph the engine holds, including the unsaved one
+    an editor user is working on, and an unsaved graph publishes no declared shape to address
+    inputs to. An unreadable registry produces the same empty allow-list for an entirely
+    different reason, and only one of the two is worth retrying.
     """
     attempted = (
         f"to execute workflow '{request.workflow_id}'" if request.workflow_id else "to execute the loaded workflow"
@@ -86,7 +88,22 @@ def handle_execute_workflow(
             workflow_id=request.workflow_id,
         )
 
-    declared = _declared_input_parameters(loaded_id)
+    declared, registry_readable = _declared_input_parameters(loaded_id)
+
+    # Only checked when there are inputs to check. With none, what the workflow declares does
+    # not bear on the run, and a graph with no declared shape is exactly what an empty
+    # workflow_id is for.
+    if request.inputs and not registry_readable:
+        return failure(
+            NukeExecuteWorkflowResultFailure,
+            attempted=attempted,
+            because=(
+                f"the engine could not read the workflow registry, so what '{loaded_id}' declares as inputs is "
+                f"unknown and the inputs sent could not be checked against it. Retry, or send no inputs to run "
+                f"the graph as it stands."
+            ),
+            workflow_id=loaded_id,
+        )
 
     # Starting anyway would run the author's values while reporting success, and every input
     # the host sent would come back rejected for a reason that reads like it named the wrong
@@ -133,17 +150,22 @@ def handle_execute_workflow(
     )
 
 
-def _declared_input_parameters(workflow_id: str) -> set[tuple[str, str]]:
-    """Return the parameters a host may set, or nothing when the workflow declares none.
+def _declared_input_parameters(workflow_id: str) -> tuple[set[tuple[str, str]], bool]:
+    """Return the parameters a host may set, and whether the registry could be read at all.
+
+    Two reasons produce no parameters and they are not the same refusal: a graph that declares
+    no shape is permanent and a host must stop sending inputs, an unreadable registry is
+    transient and a retry fixes it. Collapsing them would tell a host to save a workflow it
+    already saved.
 
     An empty set is not the same as a workflow that refuses to run: a graph with no declared
     shape still executes, it just cannot be addressed. The caller decides what that means,
     which depends on whether the host sent any inputs at all.
     """
-    entry = engine.workflow_entry(workflow_id)
-    if entry is None:
-        return set()
-    return shape.input_parameter_ids(entry)
+    found = engine.lookup_workflow(workflow_id)
+    if found.entry is None:
+        return set(), found.registry_readable
+    return shape.input_parameter_ids(found.entry), True
 
 
 def _apply_inputs(

--- a/nuke_host_api/handlers/execution.py
+++ b/nuke_host_api/handlers/execution.py
@@ -44,6 +44,10 @@ def handle_execute_workflow(
     Refuses to start over a run already in progress. With no execution id in the engine's
     events a host could not tell which run the notifications that followed belonged to, nor
     which one a cancel would stop. Serial execution is what makes those two gaps survivable.
+
+    Also refuses inputs it could not apply at all. ``current_workflow_id`` answers for any
+    graph the engine holds, including the unsaved one an editor user is working on, and an
+    unsaved graph publishes no declared shape to address inputs to.
     """
     attempted = (
         f"to execute workflow '{request.workflow_id}'" if request.workflow_id else "to execute the loaded workflow"
@@ -82,7 +86,25 @@ def handle_execute_workflow(
             workflow_id=request.workflow_id,
         )
 
-    applied, rejected = _apply_inputs(request.inputs, _declared_input_parameters(loaded_id))
+    declared = _declared_input_parameters(loaded_id)
+
+    # Starting anyway would run the author's values while reporting success, and every input
+    # the host sent would come back rejected for a reason that reads like it named the wrong
+    # parameters. An unsaved editor graph is the case that gets here: the engine keeps it in
+    # the registry under an "unsaved:" key with no declared shape.
+    if request.inputs and not declared:
+        return failure(
+            NukeExecuteWorkflowResultFailure,
+            attempted=attempted,
+            because=(
+                f"the loaded workflow '{loaded_id}' declares no input parameters, so none of the inputs sent "
+                f"could be applied. An unsaved graph an editor user is working on has no declared shape: save "
+                f"it and load it by id, or send no inputs to run it as it stands."
+            ),
+            workflow_id=loaded_id,
+        )
+
+    applied, rejected = _apply_inputs(request.inputs, declared)
 
     flow_name = engine.top_level_flow_name()
     if flow_name is None:
@@ -112,11 +134,11 @@ def handle_execute_workflow(
 
 
 def _declared_input_parameters(workflow_id: str) -> set[tuple[str, str]]:
-    """Return the parameters a host may set, or nothing when the workflow cannot be read.
+    """Return the parameters a host may set, or nothing when the workflow declares none.
 
-    An empty set is the safe answer, not a failure: a workflow the registry cannot describe
-    still runs, it just accepts no inputs, and every one a host sent is reported rejected
-    rather than silently dropped.
+    An empty set is not the same as a workflow that refuses to run: a graph with no declared
+    shape still executes, it just cannot be addressed. The caller decides what that means,
+    which depends on whether the host sent any inputs at all.
     """
     entry = engine.workflow_entry(workflow_id)
     if entry is None:

--- a/nuke_host_api/handlers/execution.py
+++ b/nuke_host_api/handlers/execution.py
@@ -187,8 +187,10 @@ def _apply_inputs(
 
     A silently dropped input is worse than a failed execution: the workflow produces plausible
     output from the wrong values. So rejections are reported rather than logged and
-    forgotten. Two kinds reach ``rejected``, and only one is free: a pair outside ``allowed``
-    never reaches the engine, while a declared pair is forwarded before its outcome is known.
+    forgotten. Only a forwarded input can be rejected by the engine; everything this function
+    turns away itself, a node whose value is not an object of parameters and a pair outside
+    ``allowed``, is rejected without a request. So a reason a host did not write is the
+    engine's, and the two it did are its own to fix.
 
     Only pairs describe_workflow declared are forwarded. The engine would happily set a
     parameter on any node in the loaded graph, and this transport carries no authentication,

--- a/nuke_host_api/handlers/load.py
+++ b/nuke_host_api/handlers/load.py
@@ -6,12 +6,17 @@ parameter's live value without starting a run, and left the layer inconsistent a
 host knows what is loaded: discovery addressed workflows by id, everything else answered for
 whatever execute happened to have loaded last.
 
-One host verb, up to five engine requests, because the engine has no load-and-describe entry
-point: ``ImportWorkflowRequest`` registers a file the engine has not seen,
-``RunWorkflowFromRegistryRequest`` builds the graph, and the values come back one
-``GetParameterValueRequest`` at a time. Collapsing them matters more here than elsewhere: a
-host doing this itself would have to know that reading a value requires a load, and that the
-load it needs clears all object state.
+One host verb, four engine requests plus one per declared parameter, because the engine has no
+load-and-describe entry point: ``ImportWorkflowRequest`` registers a file the engine has not
+seen and costs one more, ``RunWorkflowFromRegistryRequest`` builds the graph, and the values
+come back one ``GetParameterValueRequest`` at a time. Collapsing them matters more here than
+elsewhere: a host doing this itself would have to know that reading a value requires a load,
+and that the load it needs clears all object state.
+
+What a refusal costs a host is not uniform, and the failure result says which kind it got.
+Every check this handler makes itself is pre-engine and discards nothing. The engine's own load
+is not atomic: with ``run_with_clean_slate=True`` it clears all object state before it builds
+the graph, so a load that fails inside the workflow file leaves the engine empty.
 """
 
 from __future__ import annotations
@@ -39,9 +44,10 @@ def handle_load_workflow(
 ) -> NukeLoadWorkflowResultSuccess | NukeLoadWorkflowResultFailure:
     """Load one workflow, then describe and read it in the same reply.
 
-    Every check that can be made before the engine is touched is made first, because loading
-    clears all object state: a request that fails on its own arguments, or on an id that was
-    never registered, must leave whatever was loaded before intact.
+    Every check this handler can make itself is made before the engine is touched, because
+    loading clears all object state: a request that fails on its own arguments, or on an id
+    that was never registered, must leave whatever was loaded before intact. The engine's own
+    load is the exception, and reports ``engine_state_cleared`` when it fails.
     """
     if request.workflow_id and request.file_path:
         return failure(
@@ -88,16 +94,16 @@ def handle_load_workflow(
 
     # Read before loading, not after. An unknown id and an unreadable registry are different
     # answers to a host, and neither is worth clearing the engine's state to discover.
-    table = engine.workflow_table()
-    if table is None:
+    found = engine.lookup_workflow(workflow_id)
+    if not found.registry_readable:
         return failure(
             NukeLoadWorkflowResultFailure,
             attempted=attempted,
             because="the engine could not read the workflow registry.",
             workflow_id=workflow_id,
         )
-    entry = table.get(workflow_id)
-    if not isinstance(entry, dict):
+    entry = found.entry
+    if entry is None:
         return failure(
             NukeLoadWorkflowResultFailure,
             attempted=attempted,
@@ -111,11 +117,18 @@ def handle_load_workflow(
         RunWorkflowFromRegistryResultSuccess,
     )
     if loaded.value is None:
+        # The only refusal that costs a host its previous graph. A clean slate is requested,
+        # and the engine clears all object state before it builds the graph, so by the time
+        # the workflow file itself fails there is nothing left to keep.
         return failure(
             NukeLoadWorkflowResultFailure,
             attempted=attempted,
-            because=f"the engine could not load it. {loaded.details}",
+            because=(
+                f"the engine could not load it, and the engine's object state was cleared before it tried, "
+                f"so nothing is loaded now. {loaded.details}"
+            ),
             workflow_id=workflow_id,
+            engine_state_cleared=True,
         )
 
     declared_shape = shape.workflow_shape(entry)

--- a/nuke_host_api/handlers/load.py
+++ b/nuke_host_api/handlers/load.py
@@ -1,0 +1,134 @@
+"""Loading: put a workflow in the engine and hand back everything needed to drive it.
+
+The only verb that changes which workflow the engine holds. Before it existed, loading was a
+side effect of ``NukeExecuteWorkflowRequest``, which left a host unable to see or set a
+parameter's live value without starting a run, and left the layer inconsistent about whether a
+host knows what is loaded: discovery addressed workflows by id, everything else answered for
+whatever execute happened to have loaded last.
+
+One host verb, up to five engine requests, because the engine has no load-and-describe entry
+point: ``ImportWorkflowRequest`` registers a file the engine has not seen,
+``RunWorkflowFromRegistryRequest`` builds the graph, and the values come back one
+``GetParameterValueRequest`` at a time. Collapsing them matters more here than elsewhere: a
+host doing this itself would have to know that reading a value requires a load, and that the
+load it needs clears all object state.
+"""
+
+from __future__ import annotations
+
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowRequest,
+    ImportWorkflowResultSuccess,
+    RunWorkflowFromRegistryRequest,
+    RunWorkflowFromRegistryResultSuccess,
+)
+
+from nuke_host_api import engine, parameter_values, shape
+from nuke_host_api.dispatch import failure, verb
+from nuke_host_api.events import (
+    NukeLoadWorkflowRequest,
+    NukeLoadWorkflowResultFailure,
+    NukeLoadWorkflowResultSuccess,
+)
+from nuke_host_api.protocol import PARAMETER_SECTIONS
+
+
+@verb(NukeLoadWorkflowRequest)
+def handle_load_workflow(
+    request: NukeLoadWorkflowRequest,
+) -> NukeLoadWorkflowResultSuccess | NukeLoadWorkflowResultFailure:
+    """Load one workflow, then describe and read it in the same reply.
+
+    Every check that can be made before the engine is touched is made first, because loading
+    clears all object state: a request that fails on its own arguments, or on an id that was
+    never registered, must leave whatever was loaded before intact.
+    """
+    if request.workflow_id and request.file_path:
+        return failure(
+            NukeLoadWorkflowResultFailure,
+            attempted="to load a workflow",
+            because=(
+                f"both workflow_id '{request.workflow_id}' and file_path '{request.file_path}' were given, "
+                f"and they may name different workflows. Send one."
+            ),
+            error=ValueError,
+        )
+    if not request.workflow_id and not request.file_path:
+        return failure(
+            NukeLoadWorkflowResultFailure,
+            attempted="to load a workflow",
+            because="neither workflow_id nor file_path was given, so there is nothing to load.",
+            error=ValueError,
+        )
+
+    if engine.is_running():
+        return failure(
+            NukeLoadWorkflowResultFailure,
+            attempted=f"to load '{request.workflow_id or request.file_path}'",
+            because=(
+                "the engine is already executing, and loading discards the running graph. "
+                "Wait for the run to finish, or cancel it with NukeCancelExecutionRequest, then retry."
+            ),
+            workflow_id=request.workflow_id,
+        )
+
+    if request.file_path:
+        imported = engine.request(ImportWorkflowRequest(file_path=request.file_path), ImportWorkflowResultSuccess)
+        if imported.value is None:
+            return failure(
+                NukeLoadWorkflowResultFailure,
+                attempted=f"to load the workflow file '{request.file_path}'",
+                because=f"the engine could not import it. {imported.details}",
+            )
+        workflow_id = imported.value.workflow_name
+    else:
+        workflow_id = request.workflow_id
+
+    attempted = f"to load workflow '{workflow_id}'"
+
+    # Read before loading, not after. An unknown id and an unreadable registry are different
+    # answers to a host, and neither is worth clearing the engine's state to discover.
+    table = engine.workflow_table()
+    if table is None:
+        return failure(
+            NukeLoadWorkflowResultFailure,
+            attempted=attempted,
+            because="the engine could not read the workflow registry.",
+            workflow_id=workflow_id,
+        )
+    entry = table.get(workflow_id)
+    if not isinstance(entry, dict):
+        return failure(
+            NukeLoadWorkflowResultFailure,
+            attempted=attempted,
+            because="no workflow with that name is registered.",
+            error=KeyError,
+            workflow_id=workflow_id,
+        )
+
+    loaded = engine.request(
+        RunWorkflowFromRegistryRequest(workflow_name=workflow_id, run_with_clean_slate=True),
+        RunWorkflowFromRegistryResultSuccess,
+    )
+    if loaded.value is None:
+        return failure(
+            NukeLoadWorkflowResultFailure,
+            attempted=attempted,
+            because=f"the engine could not load it. {loaded.details}",
+            workflow_id=workflow_id,
+        )
+
+    declared_shape = shape.workflow_shape(entry)
+    input_values, output_values, unavailable = parameter_values.read_sections(declared_shape, list(PARAMETER_SECTIONS))
+
+    return NukeLoadWorkflowResultSuccess(
+        workflow_id=workflow_id,
+        name=str(entry.get("name") or workflow_id),
+        description=str(entry.get("description") or ""),
+        inputs=shape.declared_parameters(declared_shape.get("inputs")),
+        outputs=shape.declared_parameters(declared_shape.get("outputs")),
+        input_values=input_values,
+        output_values=output_values,
+        unavailable=unavailable,
+        result_details=f"Loaded workflow '{workflow_id}' for a host client.",
+    )

--- a/nuke_host_api/handlers/values.py
+++ b/nuke_host_api/handlers/values.py
@@ -1,54 +1,21 @@
 """Bulk value reads: every declared start-flow or end-flow parameter in one call.
 
-``NukeGetParameterValuesRequest`` is one host verb answered by one engine request per declared
-parameter, looped rather than batched through the engine's own ``GetAllNodeInfoRequest``. That
-choice was not obvious, so it is recorded here rather than left for a later reader to
-re-derive from behaviour.
-
-``GetAllNodeInfoRequest`` (``retained_mode/events/node_events.py``) batches a node's
-metadata, resolution state, connections, and every parameter's value into one engine
-request, which reads like exactly what a bulk read should use. It does not fit this job,
-for three reasons found by reading ``node_manager.py`` rather than the event's docstring:
-
-1. Its ``element_id_to_value`` is keyed by ``parameter.element_id``
-   (``NodeManager._set_param_to_value``), not by parameter name. Turning that into the
-   ``{node: {parameter: value}}`` shape this verb promises needs a second lookup, through
-   the node's element tree, to recover the name behind each id.
-2. Its values are display-serialized: ``_set_param_to_value`` calls ``.to_dict()`` or falls
-   back to ``.__dict__`` on anything that is not a Python builtin, so an artifact instance
-   arrives as a plain dict rather than the object ``value_types.normalize_value`` inspects
-   for a ``.value`` attribute. Handing it a dict silently produces a wrong descriptor rather
-   than a wrong answer that shows up in a test.
-3. It drops a parameter whose value is ``None`` outright (``if value is not None:``), which
-   collides with this verb's own rule that a value the engine truly holds as absent is not
-   the same thing as a parameter the engine would not answer for, tracked instead in
-   ``unavailable``.
-
-``GetParameterValueRequest`` (``parameter_events.py``) has none of those problems: it hands
-back the live value alongside ``type``, the exact declared-type hint ``normalize_value``
-needs to disambiguate a bare string, for the one parameter asked about. The cost is one engine
-request per declared parameter, and a workflow's declared surface is knobs, not hundreds of
-them.
+Thin, because the reading itself is shared with ``NukeLoadWorkflowRequest``: see
+``nuke_host_api.parameter_values`` for how a section is read and why it is read one engine
+request at a time. What lives here is the part that is this verb's own, which is section
+selection and refusing a name that is not a section.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-from griptape_nodes.retained_mode.events.parameter_events import (
-    GetParameterValueRequest,
-    GetParameterValueResultSuccess,
-)
-
-from nuke_host_api import engine, shape
+from nuke_host_api import engine, parameter_values, shape
 from nuke_host_api.dispatch import failure, verb
 from nuke_host_api.events import (
     NukeGetParameterValuesRequest,
     NukeGetParameterValuesResultFailure,
     NukeGetParameterValuesResultSuccess,
 )
-from nuke_host_api.protocol import PARAMETER_SECTIONS, ParameterSection
-from nuke_host_api.value_types import normalize_value
+from nuke_host_api.protocol import PARAMETER_SECTIONS
 
 
 @verb(NukeGetParameterValuesRequest)
@@ -82,7 +49,7 @@ def handle_get_parameter_values(
         return failure(
             NukeGetParameterValuesResultFailure,
             attempted=attempted,
-            because="no workflow is loaded, so there are no parameters to read.",
+            because="no workflow is loaded, so there are no parameters to read. Load one with NukeLoadWorkflowRequest.",
         )
 
     entry = engine.workflow_entry(workflow_id)
@@ -93,17 +60,7 @@ def handle_get_parameter_values(
             because=f"the loaded workflow '{workflow_id}' is no longer in the registry.",
         )
 
-    declared_shape = shape.workflow_shape(entry)
-    inputs: dict[str, dict[str, Any]] = {}
-    outputs: dict[str, dict[str, Any]] = {}
-    unavailable: list[dict[str, str]] = []
-
-    if ParameterSection.INPUTS in sections:
-        inputs, missing = _read_section_values(declared_shape.get("inputs"))
-        unavailable.extend({"section": ParameterSection.INPUTS, **entry} for entry in missing)
-    if ParameterSection.OUTPUTS in sections:
-        outputs, missing = _read_section_values(declared_shape.get("outputs"))
-        unavailable.extend({"section": ParameterSection.OUTPUTS, **entry} for entry in missing)
+    inputs, outputs, unavailable = parameter_values.read_sections(shape.workflow_shape(entry), sections)
 
     return NukeGetParameterValuesResultSuccess(
         workflow_id=workflow_id,
@@ -113,27 +70,3 @@ def handle_get_parameter_values(
         unavailable=unavailable,
         result_details=f"Read {len(sections)} section(s) of parameter values for '{workflow_id}'.",
     )
-
-
-def _read_section_values(section: object) -> tuple[dict[str, dict[str, Any]], list[dict[str, str]]]:
-    """Read one shape section's declared parameters, reporting what the engine would not answer for.
-
-    Omitting an unreadable parameter would read to a host as an empty knob rather than one it
-    could not fetch, so every miss is reported in the second return value instead.
-    """
-    values: dict[str, dict[str, Any]] = {}
-    missing: list[dict[str, str]] = []
-
-    for declared in shape.declared_parameters(section):
-        attempt = engine.request(
-            GetParameterValueRequest(node_name=declared["node"], parameter_name=declared["parameter"]),
-            GetParameterValueResultSuccess,
-        )
-        if attempt.value is None:
-            missing.append({"node": declared["node"], "parameter": declared["parameter"], "reason": attempt.details})
-            continue
-        values.setdefault(declared["node"], {})[declared["parameter"]] = normalize_value(
-            attempt.value.value, attempt.value.type
-        )
-
-    return values, missing

--- a/nuke_host_api/handlers/workflows.py
+++ b/nuke_host_api/handlers/workflows.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from nuke_host_api import shape
 from nuke_host_api.dispatch import failure, verb
-from nuke_host_api.engine import workflow_table
+from nuke_host_api.engine import lookup_workflow, workflow_table
 from nuke_host_api.events import (
     NukeDescribeWorkflowRequest,
     NukeDescribeWorkflowResultFailure,
@@ -57,11 +57,11 @@ def handle_describe_workflow(
 ) -> NukeDescribeWorkflowResultSuccess | NukeDescribeWorkflowResultFailure:
     """Describe one workflow, narrowing every parameter type on the way out.
 
-    Reads the table rather than a single entry, because an unreadable registry and an
-    unknown id are different answers to a host: one is worth retrying, the other never is.
+    Distinguishes an unreadable registry from an unknown id, because they are different
+    answers to a host: one is worth retrying, the other never is.
     """
-    table = workflow_table()
-    if table is None:
+    found = lookup_workflow(request.workflow_id)
+    if not found.registry_readable:
         return failure(
             NukeDescribeWorkflowResultFailure,
             attempted=f"to describe workflow '{request.workflow_id}'",
@@ -69,8 +69,8 @@ def handle_describe_workflow(
             workflow_id=request.workflow_id,
         )
 
-    entry = table.get(request.workflow_id)
-    if not isinstance(entry, dict):
+    entry = found.entry
+    if entry is None:
         return failure(
             NukeDescribeWorkflowResultFailure,
             attempted=f"to describe workflow '{request.workflow_id}'",

--- a/nuke_host_api/parameter_values.py
+++ b/nuke_host_api/parameter_values.py
@@ -1,0 +1,96 @@
+"""Reading a loaded workflow's declared parameter values.
+
+Two verbs answer with these values: ``NukeLoadWorkflowRequest`` returns them once as part of
+handing a host everything it needs to build knobs, and ``NukeGetParameterValuesRequest``
+returns them on demand afterwards. Sharing the reader is what stops the two from disagreeing
+about what a parameter holds, or about how an unreadable one is reported.
+
+Driven by the same ``shape.workflow_shape`` that ``describe_workflow`` publishes, so what a
+host can read back is exactly the set of parameters it was told to expect.
+
+One engine request per declared parameter, deliberately, rather than the engine's own
+``GetAllNodeInfoRequest``. That request batches a node's metadata, resolution state,
+connections, and every parameter's value into one call, which reads like exactly what a bulk
+read should use. It does not fit, for three reasons found by reading ``node_manager.py``
+rather than the event's docstring:
+
+1. Its ``element_id_to_value`` is keyed by ``parameter.element_id``
+   (``NodeManager._set_param_to_value``), not by parameter name. Turning that into the
+   ``{node: {parameter: value}}`` shape these verbs promise needs a second lookup, through
+   the node's element tree, to recover the name behind each id.
+2. Its values are display-serialized: ``_set_param_to_value`` calls ``.to_dict()`` or falls
+   back to ``.__dict__`` on anything that is not a Python builtin, so an artifact instance
+   arrives as a plain dict rather than the object ``value_types.normalize_value`` inspects
+   for a ``.value`` attribute. Handing it a dict silently produces a wrong descriptor rather
+   than a wrong answer that shows up in a test.
+3. It drops a parameter whose value is ``None`` outright (``if value is not None:``), which
+   collides with the rule below that a value the engine truly holds as absent is not the same
+   thing as a parameter the engine would not answer for.
+
+``GetParameterValueRequest`` (``parameter_events.py``) has none of those problems: it hands
+back the live value alongside ``type``, the exact declared-type hint ``normalize_value`` needs
+to disambiguate a bare string, for the one parameter asked about. The cost is one engine
+request per declared parameter, and a workflow's declared surface is knobs, not hundreds of
+them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultSuccess,
+)
+
+from nuke_host_api import engine, shape
+from nuke_host_api.protocol import ParameterSection
+from nuke_host_api.value_types import normalize_value
+
+
+def read_sections(
+    declared_shape: dict, sections: list[str]
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[dict[str, str]]]:
+    """Read the requested sides of a loaded workflow's shape.
+
+    Returns start-flow values, end-flow values, and every parameter the engine would not
+    answer for, tagged with the section it came from. A section not asked for comes back
+    empty rather than absent, so a caller never has to distinguish a missing key from an
+    empty one.
+    """
+    inputs: dict[str, dict[str, Any]] = {}
+    outputs: dict[str, dict[str, Any]] = {}
+    unavailable: list[dict[str, str]] = []
+
+    if ParameterSection.INPUTS in sections:
+        inputs, missing = read_section(declared_shape.get("inputs"))
+        unavailable.extend({"section": ParameterSection.INPUTS, **entry} for entry in missing)
+    if ParameterSection.OUTPUTS in sections:
+        outputs, missing = read_section(declared_shape.get("outputs"))
+        unavailable.extend({"section": ParameterSection.OUTPUTS, **entry} for entry in missing)
+
+    return inputs, outputs, unavailable
+
+
+def read_section(section: object) -> tuple[dict[str, dict[str, Any]], list[dict[str, str]]]:
+    """Read one shape section, reporting what the engine would not answer for.
+
+    Omitting an unreadable parameter would read to a host as an empty knob rather than one it
+    could not fetch, so every miss is reported in the second return value instead.
+    """
+    values: dict[str, dict[str, Any]] = {}
+    missing: list[dict[str, str]] = []
+
+    for declared in shape.declared_parameters(section):
+        attempt = engine.request(
+            GetParameterValueRequest(node_name=declared["node"], parameter_name=declared["parameter"]),
+            GetParameterValueResultSuccess,
+        )
+        if attempt.value is None:
+            missing.append({"node": declared["node"], "parameter": declared["parameter"], "reason": attempt.details})
+            continue
+        values.setdefault(declared["node"], {})[declared["parameter"]] = normalize_value(
+            attempt.value.value, attempt.value.type
+        )
+
+    return values, missing

--- a/nuke_host_api/protocol.py
+++ b/nuke_host_api/protocol.py
@@ -28,6 +28,28 @@ Bumps the version:
 binaries in service for years, so entries leave this list on a stated schedule and
 not before.
 
+How a verb is addressed
+-----------------------
+
+Two kinds of verb, and a host must know which kind it is holding.
+
+*Registry-addressed* verbs name a ``workflow_id`` and read the engine's workflow registry:
+``NukeListWorkflowsRequest`` and ``NukeDescribeWorkflowRequest``. They report what a workflow
+declares, so they answer for any registered workflow whether or not it is loaded, and they
+change no engine state.
+
+*Loaded-state-addressed* verbs answer for whatever graph the engine currently holds:
+``NukeGetParameterValuesRequest``, ``NukeGetExecutionStateRequest``,
+``NukeCancelExecutionRequest``, and ``NukeExecuteWorkflowRequest``. None of them takes a
+``workflow_id`` to select with, because there is nothing to select from: a parameter's live
+value exists on a loaded node, and a flow can only be started or cancelled where it is.
+
+``NukeLoadWorkflowRequest`` is the one verb that moves a workflow from the first group into
+the second, and the only verb that changes which workflow is loaded. That transition is
+destructive: the engine clears all object state to load a graph, discarding whatever was
+loaded before, including a graph an editor user had open. So a host calls it deliberately,
+rather than getting it as a side effect of asking for something else.
+
 One rename happened without a version bump: ``ExecutionState``'s ``SUCCEEDED`` became
 ``COMPLETED``, both a rename and a meaning change, which the rule above says should bump
 the version. It did not, because it happened before this protocol's first release: no
@@ -40,7 +62,14 @@ version yet. A third change was a pure rename: every ``Port`` in this surface be
 ``PortSection`` is ``ParameterSection``. The engine calls these parameters, the editor
 already uses "port" for the connection anchor drawn on one, and the second word bought no
 decoupling: a descriptor's keys were always ``node`` and ``parameter``. The section strings
-``inputs`` and ``outputs`` did not change. None of the three is a precedent for a version
+``inputs`` and ``outputs`` did not change. A fourth change was a change of meaning:
+``NukeExecuteWorkflowRequest.workflow_id`` was required and named the workflow to load and
+run; it is now optional and names the workflow a host believes is already loaded. Loading
+moved to ``NukeLoadWorkflowRequest``, so execute selects nothing and a mismatched id is
+refused rather than honoured. A host that keeps sending the id it loaded sees the same
+behaviour, which is why this is not a removal, but the field means something else than it did
+and that alone would bump the version after the first compiled plugin. None of the four is a
+precedent for a version
 that has shipped. The actual rule for this file, until the day a plugin is compiled against
 ``PROTOCOL_VERSION`` 1, is: a removal or rename here is free before the first compiled
 plugin, and MUST bump the version after it. Read every entry above under that rule, not as
@@ -62,6 +91,7 @@ class Verb:
     CONNECT = "NukeConnectRequest"
     LIST_WORKFLOWS = "NukeListWorkflowsRequest"
     DESCRIBE_WORKFLOW = "NukeDescribeWorkflowRequest"
+    LOAD_WORKFLOW = "NukeLoadWorkflowRequest"
     EXECUTE_WORKFLOW = "NukeExecuteWorkflowRequest"
     GET_EXECUTION_STATE = "NukeGetExecutionStateRequest"
     GET_PARAMETER_VALUES = "NukeGetParameterValuesRequest"

--- a/nuke_nodes/nuke_library_advanced.py
+++ b/nuke_nodes/nuke_library_advanced.py
@@ -28,6 +28,7 @@ logger = logging.getLogger("griptape_nodes")
 # reads as belonging to this library rather than picking a generic Lucide glyph.
 PUBLISH_TARGET_ICON = "logos/nuke.png"
 
+
 def _publish_workflow_request_handler(request: RequestPayload) -> ResultPayload:
     if not isinstance(request, PublishWorkflowRequest):
         msg = f"Expected PublishWorkflowRequest, got {type(request).__name__}"

--- a/tests/integration/test_host_api.py
+++ b/tests/integration/test_host_api.py
@@ -1,10 +1,13 @@
 """Live smoke tests for the Nuke host API, run against a real engine over local_socket.
 
-Covers the four capabilities a host needs, in the order a plugin performs them:
-discovery, connect, interrogate the start and end flow, execute. Everything the unit
-suite proves with mocks is proved here against the real engine instead, because the unit
-suite cannot catch a wrong frame envelope, a workflow_shape that arrives as a JSON string,
-or a notification that never gets pushed.
+Covers the capabilities a host needs, in the order a plugin performs them: discovery,
+connect, interrogate the start and end flow, load, execute. Everything the unit suite proves
+with mocks is proved here against the real engine instead, because the unit suite cannot catch
+a wrong frame envelope, a workflow_shape that arrives as a JSON string, or a notification that
+never gets pushed.
+
+Every execution test loads first. Execute starts the loaded graph and loads nothing, so a test
+that skipped the load would run whatever the last test or an editor user left behind.
 
 Prerequisites, and the tests say so when they are missing rather than passing quietly:
 
@@ -124,6 +127,20 @@ def _smoke_workflow_id(client: HostClient) -> str:
     return str(workflows[0]["id"])
 
 
+def _load_smoke_workflow(client: HostClient) -> dict[str, Any]:
+    """Load the smoke workflow and hand back the reply body.
+
+    Every execution test starts here, because execute no longer loads: it starts whatever the
+    engine holds, so a test that did not load would assert against a graph it did not choose.
+    """
+    workflow_id = _smoke_workflow_id(client)
+    reply = client.request(Verb.LOAD_WORKFLOW, {"workflow_id": workflow_id})
+    assert succeeded(reply), f"load failed: {detail_of(reply)}"
+    body = result_of(reply)
+    assert body["workflow_id"] == workflow_id
+    return body
+
+
 # 1. Engine discovery
 
 
@@ -232,7 +249,63 @@ class TestDescribe:
         assert detail_of(reply), "a failure must carry a message an artist can read"
 
 
-# 4. Execute
+# 4. Load
+
+
+class TestLoad:
+    def test_loading_returns_declarations_and_current_values_in_one_reply(self, client: HostClient) -> None:
+        """The reason the verb exists: one round trip is enough to build and initialize knobs.
+
+        Also the assertion the mocked suite cannot make, since these values come off a real
+        graph the engine actually built rather than a fake's canned answer.
+        """
+        body = _load_smoke_workflow(client)
+
+        assert body["name"]
+        assert body["inputs"] or body["outputs"], "a runnable workflow declares parameters"
+        for declared in body["inputs"]:
+            value = body["input_values"].get(declared["node"], {}).get(declared["parameter"])
+            assert value is not None, f"{declared['name']} was declared but no value came back for it"
+            assert value["value_type"] in VALUE_TYPES
+        assert body["unavailable"] == [], f"every declared parameter should have answered: {body['unavailable']}"
+
+    def test_what_load_declares_is_what_describe_declares(self, client: HostClient) -> None:
+        """Two verbs publishing the same parameters must not disagree about them."""
+        workflow_id = _smoke_workflow_id(client)
+        described = result_of(client.request(Verb.DESCRIBE_WORKFLOW, {"workflow_id": workflow_id}))
+        loaded = _load_smoke_workflow(client)
+
+        for side in ("inputs", "outputs"):
+            assert [declared["name"] for declared in loaded[side]] == [
+                declared["name"] for declared in described[side]
+            ], f"load and describe disagree about {side}"
+
+    def test_what_load_reads_is_what_the_bulk_read_verb_reads(self, client: HostClient) -> None:
+        """Both go through one reader, so a host may cache either and get the same answer."""
+        loaded = _load_smoke_workflow(client)
+        read = result_of(client.request(Verb.GET_PARAMETER_VALUES))
+
+        assert loaded["input_values"] == read["inputs"]
+        assert loaded["output_values"] == read["outputs"]
+
+    def test_an_unknown_workflow_id_fails_without_disturbing_what_is_loaded(self, client: HostClient) -> None:
+        """Loading clears all object state, so a refusal must happen before it does."""
+        loaded = _load_smoke_workflow(client)
+
+        reply = client.request(Verb.LOAD_WORKFLOW, {"workflow_id": "does-not-exist"})
+        assert not succeeded(reply)
+        assert detail_of(reply), "a failure must carry a message an artist can read"
+
+        state = result_of(client.request(Verb.GET_EXECUTION_STATE))
+        assert state["workflow_id"] == loaded["workflow_id"], "a refused load discarded the loaded graph"
+
+    def test_a_request_naming_neither_a_workflow_nor_a_file_is_refused(self, client: HostClient) -> None:
+        reply = client.request(Verb.LOAD_WORKFLOW, {})
+        assert not succeeded(reply)
+        assert detail_of(reply)
+
+
+# 5. Execute
 
 
 class TestExecute:
@@ -245,7 +318,7 @@ class TestExecute:
 
         The fixture has already connected, which is what installs the bridge.
         """
-        workflow_id = _smoke_workflow_id(client)
+        workflow_id = _load_smoke_workflow(client)["workflow_id"]
         started = client.request(Verb.EXECUTE_WORKFLOW, {"workflow_id": workflow_id})
         assert succeeded(started), f"execute failed: {detail_of(started)}"
         assert result_of(started)["rejected_inputs"] == [], "no inputs were sent, so none may be rejected"
@@ -271,7 +344,7 @@ class TestExecute:
         for exec_in like any other parameter, and a host that received it would be told
         control flow is GTText, contradicting describe_workflow which never lists it.
         """
-        workflow_id = _smoke_workflow_id(client)
+        workflow_id = _load_smoke_workflow(client)["workflow_id"]
         assert succeeded(client.request(Verb.EXECUTE_WORKFLOW, {"workflow_id": workflow_id}))
         client.drain(NOTIFICATION_WINDOW_S)
 
@@ -296,8 +369,8 @@ class TestExecute:
         What it returns must be the parameters describe promised, not whichever node control flow
         happened to end on.
         """
-        workflow_id = _smoke_workflow_id(client)
-        described = result_of(client.request(Verb.DESCRIBE_WORKFLOW, {"workflow_id": workflow_id}))
+        loaded = _load_smoke_workflow(client)
+        workflow_id = loaded["workflow_id"]
         assert succeeded(client.request(Verb.EXECUTE_WORKFLOW, {"workflow_id": workflow_id}))
         client.drain(NOTIFICATION_WINDOW_S)
 
@@ -306,7 +379,7 @@ class TestExecute:
         body = result_of(reply)
         assert body["workflow_id"] == workflow_id
 
-        promised = {declared["node"] for declared in described["outputs"]}
+        promised = {declared["node"] for declared in loaded["outputs"]}
         assert promised <= set(body["outputs"]), (
             f"describe promised outputs on {sorted(promised)} but parameter values returned {sorted(body['outputs'])}"
         )
@@ -321,7 +394,7 @@ class TestExecute:
         Skips rather than fails when the first run finishes too fast to race, since that is a
         property of the chosen workflow and not of the guard.
         """
-        workflow_id = _smoke_workflow_id(client)
+        workflow_id = _load_smoke_workflow(client)["workflow_id"]
         assert succeeded(client.request(Verb.EXECUTE_WORKFLOW, {"workflow_id": workflow_id}))
 
         state = result_of(client.request(Verb.GET_EXECUTION_STATE))
@@ -332,9 +405,25 @@ class TestExecute:
         assert not succeeded(second), "a second run must be refused, not allowed to displace the first"
         assert "already executing" in detail_of(second).lower()
 
+    def test_no_workflow_id_runs_whatever_is_loaded(self, client: HostClient) -> None:
+        """A host driving a graph it did not load itself has no id to send."""
+        workflow_id = _load_smoke_workflow(client)["workflow_id"]
+
+        reply = client.request(Verb.EXECUTE_WORKFLOW, {})
+        assert succeeded(reply), f"execute without an id failed: {detail_of(reply)}"
+        assert result_of(reply)["workflow_id"] == workflow_id, "the reply must name what actually ran"
+
+    def test_a_workflow_id_other_than_the_loaded_one_is_refused(self, client: HostClient) -> None:
+        """Execute loads nothing, so the alternative is silently running the wrong workflow."""
+        _load_smoke_workflow(client)
+
+        reply = client.request(Verb.EXECUTE_WORKFLOW, {"workflow_id": "some-other-workflow"})
+        assert not succeeded(reply)
+        assert "NukeLoadWorkflowRequest" in detail_of(reply), "a refusal must say what to do next"
+
     def test_an_undeclared_input_is_rejected_and_never_reaches_the_graph(self, client: HostClient) -> None:
         """The engine would set a parameter on any node, and this transport authenticates nobody."""
-        workflow_id = _smoke_workflow_id(client)
+        workflow_id = _load_smoke_workflow(client)["workflow_id"]
         reply = client.request(
             Verb.EXECUTE_WORKFLOW,
             {"workflow_id": workflow_id, "inputs": {"No Such Node": {"api_key": "stolen"}}},
@@ -350,10 +439,10 @@ class TestExecute:
         ]
 
     def test_a_declared_input_is_applied(self, client: HostClient) -> None:
-        workflow_id = _smoke_workflow_id(client)
-        described = result_of(client.request(Verb.DESCRIBE_WORKFLOW, {"workflow_id": workflow_id}))
+        loaded = _load_smoke_workflow(client)
+        workflow_id = loaded["workflow_id"]
         text_parameters = [
-            declared for declared in described["inputs"] if declared["type"] == "GTText" and declared["settable"]
+            declared for declared in loaded["inputs"] if declared["type"] == "GTText" and declared["settable"]
         ]
         if not text_parameters:
             pytest.skip(f"workflow {workflow_id!r} has no settable text input to drive")

--- a/tests/unit/host_api_fakes.py
+++ b/tests/unit/host_api_fakes.py
@@ -12,6 +12,10 @@ from griptape_nodes.retained_mode.events.app_events import (
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
 )
+from griptape_nodes.retained_mode.events.context_events import (
+    GetWorkflowContextRequest,
+    GetWorkflowContextSuccess,
+)
 from griptape_nodes.retained_mode.events.execution_events import (
     GetFlowStateRequest,
     GetFlowStateResultSuccess,
@@ -23,10 +27,14 @@ from griptape_nodes.retained_mode.events.flow_events import (
     GetTopLevelFlowResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultSuccess,
     SetParameterValueRequest,
     SetParameterValueResultSuccess,
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowRequest,
+    ImportWorkflowResultSuccess,
     ListAllWorkflowsRequest,
     ListAllWorkflowsResultSuccess,
     RunWorkflowFromRegistryRequest,
@@ -110,22 +118,65 @@ def use_engine(monkeypatch: pytest.MonkeyPatch, responses: dict[type, Any] | Non
     return fake
 
 
+def respond_to_get_value(request: GetParameterValueRequest) -> Any:
+    """Answer a value read for every data parameter in ``SHAPE``.
+
+    Raises on anything else, so a verb that reads a parameter it was never told about fails
+    loudly rather than being handed a plausible value.
+    """
+    answers: dict[str, tuple[str, Any]] = {
+        "topic": ("str", "a quiet harbour at dusk"),
+        "plate": ("ImageUrlArtifact", None),
+        "was_successful": ("bool", True),
+        "mixed_audio": ("AudioUrlArtifact", "http://x/audio.mp3"),
+    }
+    if request.parameter_name not in answers:
+        msg = f"no fake response configured for parameter '{request.parameter_name}'"
+        raise AssertionError(msg)
+    declared_type, value = answers[request.parameter_name]
+    return GetParameterValueResultSuccess(
+        input_types=[declared_type],
+        type=declared_type,
+        output_type=declared_type,
+        value=value,
+        result_details="ok",
+    )
+
+
 def execute_responses(overrides: dict[type, Any] | None = None) -> dict[type, Any]:
     """Engine responses for a clean execute, so each test overrides only what it is about.
 
-    Execute preflights twice before it loads anything: once to refuse starting over a run in
-    progress, once to learn which parameters it may set.
+    Execute preflights twice before it touches an input: once to refuse starting over a run in
+    progress, once to learn which workflow is loaded and which parameters it may set.
     """
     responses: dict[type, Any] = {
         ListAllWorkflowsRequest: ListAllWorkflowsResultSuccess(workflows=WORKFLOW_TABLE, result_details="ok"),
         GetFlowStateRequest: IDLE_FLOW,
-        RunWorkflowFromRegistryRequest: RunWorkflowFromRegistryResultSuccess(result_details="loaded"),
+        GetWorkflowContextRequest: GetWorkflowContextSuccess(workflow_name="wf1", result_details="ok"),
         SetParameterValueRequest: lambda req: SetParameterValueResultSuccess(
             finalized_value=req.value, data_type="str", result_details="set"
         ),
         GetTopLevelFlowRequest: GetTopLevelFlowResultSuccess(flow_name="main", result_details="ok"),
         StartFlowRequest: StartFlowResultSuccess(result_details="started"),
         GetEngineVersionRequest: ENGINE_VERSION,
+    }
+    responses.update(overrides or {})
+    return responses
+
+
+def load_responses(overrides: dict[type, Any] | None = None) -> dict[type, Any]:
+    """Engine responses for a clean load, including the per-parameter value reads.
+
+    Every declared parameter answers, so a test about an unreadable one overrides
+    ``GetParameterValueRequest`` with a callable that refuses the parameter it cares about.
+    """
+    responses: dict[type, Any] = {
+        GetFlowStateRequest: IDLE_FLOW,
+        GetTopLevelFlowRequest: GetTopLevelFlowResultSuccess(flow_name="main", result_details="ok"),
+        ListAllWorkflowsRequest: ListAllWorkflowsResultSuccess(workflows=WORKFLOW_TABLE, result_details="ok"),
+        ImportWorkflowRequest: ImportWorkflowResultSuccess(workflow_name="wf1", result_details="imported"),
+        RunWorkflowFromRegistryRequest: RunWorkflowFromRegistryResultSuccess(result_details="loaded"),
+        GetParameterValueRequest: respond_to_get_value,
     }
     responses.update(overrides or {})
     return responses

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -153,6 +153,53 @@ class TestWorkflowEntry:
         assert engine.workflow_entry("wf1") is None
 
 
+class TestLookupWorkflow:
+    """An unreadable registry is worth retrying and an unknown id never is.
+
+    Two verbs word different failures for the two, so the split lives here rather than in
+    each of them.
+    """
+
+    def test_a_known_id_returns_its_entry_from_a_readable_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(
+            monkeypatch,
+            {ListAllWorkflowsRequest: ListAllWorkflowsResultSuccess(workflows=WORKFLOW_TABLE, result_details="ok")},
+        )
+        found = engine.lookup_workflow("wf1")
+        assert found.entry == WORKFLOW_TABLE["wf1"]
+        assert found.registry_readable is True
+
+    def test_an_unknown_id_in_a_readable_registry_is_not_an_unreadable_registry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        use_engine(
+            monkeypatch,
+            {ListAllWorkflowsRequest: ListAllWorkflowsResultSuccess(workflows=WORKFLOW_TABLE, result_details="ok")},
+        )
+        found = engine.lookup_workflow("ghost")
+        assert found.entry is None
+        assert found.registry_readable is True
+
+    def test_an_unreadable_registry_says_so(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(monkeypatch, {ListAllWorkflowsRequest: ListAllWorkflowsResultFailure(result_details="gone")})
+        found = engine.lookup_workflow("wf1")
+        assert found.entry is None
+        assert found.registry_readable is False
+
+    def test_a_malformed_entry_reads_as_an_unknown_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(
+            monkeypatch,
+            {
+                ListAllWorkflowsRequest: ListAllWorkflowsResultSuccess(
+                    workflows={"wf1": "not a dict"}, result_details="ok"
+                )
+            },
+        )
+        found = engine.lookup_workflow("wf1")
+        assert found.entry is None
+        assert found.registry_readable is True
+
+
 class TestIsRunning:
     """One predicate for the execute guard and the state report, so they cannot disagree."""
 

--- a/tests/unit/test_handlers_execution.py
+++ b/tests/unit/test_handlers_execution.py
@@ -29,7 +29,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
     RunWorkflowFromRegistryRequest,
-    RunWorkflowFromRegistryResultFailure,
 )
 
 from nuke_host_api import shape
@@ -50,10 +49,11 @@ from nuke_host_api.protocol import ExecutionState
 from tests.unit.host_api_fakes import execute_responses, use_engine
 
 NOTHING_LOADED = {GetTopLevelFlowRequest: GetTopLevelFlowResultSuccess(flow_name=None, result_details="ok")}
+NO_WORKFLOW_IN_CONTEXT = {GetWorkflowContextRequest: GetWorkflowContextSuccess(workflow_name="", result_details="ok")}
 
 
 class TestExecuteWorkflow:
-    def test_a_successful_run_calls_the_engine_in_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_a_successful_run_applies_inputs_then_starts_the_loaded_flow(self, monkeypatch: pytest.MonkeyPatch) -> None:
         engine = use_engine(monkeypatch, execute_responses())
 
         result = handle_execute_workflow(
@@ -66,17 +66,55 @@ class TestExecuteWorkflow:
         assert result.rejected_inputs == []
 
         request_types = [type(request) for request in engine.requests]
-        assert request_types.index(RunWorkflowFromRegistryRequest) < request_types.index(SetParameterValueRequest)
         assert request_types.index(SetParameterValueRequest) < request_types.index(StartFlowRequest)
 
-        load_request = next(r for r in engine.requests if isinstance(r, RunWorkflowFromRegistryRequest))
-        assert load_request.run_with_clean_slate is True
+    def test_loads_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loading is NukeLoadWorkflowRequest's job, and it clears all object state.
+
+        Doing it here would discard the graph whose inputs a host has been setting, and would
+        make every execute pay for a rebuild of a graph that is already loaded.
+        """
+        engine = use_engine(monkeypatch, execute_responses())
+
+        result = handle_execute_workflow(NukeExecuteWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeExecuteWorkflowResultSuccess)
+        assert not any(isinstance(request, RunWorkflowFromRegistryRequest) for request in engine.requests)
+
+    def test_no_workflow_id_runs_whatever_is_loaded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A host driving a graph an editor user loaded has no id to send."""
+        use_engine(monkeypatch, execute_responses())
+
+        result = handle_execute_workflow(NukeExecuteWorkflowRequest())
+
+        assert isinstance(result, NukeExecuteWorkflowResultSuccess)
+        assert result.workflow_id == "wf1", "the reply must name what actually ran"
+
+    def test_a_workflow_id_that_is_not_the_loaded_one_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Honouring it would put loading back inside execute; ignoring it would run the wrong graph."""
+        engine = use_engine(monkeypatch, execute_responses())
+
+        result = handle_execute_workflow(NukeExecuteWorkflowRequest(workflow_id="wf2"))
+
+        assert isinstance(result, NukeExecuteWorkflowResultFailure)
+        assert "wf1" in str(result.result_details) and "wf2" in str(result.result_details)
+        assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
+        assert not any(isinstance(request, SetParameterValueRequest) for request in engine.requests)
+
+    def test_fails_when_nothing_is_loaded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        engine = use_engine(monkeypatch, execute_responses(NO_WORKFLOW_IN_CONTEXT))
+
+        result = handle_execute_workflow(NukeExecuteWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeExecuteWorkflowResultFailure)
+        assert "NukeLoadWorkflowRequest" in str(result.result_details), "tell a host what to do next"
+        assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
 
     def test_refuses_to_start_over_a_run_already_in_progress(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Loading a second graph would discard the first mid-flight.
+        """With no execution id in the engine's events, a host could not tell two runs apart.
 
-        With no execution id in the engine's events, a host could not tell which run the
-        following notifications belonged to, nor which one a cancel would stop.
+        It could not say which run the notifications that followed belonged to, nor which one a
+        cancel would stop.
         """
         engine = use_engine(
             monkeypatch,
@@ -92,8 +130,8 @@ class TestExecuteWorkflow:
         result = handle_execute_workflow(NukeExecuteWorkflowRequest(workflow_id="wf1"))
 
         assert isinstance(result, NukeExecuteWorkflowResultFailure)
-        assert not any(isinstance(request, RunWorkflowFromRegistryRequest) for request in engine.requests), (
-            "must not load a graph over a running one"
+        assert not any(isinstance(request, SetParameterValueRequest) for request in engine.requests), (
+            "must not touch inputs of a run it refused to start"
         )
         assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
 
@@ -149,36 +187,6 @@ class TestExecuteWorkflow:
         assert isinstance(result, NukeExecuteWorkflowResultSuccess)
         assert result.applied_inputs == [{"node": "Start Flow", "parameter": "topic"}]
 
-    def test_short_circuits_when_the_engine_cannot_load_the_workflow(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        engine = use_engine(
-            monkeypatch,
-            execute_responses(
-                {RunWorkflowFromRegistryRequest: RunWorkflowFromRegistryResultFailure(result_details="not found")}
-            ),
-        )
-
-        result = handle_execute_workflow(NukeExecuteWorkflowRequest(workflow_id="ghost"))
-
-        assert isinstance(result, NukeExecuteWorkflowResultFailure)
-        assert not any(isinstance(request, SetParameterValueRequest) for request in engine.requests), (
-            "must not touch inputs of a workflow it never loaded"
-        )
-        assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
-
-    def test_the_engines_own_reason_reaches_the_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A host cannot see the engine's result, so a refusal it never quotes is lost."""
-        use_engine(
-            monkeypatch,
-            execute_responses(
-                {RunWorkflowFromRegistryRequest: RunWorkflowFromRegistryResultFailure(result_details="file is missing")}
-            ),
-        )
-
-        result = handle_execute_workflow(NukeExecuteWorkflowRequest(workflow_id="wf1"))
-
-        assert isinstance(result, NukeExecuteWorkflowResultFailure)
-        assert "file is missing" in str(result.result_details)
-
     def test_short_circuits_when_the_loaded_workflow_has_no_top_level_flow(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -189,7 +197,10 @@ class TestExecuteWorkflow:
         assert isinstance(result, NukeExecuteWorkflowResultFailure)
         assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
 
-    def test_short_circuits_when_the_engine_refuses_to_start(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_the_engines_own_reason_for_refusing_to_start_reaches_the_host(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A host cannot see the engine's result, so a refusal it never quotes is lost."""
         use_engine(
             monkeypatch,
             execute_responses(
@@ -200,6 +211,7 @@ class TestExecuteWorkflow:
         result = handle_execute_workflow(NukeExecuteWorkflowRequest(workflow_id="wf1"))
 
         assert isinstance(result, NukeExecuteWorkflowResultFailure)
+        assert "validation failed" in str(result.result_details)
 
 
 class TestApplyInputs:

--- a/tests/unit/test_handlers_execution.py
+++ b/tests/unit/test_handlers_execution.py
@@ -28,6 +28,8 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     SetParameterValueResultSuccess,
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
+    ListAllWorkflowsRequest,
+    ListAllWorkflowsResultSuccess,
     RunWorkflowFromRegistryRequest,
 )
 
@@ -46,10 +48,21 @@ from nuke_host_api.events import (
 from nuke_host_api.handlers import handle_cancel_execution, handle_execute_workflow, handle_get_execution_state
 from nuke_host_api.handlers.execution import _apply_inputs
 from nuke_host_api.protocol import ExecutionState
-from tests.unit.host_api_fakes import execute_responses, use_engine
+from tests.unit.host_api_fakes import WORKFLOW_TABLE, execute_responses, use_engine
 
 NOTHING_LOADED = {GetTopLevelFlowRequest: GetTopLevelFlowResultSuccess(flow_name=None, result_details="ok")}
 NO_WORKFLOW_IN_CONTEXT = {GetWorkflowContextRequest: GetWorkflowContextSuccess(workflow_name="", result_details="ok")}
+
+# The engine keeps the graph an editor user is working on in its registry under an "unsaved:"
+# key with no declared shape, and GetWorkflowContextRequest answers with that key.
+UNSAVED_GRAPH_LOADED = {
+    GetWorkflowContextRequest: GetWorkflowContextSuccess(
+        workflow_name="unsaved:9f0c", is_saved=False, result_details="ok"
+    ),
+    ListAllWorkflowsRequest: ListAllWorkflowsResultSuccess(
+        workflows={**WORKFLOW_TABLE, "unsaved:9f0c": {"name": "Untitled"}}, result_details="ok"
+    ),
+}
 
 
 class TestExecuteWorkflow:
@@ -163,6 +176,38 @@ class TestExecuteWorkflow:
         ]
         touched = {r.node_name for r in engine.requests if isinstance(r, SetParameterValueRequest)}
         assert touched == {"Start Flow"}
+
+    def test_inputs_sent_to_a_graph_that_declares_none_are_refused_not_rejected_one_by_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unsaved editor graph is in the registry with no shape, so nothing could be applied.
+
+        Starting anyway would report success while running the author's values, and every input
+        would come back rejected for a reason that reads like the host named the wrong
+        parameters.
+        """
+        engine = use_engine(monkeypatch, execute_responses(UNSAVED_GRAPH_LOADED))
+
+        result = handle_execute_workflow(NukeExecuteWorkflowRequest(inputs={"Start Flow": {"topic": "hello"}}))
+
+        assert isinstance(result, NukeExecuteWorkflowResultFailure)
+        assert result.workflow_id == "unsaved:9f0c"
+        assert "declares no input parameters" in str(result.result_details)
+        assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
+        assert not any(isinstance(request, SetParameterValueRequest) for request in engine.requests)
+
+    def test_a_graph_that_declares_no_inputs_still_runs_when_none_are_sent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Driving a graph an editor user opened is what an empty workflow_id is for."""
+        use_engine(monkeypatch, execute_responses(UNSAVED_GRAPH_LOADED))
+
+        result = handle_execute_workflow(NukeExecuteWorkflowRequest())
+
+        assert isinstance(result, NukeExecuteWorkflowResultSuccess)
+        assert result.workflow_id == "unsaved:9f0c"
+        assert result.applied_inputs == []
+        assert result.rejected_inputs == []
 
     def test_the_preflight_reads_parameter_identity_without_normalizing_defaults(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_handlers_execution.py
+++ b/tests/unit/test_handlers_execution.py
@@ -29,6 +29,7 @@ from griptape_nodes.retained_mode.events.parameter_events import (
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
     ListAllWorkflowsRequest,
+    ListAllWorkflowsResultFailure,
     ListAllWorkflowsResultSuccess,
     RunWorkflowFromRegistryRequest,
 )
@@ -196,6 +197,44 @@ class TestExecuteWorkflow:
         assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
         assert not any(isinstance(request, SetParameterValueRequest) for request in engine.requests)
 
+    def test_an_unreadable_registry_is_a_retryable_refusal_not_a_graph_that_declares_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both produce an empty allow-list, and only one of them is the host's problem to fix.
+
+        Telling a host that a workflow it saved "declares no input parameters" sends it down the
+        unsaved-graph recovery path for something a retry fixes.
+        """
+        engine = use_engine(
+            monkeypatch,
+            execute_responses({ListAllWorkflowsRequest: ListAllWorkflowsResultFailure(result_details="registry down")}),
+        )
+
+        result = handle_execute_workflow(
+            NukeExecuteWorkflowRequest(workflow_id="wf1", inputs={"Start Flow": {"topic": "hello"}})
+        )
+
+        assert isinstance(result, NukeExecuteWorkflowResultFailure)
+        details = str(result.result_details)
+        assert "could not read the workflow registry" in details
+        assert "Retry" in details
+        assert "declares no input parameters" not in details, "wf1 does declare one"
+        assert "save it and load it by id" not in details
+        assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
+        assert not any(isinstance(request, SetParameterValueRequest) for request in engine.requests)
+
+    def test_an_unreadable_registry_does_not_block_a_run_with_no_inputs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With nothing to check against the allow-list, the registry does not bear on the run."""
+        use_engine(
+            monkeypatch,
+            execute_responses({ListAllWorkflowsRequest: ListAllWorkflowsResultFailure(result_details="registry down")}),
+        )
+
+        result = handle_execute_workflow(NukeExecuteWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeExecuteWorkflowResultSuccess)
+        assert result.applied_inputs == []
+
     def test_a_graph_that_declares_no_inputs_still_runs_when_none_are_sent(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -208,6 +247,23 @@ class TestExecuteWorkflow:
         assert result.workflow_id == "unsaved:9f0c"
         assert result.applied_inputs == []
         assert result.rejected_inputs == []
+
+    def test_an_execution_costs_six_engine_requests_plus_one_per_applied_input(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """None of them loads, which is the whole point of the split. A rejected input costs none."""
+        engine = use_engine(monkeypatch, execute_responses())
+
+        result = handle_execute_workflow(
+            NukeExecuteWorkflowRequest(
+                workflow_id="wf1",
+                inputs={"Start Flow": {"topic": "hello"}, "Some Private Node": {"api_key": "stolen"}},
+            )
+        )
+
+        assert isinstance(result, NukeExecuteWorkflowResultSuccess)
+        assert len(engine.requests) == 6 + len(result.applied_inputs)
+        assert result.rejected_inputs != [], "a rejected input must not have cost a request"
 
     def test_the_preflight_reads_parameter_identity_without_normalizing_defaults(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_handlers_execution.py
+++ b/tests/unit/test_handlers_execution.py
@@ -248,10 +248,13 @@ class TestExecuteWorkflow:
         assert result.applied_inputs == []
         assert result.rejected_inputs == []
 
-    def test_an_execution_costs_six_engine_requests_plus_one_per_applied_input(
+    def test_an_execution_costs_six_engine_requests_plus_one_per_input_it_forwards(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """None of them loads, which is the whole point of the split. A rejected input costs none."""
+        """None of them loads, which is the whole point of the split.
+
+        Only declared pairs are forwarded, so an undeclared one is the rejection that is free.
+        """
         engine = use_engine(monkeypatch, execute_responses())
 
         result = handle_execute_workflow(
@@ -262,8 +265,61 @@ class TestExecuteWorkflow:
         )
 
         assert isinstance(result, NukeExecuteWorkflowResultSuccess)
-        assert len(engine.requests) == 6 + len(result.applied_inputs)
-        assert result.rejected_inputs != [], "a rejected input must not have cost a request"
+        forwarded = sum(isinstance(request, SetParameterValueRequest) for request in engine.requests)
+        assert forwarded == 1, "the undeclared pair must not have been forwarded"
+        assert len(engine.requests) == 6 + forwarded
+
+    def test_an_input_the_engine_refuses_has_already_cost_a_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A declared pair is forwarded before its outcome is known, so its rejection is not free.
+
+        The count is per input forwarded, not per input applied. Only the allow-list filters for
+        free.
+        """
+        engine = use_engine(
+            monkeypatch,
+            execute_responses(
+                {SetParameterValueRequest: SetParameterValueResultFailure(result_details="knob is read-only")}
+            ),
+        )
+
+        result = handle_execute_workflow(
+            NukeExecuteWorkflowRequest(workflow_id="wf1", inputs={"Start Flow": {"topic": "hello"}})
+        )
+
+        assert isinstance(result, NukeExecuteWorkflowResultSuccess)
+        assert result.applied_inputs == []
+        assert result.rejected_inputs == [{"node": "Start Flow", "parameter": "topic", "reason": "knob is read-only"}]
+        assert len(engine.requests) == 7, "six plus the one forwarded input, whatever the engine said about it"
+
+    def test_a_loaded_id_missing_from_a_readable_registry_is_not_an_unsaved_graph(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale context key over a live registry: the engine can drop an entry without popping it.
+
+        Telling a host to save a workflow that is not unsaved names a cause it cannot act on.
+        Worded as NukeGetParameterValuesRequest words the same engine state.
+        """
+        engine = use_engine(
+            monkeypatch,
+            execute_responses(
+                {
+                    ListAllWorkflowsRequest: ListAllWorkflowsResultSuccess(
+                        workflows={k: v for k, v in WORKFLOW_TABLE.items() if k != "wf1"}, result_details="ok"
+                    )
+                }
+            ),
+        )
+
+        result = handle_execute_workflow(
+            NukeExecuteWorkflowRequest(workflow_id="wf1", inputs={"Start Flow": {"topic": "hello"}})
+        )
+
+        assert isinstance(result, NukeExecuteWorkflowResultFailure)
+        details = str(result.result_details)
+        assert "no longer in the registry" in details
+        assert "unsaved" not in details
+        assert not any(isinstance(request, StartFlowRequest) for request in engine.requests)
+        assert not any(isinstance(request, SetParameterValueRequest) for request in engine.requests)
 
     def test_the_preflight_reads_parameter_identity_without_normalizing_defaults(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_handlers_load.py
+++ b/tests/unit/test_handlers_load.py
@@ -211,6 +211,79 @@ class TestLoadWorkflow:
             "must not read values off a graph it never loaded"
         )
 
+    def test_a_load_the_engine_refuses_reports_that_the_previous_graph_is_already_gone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The engine clears all object state before it builds the graph, so this failure costs.
+
+        A host that read the refusal as "nothing changed" would keep showing knobs for a graph
+        the engine no longer holds, and the artist whose comp was discarded gets no signal.
+        """
+        use_engine(
+            monkeypatch,
+            load_responses(
+                {RunWorkflowFromRegistryRequest: RunWorkflowFromRegistryResultFailure(result_details="library missing")}
+            ),
+        )
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert result.engine_state_cleared is True
+        assert "cleared" in str(result.result_details)
+
+    @pytest.mark.parametrize(
+        ("request_payload", "overrides"),
+        [
+            (NukeLoadWorkflowRequest(workflow_id="ghost"), {}),
+            (NukeLoadWorkflowRequest(), {}),
+            (NukeLoadWorkflowRequest(workflow_id="wf1", file_path="/shots/other.py"), {}),
+            (NukeLoadWorkflowRequest(workflow_id="wf1"), {GetFlowStateRequest: BUSY_FLOW}),
+            (
+                NukeLoadWorkflowRequest(file_path="/tmp/notes.txt"),
+                {ImportWorkflowRequest: ImportWorkflowResultFailure(result_details="not a workflow file")},
+            ),
+            (
+                NukeLoadWorkflowRequest(workflow_id="wf1"),
+                {ListAllWorkflowsRequest: ListAllWorkflowsResultFailure(result_details="down")},
+            ),
+        ],
+    )
+    def test_a_refusal_decided_before_the_engine_load_reports_nothing_cleared(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        request_payload: NukeLoadWorkflowRequest,
+        overrides: dict[type, Any],
+    ) -> None:
+        """The flag is a host's recovery signal, so it must be false for every cheap refusal."""
+        use_engine(monkeypatch, load_responses(overrides))
+
+        result = handle_load_workflow(request_payload)
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert result.engine_state_cleared is False
+
+    def test_a_clean_load_costs_four_engine_requests_plus_one_per_declared_parameter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cost scales with the workflow, which is why no fixed number is documented."""
+        engine = use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        declared = len(result.inputs) + len(result.outputs)
+        assert len(engine.requests) == 4 + declared
+        assert sum(isinstance(r, GetParameterValueRequest) for r in engine.requests) == declared
+
+    def test_a_file_path_load_costs_one_engine_request_more(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        engine = use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(file_path="/shots/sq010/comp.py"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        assert len(engine.requests) == 5 + len(result.inputs) + len(result.outputs)
+
     def test_a_parameter_the_engine_will_not_answer_for_is_reported_not_omitted(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_handlers_load.py
+++ b/tests/unit/test_handlers_load.py
@@ -1,0 +1,258 @@
+"""Tests for the load verb.
+
+Loading clears all object state, so most of these assert what the handler does *not* do: a
+request that cannot succeed must not reach ``RunWorkflowFromRegistryRequest``, because
+whatever the engine had loaded before, including a graph an editor user has open, is gone the
+moment it does.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from griptape_nodes.retained_mode.events.execution_events import (
+    GetFlowStateRequest,
+    GetFlowStateResultSuccess,
+)
+from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultFailure,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowRequest,
+    ImportWorkflowResultFailure,
+    ImportWorkflowResultSuccess,
+    ListAllWorkflowsRequest,
+    ListAllWorkflowsResultFailure,
+    ListAllWorkflowsResultSuccess,
+    RunWorkflowFromRegistryRequest,
+    RunWorkflowFromRegistryResultFailure,
+)
+
+from nuke_host_api.events import (
+    NukeLoadWorkflowRequest,
+    NukeLoadWorkflowResultFailure,
+    NukeLoadWorkflowResultSuccess,
+)
+from nuke_host_api.handlers import handle_load_workflow
+from nuke_host_api.protocol import ParameterSection, ValueType
+from tests.unit.host_api_fakes import WORKFLOW_TABLE, load_responses, respond_to_get_value, use_engine
+
+BUSY_FLOW = GetFlowStateResultSuccess(
+    control_nodes=["C1"], resolving_nodes=["N1"], involved_nodes=["N1"], result_details="busy"
+)
+
+
+def _loaded(engine: Any) -> bool:
+    return any(isinstance(request, RunWorkflowFromRegistryRequest) for request in engine.requests)
+
+
+class TestLoadWorkflow:
+    def test_a_workflow_id_is_loaded_with_a_clean_slate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        engine = use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        assert result.workflow_id == "wf1"
+        assert result.name == "WF One"
+        load = next(r for r in engine.requests if isinstance(r, RunWorkflowFromRegistryRequest))
+        assert load.workflow_name == "wf1"
+        assert load.run_with_clean_slate is True
+
+    def test_declared_parameters_match_what_describe_publishes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A host must not have to call describe as well, nor learn a second descriptor shape."""
+        use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        assert {declared["parameter"] for declared in result.inputs} == {"topic", "plate"}
+        assert {declared["parameter"] for declared in result.outputs} == {"was_successful", "mixed_audio"}
+        assert set(result.inputs[0]) == {"node", "parameter", "name", "type", "default", "tooltip", "settable"}
+
+    def test_current_values_come_back_for_both_sides(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The whole point of the verb: knobs can be built and initialized from one reply."""
+        use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        assert result.input_values["Start Flow"]["topic"]["value_type"] == ValueType.TEXT
+        assert result.output_values["End Flow"]["was_successful"]["value_type"] == ValueType.BOOL
+        assert result.unavailable == []
+
+    def test_values_use_the_same_descriptor_shape_as_a_declared_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        keys = {"value_type", "sources", "colorspace", "engine_type"}
+        assert set(result.input_values["Start Flow"]["topic"]) == keys
+        assert set(result.inputs[0]["default"]) == keys
+
+    def test_control_parameters_reach_neither_the_declarations_nor_the_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        assert "exec_out" not in {declared["parameter"] for declared in result.inputs}
+        assert "exec_out" not in result.input_values.get("Start Flow", {})
+        assert "exec_in" not in result.output_values.get("End Flow", {})
+
+    def test_a_file_path_is_imported_and_the_resolved_id_is_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A host that picked a file has no id to send, so the reply is where it learns one."""
+        engine = use_engine(
+            monkeypatch,
+            load_responses(
+                {ImportWorkflowRequest: ImportWorkflowResultSuccess(workflow_name="wf1", result_details="imported")}
+            ),
+        )
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(file_path="/shots/sq010/comp.py"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        assert result.workflow_id == "wf1"
+        imported = next(r for r in engine.requests if isinstance(r, ImportWorkflowRequest))
+        assert imported.file_path == "/shots/sq010/comp.py"
+
+    def test_a_file_the_engine_cannot_import_is_refused_before_anything_is_cleared(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        engine = use_engine(
+            monkeypatch,
+            load_responses({ImportWorkflowRequest: ImportWorkflowResultFailure(result_details="not a workflow file")}),
+        )
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(file_path="/tmp/notes.txt"))
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert "not a workflow file" in str(result.result_details)
+        assert not _loaded(engine)
+
+    def test_both_a_workflow_id_and_a_file_path_is_refused_without_touching_the_engine(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """They can name different workflows, and guessing which one the host meant is worse."""
+        engine = use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1", file_path="/shots/other.py"))
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert engine.requests == []
+
+    def test_an_empty_request_is_refused_without_touching_the_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        engine = use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest())
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert engine.requests == []
+
+    def test_refuses_while_the_engine_is_executing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loading discards the running graph, and the host would still be told it succeeded."""
+        engine = use_engine(monkeypatch, load_responses({GetFlowStateRequest: BUSY_FLOW}))
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert not _loaded(engine)
+
+    def test_an_unknown_id_is_refused_before_the_engine_state_is_cleared(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The registry is read first for exactly this reason."""
+        engine = use_engine(monkeypatch, load_responses())
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="ghost"))
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert result.workflow_id == "ghost"
+        assert not _loaded(engine)
+
+    def test_an_unreadable_registry_is_a_different_answer_than_an_unknown_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One is worth retrying, the other never is."""
+        engine = use_engine(
+            monkeypatch, load_responses({ListAllWorkflowsRequest: ListAllWorkflowsResultFailure(result_details="down")})
+        )
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert "registry" in str(result.result_details)
+        assert not _loaded(engine)
+
+    def test_the_engines_own_reason_for_refusing_to_load_reaches_the_host(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A host cannot see the engine's result, so a refusal it never quotes is lost."""
+        engine = use_engine(
+            monkeypatch,
+            load_responses(
+                {
+                    RunWorkflowFromRegistryRequest: RunWorkflowFromRegistryResultFailure(
+                        result_details="the workflow file is missing"
+                    )
+                }
+            ),
+        )
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultFailure)
+        assert result.workflow_id == "wf1"
+        assert "the workflow file is missing" in str(result.result_details)
+        assert not any(isinstance(r, GetParameterValueRequest) for r in engine.requests), (
+            "must not read values off a graph it never loaded"
+        )
+
+    def test_a_parameter_the_engine_will_not_answer_for_is_reported_not_omitted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same rule as the bulk read verb, because both go through one reader."""
+
+        def respond(request: GetParameterValueRequest) -> Any:
+            if request.parameter_name == "topic":
+                return GetParameterValueResultFailure(result_details="node was deleted mid-read")
+            return respond_to_get_value(request)
+
+        use_engine(monkeypatch, load_responses({GetParameterValueRequest: respond}))
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="wf1"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        assert "topic" not in result.input_values.get("Start Flow", {})
+        assert result.unavailable == [
+            {
+                "section": ParameterSection.INPUTS,
+                "node": "Start Flow",
+                "parameter": "topic",
+                "reason": "node was deleted mid-read",
+            }
+        ]
+        assert {declared["parameter"] for declared in result.inputs} == {"topic", "plate"}, (
+            "an unreadable value must not remove the parameter's declaration"
+        )
+
+    def test_a_workflow_with_no_declared_shape_loads_and_reports_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The engine sends workflow_shape as null for some workflows. It is still loadable."""
+        table = {**WORKFLOW_TABLE, "shapeless": {"name": "Shapeless"}}
+        engine = use_engine(
+            monkeypatch,
+            load_responses(
+                {ListAllWorkflowsRequest: ListAllWorkflowsResultSuccess(workflows=table, result_details="ok")}
+            ),
+        )
+
+        result = handle_load_workflow(NukeLoadWorkflowRequest(workflow_id="shapeless"))
+
+        assert isinstance(result, NukeLoadWorkflowResultSuccess)
+        assert result.inputs == []
+        assert result.input_values == {}
+        assert result.unavailable == []
+        assert _loaded(engine)

--- a/tests/unit/test_handlers_values.py
+++ b/tests/unit/test_handlers_values.py
@@ -12,7 +12,6 @@ from griptape_nodes.retained_mode.events.context_events import (
 from griptape_nodes.retained_mode.events.parameter_events import (
     GetParameterValueRequest,
     GetParameterValueResultFailure,
-    GetParameterValueResultSuccess,
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
     ListAllWorkflowsRequest,
@@ -26,7 +25,7 @@ from nuke_host_api.events import (
 )
 from nuke_host_api.handlers import handle_get_parameter_values
 from nuke_host_api.protocol import ParameterSection, ValueType
-from tests.unit.host_api_fakes import SHAPE, use_engine
+from tests.unit.host_api_fakes import SHAPE, respond_to_get_value, use_engine
 
 NOTHING_LOADED = {GetWorkflowContextRequest: GetWorkflowContextSuccess(workflow_name="", result_details="ok")}
 
@@ -38,38 +37,9 @@ WORKFLOW_LOADED: dict[type, Any] = {
 }
 
 
-def _respond_to_get_value(request: GetParameterValueRequest) -> Any:
-    if request.parameter_name == "topic":
-        return GetParameterValueResultSuccess(
-            input_types=["str"], type="str", output_type="str", value="a quiet harbour at dusk", result_details="ok"
-        )
-    if request.parameter_name == "plate":
-        return GetParameterValueResultSuccess(
-            input_types=["ImageUrlArtifact"],
-            type="ImageUrlArtifact",
-            output_type="ImageUrlArtifact",
-            value=None,
-            result_details="ok",
-        )
-    if request.parameter_name == "was_successful":
-        return GetParameterValueResultSuccess(
-            input_types=["bool"], type="bool", output_type="bool", value=True, result_details="ok"
-        )
-    if request.parameter_name == "mixed_audio":
-        return GetParameterValueResultSuccess(
-            input_types=["AudioUrlArtifact"],
-            type="AudioUrlArtifact",
-            output_type="AudioUrlArtifact",
-            value="http://x/audio.mp3",
-            result_details="ok",
-        )
-    msg = f"no fake response configured for parameter '{request.parameter_name}'"
-    raise AssertionError(msg)
-
-
 class TestGetParameterValues:
     def test_no_sections_requested_reads_both_sides(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: _respond_to_get_value})
+        use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: respond_to_get_value})
 
         result = handle_get_parameter_values(NukeGetParameterValuesRequest())
 
@@ -86,7 +56,7 @@ class TestGetParameterValues:
         assert result.unavailable == []
 
     def test_a_single_section_reads_only_that_side(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        engine = use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: _respond_to_get_value})
+        engine = use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: respond_to_get_value})
 
         result = handle_get_parameter_values(NukeGetParameterValuesRequest(sections=[ParameterSection.INPUTS]))
 
@@ -98,7 +68,7 @@ class TestGetParameterValues:
         assert read_parameters == {"topic", "plate"}, "must not read the output side when only inputs was requested"
 
     def test_an_unknown_section_is_refused_without_reaching_the_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        engine = use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: _respond_to_get_value})
+        engine = use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: respond_to_get_value})
 
         result = handle_get_parameter_values(NukeGetParameterValuesRequest(sections=["sideways"]))
 
@@ -120,7 +90,7 @@ class TestGetParameterValues:
         def respond(request: GetParameterValueRequest) -> Any:
             if request.parameter_name == "topic":
                 return GetParameterValueResultFailure(result_details="node was deleted mid-read")
-            return _respond_to_get_value(request)
+            return respond_to_get_value(request)
 
         use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: respond})
 
@@ -138,7 +108,7 @@ class TestGetParameterValues:
         ]
 
     def test_control_parameters_are_excluded(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: _respond_to_get_value})
+        use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: respond_to_get_value})
 
         result = handle_get_parameter_values(NukeGetParameterValuesRequest())
 
@@ -147,7 +117,7 @@ class TestGetParameterValues:
         assert "exec_in" not in result.outputs.get("End Flow", {})
 
     def test_values_are_normalized_the_same_shape_as_a_describe_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: _respond_to_get_value})
+        use_engine(monkeypatch, {**WORKFLOW_LOADED, GetParameterValueRequest: respond_to_get_value})
 
         result = handle_get_parameter_values(NukeGetParameterValuesRequest())
 

--- a/tests/unit/test_parameter_values.py
+++ b/tests/unit/test_parameter_values.py
@@ -1,0 +1,90 @@
+"""Tests for the shared parameter-value reader.
+
+The reader is what stops ``NukeLoadWorkflowRequest`` and ``NukeGetParameterValuesRequest``
+from disagreeing about what a parameter holds, so its behaviour is asserted here once rather
+than twice through the two verbs that use it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultFailure,
+)
+
+from nuke_host_api import parameter_values
+from nuke_host_api.protocol import PARAMETER_SECTIONS, ParameterSection, ValueType
+from tests.unit.host_api_fakes import SHAPE, respond_to_get_value, use_engine
+
+
+class TestReadSections:
+    def test_both_sections_are_read_when_both_are_requested(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(monkeypatch, {GetParameterValueRequest: respond_to_get_value})
+
+        inputs, outputs, unavailable = parameter_values.read_sections(SHAPE, list(PARAMETER_SECTIONS))
+
+        assert inputs["Start Flow"]["topic"]["value_type"] == ValueType.TEXT
+        assert outputs["End Flow"]["was_successful"]["value_type"] == ValueType.BOOL
+        assert unavailable == []
+
+    def test_a_section_not_requested_comes_back_empty_and_unread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty map rather than a missing key, so no caller has to tell the two apart."""
+        engine = use_engine(monkeypatch, {GetParameterValueRequest: respond_to_get_value})
+
+        inputs, outputs, _ = parameter_values.read_sections(SHAPE, [ParameterSection.INPUTS])
+
+        assert inputs
+        assert outputs == {}
+        read = {r.parameter_name for r in engine.requests if isinstance(r, GetParameterValueRequest)}
+        assert read == {"topic", "plate"}
+
+    def test_an_unreadable_parameter_is_tagged_with_the_section_it_came_from(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def respond(request: GetParameterValueRequest) -> Any:
+            if request.parameter_name == "was_successful":
+                return GetParameterValueResultFailure(result_details="node was deleted mid-read")
+            return respond_to_get_value(request)
+
+        use_engine(monkeypatch, {GetParameterValueRequest: respond})
+
+        _, outputs, unavailable = parameter_values.read_sections(SHAPE, list(PARAMETER_SECTIONS))
+
+        assert "was_successful" not in outputs.get("End Flow", {})
+        assert unavailable == [
+            {
+                "section": ParameterSection.OUTPUTS,
+                "node": "End Flow",
+                "parameter": "was_successful",
+                "reason": "node was deleted mid-read",
+            }
+        ]
+
+    def test_a_value_the_engine_holds_as_none_is_a_value_not_a_miss(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unset knob and one that could not be read mean different things to a host."""
+        use_engine(monkeypatch, {GetParameterValueRequest: respond_to_get_value})
+
+        inputs, _, unavailable = parameter_values.read_sections(SHAPE, [ParameterSection.INPUTS])
+
+        assert inputs["Start Flow"]["plate"]["value_type"] == ValueType.NULL
+        assert unavailable == []
+
+    def test_an_empty_shape_reads_nothing_and_reports_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        engine = use_engine(monkeypatch, {})
+
+        inputs, outputs, unavailable = parameter_values.read_sections({}, list(PARAMETER_SECTIONS))
+
+        assert (inputs, outputs, unavailable) == ({}, {}, [])
+        assert engine.requests == []
+
+    def test_control_parameters_are_never_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Execution wiring is not data, and the normalizer has no case for its type."""
+        engine = use_engine(monkeypatch, {GetParameterValueRequest: respond_to_get_value})
+
+        parameter_values.read_sections(SHAPE, list(PARAMETER_SECTIONS))
+
+        read = {r.parameter_name for r in engine.requests if isinstance(r, GetParameterValueRequest)}
+        assert not read & {"exec_in", "exec_out"}


### PR DESCRIPTION
Loading used to be a side effect of `NukeExecuteWorkflowRequest`. That left a host unable to
see or set a parameter's live value without starting a run, and left the layer inconsistent
about what a host is addressing: discovery answered for a `workflow_id`, everything else
answered for whatever execute happened to have loaded last.

`NukeLoadWorkflowRequest` takes over that job and is now the only verb that changes which
workflow the engine holds. It returns the declared parameters and their current values for both
sides in one reply, so a host can build knobs and initialize them without a second call.

Two consequences worth knowing before reading the diff:

- **Loading is destructive, and a failed load can be too.** The engine clears all object state
  before it builds the graph, so a workflow that fails inside its own file leaves nothing
  loaded. `NukeLoadWorkflowResultFailure.engine_state_cleared` tells a host which kind of
  refusal it got; branch on it rather than on the reason text.
- **`NukeExecuteWorkflowRequest.workflow_id` means something else.** It was required and named
  the workflow to load and run. It is now optional and names the workflow a host believes is
  already loaded; a mismatch is refused rather than honoured. `protocol.py` records why that is
  free of a version bump today and would not be after the first compiled plugin.

`NukeGetParameterValuesRequest` and load share one reader (`parameter_values.py`), so the two
cannot disagree about what a parameter holds or how an unreadable one is reported.
