### PR TITLE
feat(host-api): carry engine identity on NukeConnectResultSuccess

### DIFF
--- a/nuke_host_api/INTEGRATION.md
+++ b/nuke_host_api/INTEGRATION.md
@@ -135,8 +135,9 @@ this protocol, so a host that parses them binds to the one surface here that is 
 unversioned. The result envelope carries `engine_id` and `session_id` too, but the same
 rule applies: envelope shape belongs to the wire protocol shared by the engine and every
 client, not to this library, so it makes no promise either. `NukeConnectResultSuccess`
-carries the engine and library versions, plus `engine_id`, `session_id`, and `engine_name`,
-so identity a plugin binds to comes from the one place this protocol actually versions.
+carries the engine and library versions, plus `engine_id`, `engine_name`, and `session_id`
+(the engine's active session, shared engine state rather than a per-connection identity),
+so what a plugin binds to comes from the one place this protocol actually versions.
 
 ### 3. Subscribe, then connect
 
@@ -342,7 +343,7 @@ other verbs answer without it.
 | `event_topic` | `str` | The topic notifications are published on. Subscribe to it or receive none |
 | `value_types` | `list[str]` | Closed value type set for this version |
 | `engine_id` | `str` | The engine's own id. Empty when the engine has not set one |
-| `session_id` | `str` | The session this connection joined. Empty for a direct engine connection with no session layered on top |
+| `session_id` | `str` | The engine's active session, shared engine state, not this connection's own. Empty when no session is open |
 | `engine_name` | `str` | Human-readable. Empty when the engine could not report one |
 
 **Connect before expecting notifications.** The outbound event bridge installs on the first

--- a/nuke_host_api/INTEGRATION.md
+++ b/nuke_host_api/INTEGRATION.md
@@ -132,9 +132,11 @@ to `ws://127.0.0.1:18125/`. The engine does write files that look like a registr
 `engines.json` and `sessions.json` under `$XDG_DATA_HOME/griptape_nodes`, and they are
 app-layer internals: their path, shape, and existence carry no compatibility promise from
 this protocol, so a host that parses them binds to the one surface here that is explicitly
-unversioned. Identity arrives on the wire instead. Every result envelope carries
-`engine_id` and `session_id`, and `NukeConnectResultSuccess` carries the engine and library
-versions.
+unversioned. The result envelope carries `engine_id` and `session_id` too, but the same
+rule applies: envelope shape belongs to the wire protocol shared by the engine and every
+client, not to this library, so it makes no promise either. `NukeConnectResultSuccess`
+carries the engine and library versions, plus `engine_id`, `session_id`, and `engine_name`,
+so identity a plugin binds to comes from the one place this protocol actually versions.
 
 ### 3. Subscribe, then connect
 
@@ -339,6 +341,9 @@ other verbs answer without it.
 | `library_version` | `str` | Display only |
 | `event_topic` | `str` | The topic notifications are published on. Subscribe to it or receive none |
 | `value_types` | `list[str]` | Closed value type set for this version |
+| `engine_id` | `str` | The engine's own id. Empty when the engine has not set one |
+| `session_id` | `str` | The session this connection joined. Empty for a direct engine connection with no session layered on top |
+| `engine_name` | `str` | Human-readable. Empty when the engine could not report one |
 
 **Connect before expecting notifications.** The outbound event bridge installs on the first
 `NukeConnectRequest` rather than at library load, so an engine no host has spoken to does not
@@ -354,7 +359,10 @@ yet.
   "engine_version": "0.99.0",
   "library_version": "0.3.0",
   "event_topic": "sessions/50c24f4744a4463084ea3a701644993a/response",
-  "value_types": ["GTImage", "GTMovie", "GTFile", "GTText", "GTNumber", "GTBool", "GTNull"]
+  "value_types": ["GTImage", "GTMovie", "GTFile", "GTText", "GTNumber", "GTBool", "GTNull"],
+  "engine_id": "a69c283e-...",
+  "session_id": "50c24f47-...",
+  "engine_name": "Dan's workstation"
 }
 ```
 

--- a/nuke_host_api/README.md
+++ b/nuke_host_api/README.md
@@ -79,12 +79,11 @@ until the plugin exists.
 closed host type set, and the event topic. Offering an unsupported version gets a clean
 refusal naming the support window.
 
-`NukeConnectResultSuccess` also carries `engine_id`, `session_id`, and `engine_name`, so a
-plugin reads identity from the versioned handshake reply rather than from the result
-envelope, which carries the first two as well but makes no compatibility promise about
-doing so. All three are empty string, never null, when the engine has not set one, and a
-connect that cannot name the engine is still a successful handshake: a bare connectivity
-check has to succeed with none of them set.
+`NukeConnectResultSuccess` also carries `engine_id`, `session_id`, and `engine_name`, read from
+the versioned handshake reply rather than the result envelope (see `INTEGRATION.md`).
+`session_id` is the engine's active session, shared engine state rather than this
+connection's own; all three are empty string, never null, when the engine has none to
+report, and a connect that cannot name the engine is still a successful handshake.
 
 Finding an engine to connect to happens off the wire, because a host has no connection yet:
 a host holds the `websocket_direct` URL as its own setting, defaulted to

--- a/nuke_host_api/README.md
+++ b/nuke_host_api/README.md
@@ -79,6 +79,13 @@ until the plugin exists.
 closed host type set, and the event topic. Offering an unsupported version gets a clean
 refusal naming the support window.
 
+`NukeConnectResultSuccess` also carries `engine_id`, `session_id`, and `engine_name`, so a
+plugin reads identity from the versioned handshake reply rather than from the result
+envelope, which carries the first two as well but makes no compatibility promise about
+doing so. All three are empty string, never null, when the engine has not set one, and a
+connect that cannot name the engine is still a successful handshake: a bare connectivity
+check has to succeed with none of them set.
+
 Finding an engine to connect to happens off the wire, because a host has no connection yet:
 a host holds the `websocket_direct` URL as its own setting, defaulted to
 `ws://127.0.0.1:18125/`, and a completed handshake is the liveness check. The engine's

