### PR TITLE
chore(deps): move engine out of runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     # griptape-nodes distribution only ships the app. 0.99.0 is the release that
     # bundles static files referenced by a macro path, and no griptape-nodes
     # release floors the engine that high, so the floor has to be declared here.
-    "griptape-nodes-engine>=0.99.0",
 ]
 
 [build-system]
@@ -21,7 +20,7 @@ build-backend = "hatchling.build"
 packages = ["nuke_nodes", "execution", "script_parser", "nuke_runner"]
 
 [dependency-groups]
-dev = ["pyright>=1.1.396", "pytest-asyncio>=0.21.0", "ruff>=0.8.0", "pytest"]
+dev = ["pyright>=1.1.396", "pytest-asyncio>=0.21.0", "ruff>=0.8.0", "pytest", "griptape-nodes-engine>=0.99.0"]
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -477,12 +477,10 @@ wheels = [
 name = "griptape-nodes-library-nuke"
 version = "0.1.0"
 source = { editable = "." }
-dependencies = [
-    { name = "griptape-nodes-engine" },
-]
 
 [package.dev-dependencies]
 dev = [
+    { name = "griptape-nodes-engine" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -490,10 +488,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "griptape-nodes-engine", specifier = ">=0.99.0" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "griptape-nodes-engine", specifier = ">=0.99.0" },
     { name = "pyright", specifier = ">=1.1.396" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },


### PR DESCRIPTION
## Problem

The engine is the host that loads this library. Declaring it under `[project] dependencies` means installing or syncing this library can materialize a **second engine** in that environment.

That matters because the engine inserts a library's venv site-packages at `sys.path[0]` of the live engine (`_add_library_paths_to_sys_path`), and a library venv resolves to `library_dir/.venv` and is reused when already present. So a dev `uv sync` in this repo puts an engine copy somewhere it can precede the running engine.

The specifier also duplicated a fact that already has an enforced home. The engine gates compatibility on `engine_version` in the library manifest via `requires_engine`; the pyproject specifier is never consulted at load time. Two declarations of one fact with nothing keeping them in sync.

## Change

Moved the engine specifier out of `[project] dependencies` and into `[dependency-groups] dev`, preserving the existing package name and version specifier so the dev environment resolves exactly what it did before. Lock regenerated.

Tests and type checking still get an engine, since uv installs the `dev` group by default. Nothing that installs this library as a package pulls a host.

## Why the manifest needs no change

`make deps/sync` generates the manifest's `pip_dependencies` from `[project] dependencies` while filtering out anything starting with `griptape-nodes`. The generated list is therefore identical before and after this change, which I verified rather than assumed.

## Verification

- Parsed the pyproject and the lock and asserted the invariant: engine absent from `[project] dependencies` and `requires-dist`, present exactly once in the dev group and `requires-dev`.
- No CI job in this repo syncs with `--no-dev`, so the dev group is always installed.

Note: relocking can also correct pre-existing staleness in `uv.lock` unrelated to this change (a stale project version, or a `requires-python` range that no longer matches the pyproject). Where that happened it is visible in the lock diff.