--- a/nuke_host_api/engine.py
+++ b/nuke_host_api/engine.py
@@ -74,10 +74,6 @@ def event_topic() -> str:
 
     Mirrors the app layer's default response topic. A host cannot derive this, so
     NukeConnectRequest hands it over.
-
-    Reads through ``session_id()``/``engine_id()`` rather than calling
-    ``GriptapeNodes`` directly a second time, so this and ``NukeConnectResultSuccess`` cannot
-    read the same engine state two different ways.
     """
     active_session = session_id()
     if active_session:

--- a/nuke_host_api/engine.py
+++ b/nuke_host_api/engine.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from griptape_nodes.retained_mode.events.app_events import (
+    GetEngineNameRequest,
+    GetEngineNameResultSuccess,
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
 )
@@ -88,6 +90,30 @@ def engine_version() -> str:
     if attempt.value is None:
         return "unknown"
     return f"{attempt.value.major}.{attempt.value.minor}.{attempt.value.patch}"
+
+
+def engine_id() -> str:
+    """Return the engine's own id, or empty when the engine has not set one."""
+    return GriptapeNodes.get_engine_id() or ""
+
+
+def session_id() -> str:
+    """Return the current session's id, or empty when no session is open."""
+    return GriptapeNodes.get_session_id() or ""
+
+
+def engine_name() -> str:
+    """Return the engine's human-readable name, or empty when the engine could not report one.
+
+    Unlike ``engine_version``, a refusal here is not "unknown": the engine's own handler only
+    fails on an unexpected exception reading its identity store, not on an unset name, so an
+    empty string is reserved for that path and never stands in for a name the engine actually
+    has.
+    """
+    attempt = request(GetEngineNameRequest(), GetEngineNameResultSuccess)
+    if attempt.value is None:
+        return ""
+    return attempt.value.engine_name
 
 
 def top_level_flow_name() -> str | None:

--- a/nuke_host_api/engine.py
+++ b/nuke_host_api/engine.py
@@ -74,13 +74,17 @@ def event_topic() -> str:
 
     Mirrors the app layer's default response topic. A host cannot derive this, so
     NukeConnectRequest hands it over.
+
+    Reads through ``session_id()``/``engine_id()`` rather than calling
+    ``GriptapeNodes`` directly a second time, so this and ``NukeConnectResultSuccess`` cannot
+    read the same engine state two different ways.
     """
-    session_id = GriptapeNodes.get_session_id()
-    if session_id:
-        return f"sessions/{session_id}/response"
-    engine_id = GriptapeNodes.get_engine_id()
-    if engine_id:
-        return f"engines/{engine_id}/response"
+    active_session = session_id()
+    if active_session:
+        return f"sessions/{active_session}/response"
+    active_engine = engine_id()
+    if active_engine:
+        return f"engines/{active_engine}/response"
     return "response"
 
 

--- a/nuke_host_api/events.py
+++ b/nuke_host_api/events.py
@@ -54,6 +54,20 @@ class NukeConnectResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
         event_topic: The topic notifications are published on. A host subscribes to it to
             receive them; it cannot derive the value.
         value_types: The closed value type set for this protocol version.
+        engine_id: The engine's own id. Empty when the engine has not set one.
+        session_id: The session this connection joined. Empty when no session is open,
+            which is the case for a direct engine connection with no session layered on top.
+        engine_name: The engine's human-readable name. Empty when the engine could not
+            report one.
+
+        The three identity fields are read from the versioned handshake reply rather than
+        from the result envelope, which also carries ``engine_id`` and ``session_id`` but
+        makes no compatibility promise about doing so: envelope shape belongs to the wire
+        protocol between the engine and every client, not to this library, and a plugin
+        binding to it would be binding to a surface this file does not own. A connect that
+        cannot name the engine is still a successful handshake, not a failure: a bare
+        connectivity check has to succeed with none of the three set, so all three are
+        empty string rather than a refusal when identity is unavailable.
     """
 
     protocol_version: int
@@ -62,6 +76,9 @@ class NukeConnectResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     library_version: str
     event_topic: str
     value_types: list[str]
+    engine_id: str = ""
+    session_id: str = ""
+    engine_name: str = ""
 
 
 @dataclass

--- a/nuke_host_api/events.py
+++ b/nuke_host_api/events.py
@@ -45,6 +45,10 @@ class NukeConnectRequest(RequestPayload):
 class NukeConnectResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     """Session opened.
 
+    ``engine_id``, ``session_id``, and ``engine_name`` are read from this reply rather than
+    from the result envelope, which makes no compatibility promise about carrying them; see
+    INTEGRATION.md.
+
     Args:
         protocol_version: The agreed version. The host must use only this version's
             vocabulary for the rest of the session.
@@ -55,19 +59,10 @@ class NukeConnectResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
             receive them; it cannot derive the value.
         value_types: The closed value type set for this protocol version.
         engine_id: The engine's own id. Empty when the engine has not set one.
-        session_id: The session this connection joined. Empty when no session is open,
-            which is the case for a direct engine connection with no session layered on top.
+        session_id: The engine's active session, or empty when no session is open. Engine
+            state, shared with the editor and every other client, not this connection's own.
         engine_name: The engine's human-readable name. Empty when the engine could not
             report one.
-
-        The three identity fields are read from the versioned handshake reply rather than
-        from the result envelope, which also carries ``engine_id`` and ``session_id`` but
-        makes no compatibility promise about doing so: envelope shape belongs to the wire
-        protocol between the engine and every client, not to this library, and a plugin
-        binding to it would be binding to a surface this file does not own. A connect that
-        cannot name the engine is still a successful handshake, not a failure: a bare
-        connectivity check has to succeed with none of the three set, so all three are
-        empty string rather than a refusal when identity is unavailable.
     """
 
     protocol_version: int

--- a/nuke_host_api/handlers/connect.py
+++ b/nuke_host_api/handlers/connect.py
@@ -1,10 +1,10 @@
-"""Negotiate a protocol version and open the event stream."""
+"""Negotiate a protocol version, open the event stream, and hand over engine identity."""
 
 from __future__ import annotations
 
 from nuke_host_api import execution_bridge, library_version
 from nuke_host_api.dispatch import failure, verb
-from nuke_host_api.engine import engine_version, event_topic
+from nuke_host_api.engine import engine_id, engine_name, engine_version, event_topic, session_id
 from nuke_host_api.events import (
     NukeConnectRequest,
     NukeConnectResultFailure,
@@ -51,5 +51,8 @@ def handle_connect(request: NukeConnectRequest) -> NukeConnectResultSuccess | Nu
         library_version=library_version.version(),
         event_topic=event_topic(),
         value_types=list(VALUE_TYPES),
+        engine_id=engine_id(),
+        session_id=session_id(),
+        engine_name=engine_name(),
         result_details=f"Connected {client} on host API protocol version {mutual[0]}.",
     )

--- a/tests/integration/test_host_api.py
+++ b/tests/integration/test_host_api.py
@@ -163,7 +163,9 @@ class TestDiscovery:
 
 
 class TestConnect:
-    def test_connect_negotiates_a_version_and_returns_the_closed_type_set(self, client: HostClient) -> None:
+    def test_connect_negotiates_a_version_and_returns_the_closed_type_set(
+        self, client: HostClient, engine: Engine
+    ) -> None:
         reply = client.request(
             Verb.CONNECT, {"client_protocol_versions": [PROTOCOL_VERSION], "client_name": "smoke test"}
         )
@@ -177,9 +179,9 @@ class TestConnect:
         assert body["engine_version"] and body["engine_version"] != "unknown"
         assert body["library_version"] != "unknown", "library_version is read from the shipped manifest"
         assert body["event_topic"]
-        assert body["engine_id"], "engine_id must survive the wire, matching engine discovery's id"
+        assert body["engine_id"] == engine.id, "engine_id must survive the wire, matching engine discovery's id"
         assert isinstance(body["session_id"], str), "session_id must be present even when empty"
-        assert body["engine_name"], "engine_name must survive the wire, matching engine discovery's name"
+        assert body["engine_name"] == engine.name, "engine_name must survive the wire, matching discovery's name"
 
     def test_an_unsupported_protocol_version_is_refused_and_names_the_window(self, client: HostClient) -> None:
         reply = client.request(Verb.CONNECT, {"client_protocol_versions": [99]})

--- a/tests/integration/test_host_api.py
+++ b/tests/integration/test_host_api.py
@@ -177,6 +177,9 @@ class TestConnect:
         assert body["engine_version"] and body["engine_version"] != "unknown"
         assert body["library_version"] != "unknown", "library_version is read from the shipped manifest"
         assert body["event_topic"]
+        assert body["engine_id"], "engine_id must survive the wire, matching engine discovery's id"
+        assert isinstance(body["session_id"], str), "session_id must be present even when empty"
+        assert body["engine_name"], "engine_name must survive the wire, matching engine discovery's name"
 
     def test_an_unsupported_protocol_version_is_refused_and_names_the_window(self, client: HostClient) -> None:
         reply = client.request(Verb.CONNECT, {"client_protocol_versions": [99]})

--- a/tests/unit/host_api_fakes.py
+++ b/tests/unit/host_api_fakes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from griptape_nodes.retained_mode.events.app_events import (
+    GetEngineNameResultSuccess,
     GetEngineVersionRequest,
     GetEngineVersionResultSuccess,
 )
@@ -73,6 +74,8 @@ WORKFLOW_TABLE = {"wf1": {"name": "WF One", "description": "d", "workflow_shape"
 IDLE_FLOW = GetFlowStateResultSuccess(control_nodes=[], resolving_nodes=[], involved_nodes=[], result_details="idle")
 
 ENGINE_VERSION = GetEngineVersionResultSuccess(major=0, minor=97, patch=0, result_details="ok")
+
+ENGINE_NAME = GetEngineNameResultSuccess(engine_name="Engine One", result_details="ok")
 
 
 class FakeEngine:

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import pytest
 from griptape_nodes.retained_mode.events.app_events import (
+    GetEngineNameRequest,
+    GetEngineNameResultFailure,
     GetEngineVersionRequest,
     GetEngineVersionResultFailure,
 )
@@ -28,7 +30,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
 )
 
 from nuke_host_api import engine
-from tests.unit.host_api_fakes import ENGINE_VERSION, IDLE_FLOW, WORKFLOW_TABLE, use_engine
+from tests.unit.host_api_fakes import ENGINE_NAME, ENGINE_VERSION, IDLE_FLOW, WORKFLOW_TABLE, use_engine
 
 BUSY_FLOW = GetFlowStateResultSuccess(
     control_nodes=["C1"], resolving_nodes=["N1"], involved_nodes=["N1"], result_details="busy"
@@ -84,6 +86,40 @@ class TestEngineVersion:
     def test_an_engine_that_will_not_say_is_unknown(self, monkeypatch: pytest.MonkeyPatch) -> None:
         use_engine(monkeypatch, {GetEngineVersionRequest: GetEngineVersionResultFailure(result_details="no")})
         assert engine.engine_version() == "unknown"
+
+
+class TestEngineId:
+    def test_a_set_id_is_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(monkeypatch, engine_id="engine-xyz")
+        assert engine.engine_id() == "engine-xyz"
+
+    def test_no_id_is_empty_not_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(monkeypatch, engine_id="")
+        assert engine.engine_id() == ""
+
+
+class TestSessionId:
+    def test_a_set_session_is_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(monkeypatch, session_id="session-abc")
+        assert engine.session_id() == "session-abc"
+
+    def test_a_direct_engine_connection_with_no_session_is_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(monkeypatch, session_id="")
+        assert engine.session_id() == ""
+
+
+class TestEngineName:
+    def test_the_engines_name_is_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        use_engine(monkeypatch, {GetEngineNameRequest: ENGINE_NAME})
+        assert engine.engine_name() == "Engine One"
+
+    def test_an_engine_that_refuses_the_lookup_is_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The engine's own handler fails only on an unexpected exception, never on an unset name."""
+        use_engine(
+            monkeypatch,
+            {GetEngineNameRequest: GetEngineNameResultFailure(error_message="boom", result_details="boom")},
+        )
+        assert engine.engine_name() == ""
 
 
 class TestTopLevelFlowName:

--- a/tests/unit/test_handlers_connect.py
+++ b/tests/unit/test_handlers_connect.py
@@ -3,18 +3,22 @@
 from __future__ import annotations
 
 import pytest
-from griptape_nodes.retained_mode.events.app_events import GetEngineVersionRequest
+from griptape_nodes.retained_mode.events.app_events import (
+    GetEngineNameRequest,
+    GetEngineNameResultFailure,
+    GetEngineVersionRequest,
+)
 
 from nuke_host_api import execution_bridge
 from nuke_host_api.events import NukeConnectRequest, NukeConnectResultFailure, NukeConnectResultSuccess
 from nuke_host_api.handlers import handle_connect
 from nuke_host_api.protocol import PROTOCOL_VERSION, VALUE_TYPES
-from tests.unit.host_api_fakes import ENGINE_VERSION, use_engine
+from tests.unit.host_api_fakes import ENGINE_NAME, ENGINE_VERSION, use_engine
 
 
 @pytest.fixture(autouse=True)
 def _fake_engine(monkeypatch: pytest.MonkeyPatch) -> None:
-    use_engine(monkeypatch, {GetEngineVersionRequest: ENGINE_VERSION})
+    use_engine(monkeypatch, {GetEngineVersionRequest: ENGINE_VERSION, GetEngineNameRequest: ENGINE_NAME})
 
 
 @pytest.fixture(autouse=True)
@@ -81,3 +85,45 @@ def test_the_highest_mutual_version_wins() -> None:
     result = handle_connect(NukeConnectRequest(client_protocol_versions=[99, PROTOCOL_VERSION]))
     assert isinstance(result, NukeConnectResultSuccess)
     assert result.protocol_version == PROTOCOL_VERSION
+
+
+def test_identity_is_read_from_the_handshake_not_the_envelope() -> None:
+    """engine_id, session_id, and engine_name belong to the versioned reply.
+
+    The result envelope also carries engine_id and session_id, but makes no compatibility
+    promise about doing so, so a plugin binds to these fields instead.
+    """
+    result = handle_connect(NukeConnectRequest(client_protocol_versions=[PROTOCOL_VERSION]))
+    assert isinstance(result, NukeConnectResultSuccess)
+    assert result.engine_id == "engine-xyz"
+    assert result.session_id == "session-abc"
+    assert result.engine_name == "Engine One"
+
+
+def test_a_direct_engine_connection_with_no_session_reports_no_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A host connecting straight to an engine, with no session layered on top, gets empty."""
+    use_engine(
+        monkeypatch,
+        {GetEngineVersionRequest: ENGINE_VERSION, GetEngineNameRequest: ENGINE_NAME},
+        session_id="",
+    )
+    result = handle_connect(NukeConnectRequest(client_protocol_versions=[PROTOCOL_VERSION]))
+    assert isinstance(result, NukeConnectResultSuccess)
+    assert result.session_id == ""
+    assert result.event_topic == "engines/engine-xyz/response"
+
+
+def test_a_refused_name_lookup_reports_an_empty_name_not_a_failed_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The engine's own name lookup fails only on an unexpected exception, never on an unset
+    name. Either way, connect is still a successful handshake.
+    """
+    use_engine(
+        monkeypatch,
+        {
+            GetEngineVersionRequest: ENGINE_VERSION,
+            GetEngineNameRequest: GetEngineNameResultFailure(error_message="boom", result_details="boom"),
+        },
+    )
+    result = handle_connect(NukeConnectRequest(client_protocol_versions=[PROTOCOL_VERSION]))
+    assert isinstance(result, NukeConnectResultSuccess)
+    assert result.engine_name == ""

--- a/tests/unit/test_handlers_connect.py
+++ b/tests/unit/test_handlers_connect.py
@@ -88,11 +88,7 @@ def test_the_highest_mutual_version_wins() -> None:
 
 
 def test_identity_is_read_from_the_handshake_not_the_envelope() -> None:
-    """engine_id, session_id, and engine_name belong to the versioned reply.
-
-    The result envelope also carries engine_id and session_id, but makes no compatibility
-    promise about doing so, so a plugin binds to these fields instead.
-    """
+    """engine_id, session_id, and engine_name are populated on the handshake reply."""
     result = handle_connect(NukeConnectRequest(client_protocol_versions=[PROTOCOL_VERSION]))
     assert isinstance(result, NukeConnectResultSuccess)
     assert result.engine_id == "engine-xyz"


### PR DESCRIPTION
Closes #130